### PR TITLE
Adds ACL, ACLProvider, Keychain, KeychainProvider

### DIFF
--- a/examples/browser-test/src/App.tsx
+++ b/examples/browser-test/src/App.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import "./App.css";
 import {
-  AutomergeSwarm,
-  AutomergeSwarmSyncMessage,
-} from "@collabswarm/collabswarm-automerge";
-import {
   connectAsync,
   openDocumentAsync,
   closeDocumentAsync,
@@ -16,8 +12,25 @@ import { ThunkDispatch } from "redux-thunk";
 import { JsonEditor } from "jsoneditor-react";
 import * as jsondiffpatch from "jsondiffpatch";
 import { AutomergeSwarmActions, AutomergeSwarmState } from "./utils";
-import { CollabswarmConfig, DEFAULT_CONFIG } from "@collabswarm/collabswarm";
+import { Collabswarm, CollabswarmConfig, CollabswarmDocument, DEFAULT_CONFIG } from "@collabswarm/collabswarm";
 import { Doc, BinaryChange } from "automerge";
+
+export type AutomergeSwarm<T = any> = Collabswarm<
+  Doc<T>,
+  BinaryChange[],
+  (doc: T) => void,
+  CryptoKey,
+  CryptoKey,
+  CryptoKey
+>;
+export type AutomergeSwarmDocument<T = any> = CollabswarmDocument<
+  Doc<T>,
+  BinaryChange[],
+  (doc: T) => void,
+  CryptoKey,
+  CryptoKey,
+  CryptoKey
+>;
 
 const jdp = jsondiffpatch.create();
 
@@ -195,8 +208,10 @@ function mapDispatchToProps(
         initializeAsync<
           Doc<any>,
           BinaryChange[],
-          (doc: Doc<any>) => void,
-          AutomergeSwarmSyncMessage
+          (doc: any) => void,
+          CryptoKey,
+          CryptoKey,
+          CryptoKey
         >(config)
       ),
     onConnect: (addresses: string[]) =>
@@ -204,8 +219,10 @@ function mapDispatchToProps(
         connectAsync<
           Doc<any>,
           BinaryChange[],
-          (doc: Doc<any>) => void,
-          AutomergeSwarmSyncMessage
+          (doc: any) => void,
+          CryptoKey,
+          CryptoKey,
+          CryptoKey
         >(addresses)
       ),
     onDocumentOpen: (documentId: string) =>
@@ -213,8 +230,10 @@ function mapDispatchToProps(
         openDocumentAsync<
           Doc<any>,
           BinaryChange[],
-          (doc: Doc<any>) => void,
-          AutomergeSwarmSyncMessage
+          (doc: any) => void,
+          CryptoKey,
+          CryptoKey,
+          CryptoKey
         >(documentId)
       ),
     onDocumentClose: (documentId: string) =>
@@ -222,8 +241,10 @@ function mapDispatchToProps(
         closeDocumentAsync<
           Doc<any>,
           BinaryChange[],
-          (doc: Doc<any>) => void,
-          AutomergeSwarmSyncMessage
+          (doc: any) => void,
+          CryptoKey,
+          CryptoKey,
+          CryptoKey
         >(documentId)
       ),
     onDocumentChange: (
@@ -235,8 +256,10 @@ function mapDispatchToProps(
         changeDocumentAsync<
           Doc<any>,
           BinaryChange[],
-          (doc: Doc<any>) => void,
-          AutomergeSwarmSyncMessage
+          (doc: any) => void,
+          CryptoKey,
+          CryptoKey,
+          CryptoKey
         >(documentId, changeFn, message)
       ),
   };

--- a/examples/browser-test/src/App.tsx
+++ b/examples/browser-test/src/App.tsx
@@ -1,19 +1,24 @@
-import React from "react";
-import "./App.css";
+import React from 'react';
+import './App.css';
 import {
   connectAsync,
   openDocumentAsync,
   closeDocumentAsync,
   changeDocumentAsync,
   initializeAsync,
-} from "@collabswarm/collabswarm-redux";
-import { connect } from "react-redux";
-import { ThunkDispatch } from "redux-thunk";
-import { JsonEditor } from "jsoneditor-react";
-import * as jsondiffpatch from "jsondiffpatch";
-import { AutomergeSwarmActions, AutomergeSwarmState } from "./utils";
-import { Collabswarm, CollabswarmConfig, CollabswarmDocument, DEFAULT_CONFIG } from "@collabswarm/collabswarm";
-import { Doc, BinaryChange } from "automerge";
+} from '@collabswarm/collabswarm-redux';
+import { connect } from 'react-redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { JsonEditor } from 'jsoneditor-react';
+import * as jsondiffpatch from 'jsondiffpatch';
+import { AutomergeSwarmActions, AutomergeSwarmState } from './utils';
+import {
+  Collabswarm,
+  CollabswarmConfig,
+  CollabswarmDocument,
+  DEFAULT_CONFIG,
+} from '@collabswarm/collabswarm';
+import { Doc, BinaryChange } from 'automerge';
 
 export type AutomergeSwarm<T = any> = Collabswarm<
   Doc<T>,
@@ -43,7 +48,7 @@ interface AppProps {
   onDocumentChange: (
     documentId: string,
     changeFn: (current: any) => void,
-    message?: string
+    message?: string,
   ) => any;
 }
 
@@ -61,8 +66,8 @@ class App extends React.Component<
     super(props);
 
     this.state = {
-      connectionAddress: "",
-      documentId: "",
+      connectionAddress: '',
+      documentId: '',
     };
   }
 
@@ -73,7 +78,7 @@ class App extends React.Component<
         : JSON.parse(JSON.stringify(DEFAULT_CONFIG));
       if (process.env.REACT_APP_SIGNALING_SERVER) {
         config.ipfs.config.Addresses.Swarm.push(
-          process.env.REACT_APP_SIGNALING_SERVER
+          process.env.REACT_APP_SIGNALING_SERVER,
         );
       }
       this.props.onInitialize(config);
@@ -86,7 +91,7 @@ class App extends React.Component<
         return this.props.state.node ? this.props.state.node.ipfsInfo : null;
       } catch (ex) {
         // No-op.
-        console.warn("Failed to read ipfs info:", ex);
+        console.warn('Failed to read ipfs info:', ex);
       }
       return null;
     })();
@@ -158,7 +163,7 @@ class App extends React.Component<
                     if (delta) {
                       console.log(
                         `Applying json patch to '${documentPath}':`,
-                        delta
+                        delta,
                       );
                       this.props.onDocumentChange(documentPath, (doc) => {
                         try {
@@ -184,7 +189,7 @@ class App extends React.Component<
                 </button>
               </div>
             </React.Fragment>
-          )
+          ),
         )}
       </div>
     );
@@ -200,7 +205,7 @@ function mapDispatchToProps(
     AutomergeSwarmState<any>,
     unknown,
     AutomergeSwarmActions
-  >
+  >,
 ) {
   return {
     onInitialize: (config: CollabswarmConfig) =>
@@ -212,7 +217,7 @@ function mapDispatchToProps(
           CryptoKey,
           CryptoKey,
           CryptoKey
-        >(config)
+        >(config),
       ),
     onConnect: (addresses: string[]) =>
       dispatch(
@@ -223,7 +228,7 @@ function mapDispatchToProps(
           CryptoKey,
           CryptoKey,
           CryptoKey
-        >(addresses)
+        >(addresses),
       ),
     onDocumentOpen: (documentId: string) =>
       dispatch(
@@ -234,7 +239,7 @@ function mapDispatchToProps(
           CryptoKey,
           CryptoKey,
           CryptoKey
-        >(documentId)
+        >(documentId),
       ),
     onDocumentClose: (documentId: string) =>
       dispatch(
@@ -245,12 +250,12 @@ function mapDispatchToProps(
           CryptoKey,
           CryptoKey,
           CryptoKey
-        >(documentId)
+        >(documentId),
       ),
     onDocumentChange: (
       documentId: string,
       changeFn: (current: any) => void,
-      message?: string
+      message?: string,
     ) =>
       dispatch(
         changeDocumentAsync<
@@ -260,7 +265,7 @@ function mapDispatchToProps(
           CryptoKey,
           CryptoKey,
           CryptoKey
-        >(documentId, changeFn, message)
+        >(documentId, changeFn, message),
       ),
   };
 }

--- a/examples/browser-test/src/utils.ts
+++ b/examples/browser-test/src/utils.ts
@@ -1,8 +1,8 @@
 import {
   CollabswarmActions,
   CollabswarmState,
-} from "@collabswarm/collabswarm-redux";
-import { Doc, BinaryChange } from "automerge";
+} from '@collabswarm/collabswarm-redux';
+import { Doc, BinaryChange } from 'automerge';
 
 export type AutomergeSwarmState<T = any> = CollabswarmState<
   Doc<T>,

--- a/examples/browser-test/src/utils.ts
+++ b/examples/browser-test/src/utils.ts
@@ -1,4 +1,3 @@
-import { AutomergeSwarmSyncMessage } from "@collabswarm/collabswarm-automerge";
 import {
   CollabswarmActions,
   CollabswarmState,
@@ -9,11 +8,15 @@ export type AutomergeSwarmState<T = any> = CollabswarmState<
   Doc<T>,
   BinaryChange[],
   (doc: T) => void,
-  AutomergeSwarmSyncMessage
+  CryptoKey,
+  CryptoKey,
+  CryptoKey
 >;
 export type AutomergeSwarmActions<T = any> = CollabswarmActions<
   Doc<T>,
   BinaryChange[],
   (doc: T) => void,
-  AutomergeSwarmSyncMessage
+  CryptoKey,
+  CryptoKey,
+  CryptoKey
 >;

--- a/examples/wiki-swarm/src/containers/WikiArticle.tsx
+++ b/examples/wiki-swarm/src/containers/WikiArticle.tsx
@@ -1,22 +1,26 @@
-import React from "react";
-import { connect } from "react-redux";
-import { ThunkDispatch } from "redux-thunk";
-import { Doc } from "automerge";
-import { CollabswarmConfig, DEFAULT_CONFIG } from "@collabswarm/collabswarm";
+import React from 'react';
+import { connect } from 'react-redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { Doc } from 'automerge';
+import { CollabswarmConfig, DEFAULT_CONFIG } from '@collabswarm/collabswarm';
 import {
   changeDocumentAsync,
   openDocumentAsync,
   closeDocumentAsync,
   initializeAsync,
-} from "@collabswarm/collabswarm-redux";
-import { WikiSwarmArticle } from "../models";
-import { RootState, selectAutomergeSwarmState } from "../reducers";
-import dayjs from "dayjs";
-import { RouteComponentProps } from "react-router-dom";
-import Spinner from "react-bootstrap/Spinner";
-import { SlateInput } from "../components/SlateInput";
-import { initialValue } from "../components/Slate";
-import { AutomergeSwarm, AutomergeSwarmActions, AutomergeSwarmDocument } from "../utils";
+} from '@collabswarm/collabswarm-redux';
+import { WikiSwarmArticle } from '../models';
+import { RootState, selectAutomergeSwarmState } from '../reducers';
+import dayjs from 'dayjs';
+import { RouteComponentProps } from 'react-router-dom';
+import Spinner from 'react-bootstrap/Spinner';
+import { SlateInput } from '../components/SlateInput';
+import { initialValue } from '../components/Slate';
+import {
+  AutomergeSwarm,
+  AutomergeSwarmActions,
+  AutomergeSwarmDocument,
+} from '../utils';
 
 interface MatchParams {
   documentId: string;
@@ -27,17 +31,17 @@ interface WikiArticleProps extends RouteComponentProps<MatchParams> {
 
   onInitialize: (config: CollabswarmConfig) => Promise<AutomergeSwarm>;
   onDocumentOpen: (
-    documentPath: string
+    documentPath: string,
   ) => Promise<AutomergeSwarmDocument<WikiSwarmArticle> | null>;
   onDocumentClose: (documentPath: string) => Promise<void>;
   onDocumentChange: (
     documentPath: string,
     changeFn: (current: WikiSwarmArticle) => void,
-    message?: string
+    message?: string,
   ) => Promise<Doc<WikiSwarmArticle>>;
 }
 
-interface WikiArticleState { }
+interface WikiArticleState {}
 
 class WikiArticle extends React.Component<
   WikiArticleProps,
@@ -51,29 +55,29 @@ class WikiArticle extends React.Component<
   componentDidMount() {
     // Load this article upon component mount.
     if (this.props.onDocumentOpen && this.props.match.params.documentId) {
-      console.log("Loading article at:", this.props.match.params.documentId);
-      console.log("Env:", process.env);
+      console.log('Loading article at:', this.props.match.params.documentId);
+      console.log('Env:', process.env);
       const config = process.env.REACT_APP_CLIENT_CONFIG
         ? JSON.parse(process.env.REACT_APP_CLIENT_CONFIG)
         : JSON.parse(JSON.stringify(DEFAULT_CONFIG));
       if (process.env.REACT_APP_SIGNALING_SERVER) {
         config.ipfs.config.Addresses.Swarm.push(
-          process.env.REACT_APP_SIGNALING_SERVER
+          process.env.REACT_APP_SIGNALING_SERVER,
         );
       }
       this.props
         .onInitialize(config)
         .then(() =>
-          this.props.onDocumentOpen(this.props.match.params.documentId)
+          this.props.onDocumentOpen(this.props.match.params.documentId),
         )
-        .then((loaded) => console.log("Loaded article:", loaded));
+        .then((loaded) => console.log('Loaded article:', loaded));
     }
   }
 
   componentWillUnmount() {
     // Close this article upon component unmount.
     if (this.props.onDocumentClose && this.props.match.params.documentId) {
-      console.log("Closing article at:", this.props.match.params.documentId);
+      console.log('Closing article at:', this.props.match.params.documentId);
       this.props.onDocumentClose(this.props.match.params.documentId);
     }
   }
@@ -83,8 +87,8 @@ class WikiArticle extends React.Component<
     if (this.props.document) {
       if (!this.props.document.content) {
         console.warn(
-          "this.props.document.content is empty!",
-          this.props.document
+          'this.props.document.content is empty!',
+          this.props.document,
         );
       }
       return (
@@ -115,7 +119,7 @@ class WikiArticle extends React.Component<
                     }
                     currentDocument.content = content;
                     // console.log('Updating editor content:', currentDocument.content.blocks.map(x => x.text).join(' '));
-                  }
+                  },
                 );
               }}
             />
@@ -149,7 +153,7 @@ function mapDispatchToProps(
     RootState,
     unknown,
     AutomergeSwarmActions<WikiSwarmArticle>
-  >
+  >,
 ) {
   return {
     onInitialize: (config: CollabswarmConfig) =>
@@ -161,15 +165,15 @@ function mapDispatchToProps(
     onDocumentChange: (
       documentId: string,
       changeFn: (current: any) => void,
-      message?: string
+      message?: string,
     ) =>
       dispatch(
         changeDocumentAsync(
           documentId,
           changeFn,
           message,
-          selectAutomergeSwarmState
-        )
+          selectAutomergeSwarmState,
+        ),
       ),
   };
 }

--- a/examples/wiki-swarm/src/containers/WikiArticle.tsx
+++ b/examples/wiki-swarm/src/containers/WikiArticle.tsx
@@ -4,10 +4,6 @@ import { ThunkDispatch } from "redux-thunk";
 import { Doc } from "automerge";
 import { CollabswarmConfig, DEFAULT_CONFIG } from "@collabswarm/collabswarm";
 import {
-  AutomergeSwarm,
-  AutomergeSwarmDocument,
-} from "@collabswarm/collabswarm-automerge";
-import {
   changeDocumentAsync,
   openDocumentAsync,
   closeDocumentAsync,
@@ -20,7 +16,7 @@ import { RouteComponentProps } from "react-router-dom";
 import Spinner from "react-bootstrap/Spinner";
 import { SlateInput } from "../components/SlateInput";
 import { initialValue } from "../components/Slate";
-import { AutomergeSwarmActions } from "../utils";
+import { AutomergeSwarm, AutomergeSwarmActions, AutomergeSwarmDocument } from "../utils";
 
 interface MatchParams {
   documentId: string;
@@ -41,7 +37,7 @@ interface WikiArticleProps extends RouteComponentProps<MatchParams> {
   ) => Promise<Doc<WikiSwarmArticle>>;
 }
 
-interface WikiArticleState {}
+interface WikiArticleState { }
 
 class WikiArticle extends React.Component<
   WikiArticleProps,

--- a/examples/wiki-swarm/src/reducers.ts
+++ b/examples/wiki-swarm/src/reducers.ts
@@ -3,7 +3,8 @@ import { WikiSwarmArticle } from "./models";
 import { WikiSwarmActions, SEARCH } from "./actions";
 import { AutomergeSwarmActions, AutomergeSwarmState } from "./utils";
 import { collabswarmReducer } from "@collabswarm/collabswarm-redux";
-import { AutomergeJSONSerializer, AutomergeProvider } from "@collabswarm/collabswarm-automerge";
+import { AutomergeACLProvider, AutomergeJSONSerializer, AutomergeKeychainProvider, AutomergeProvider } from "@collabswarm/collabswarm-automerge";
+import { SubtleCrypto } from "@collabswarm/collabswarm";
 
 export interface WikiAppState {
 }
@@ -31,7 +32,7 @@ export type RootState = CombinedState<{
 
 export const rootReducer: (state: RootState | undefined, action: WikiSwarmActions) => RootState = combineReducers({
   // automergeSwarm: collabswarmReducer(new AutomergeProvider<WikiSwarmArticle>()),
-  automergeSwarm: collabswarmReducer(new AutomergeProvider(), new AutomergeJSONSerializer(), new AutomergeJSONSerializer()) as (state: AutomergeSwarmState<WikiSwarmArticle> | undefined, action: AutomergeSwarmActions) => AutomergeSwarmState<WikiSwarmArticle>,
+  automergeSwarm: collabswarmReducer(new AutomergeProvider(), new AutomergeJSONSerializer(), new AutomergeJSONSerializer(), new SubtleCrypto(), new AutomergeACLProvider(), new AutomergeKeychainProvider()) as (state: AutomergeSwarmState<WikiSwarmArticle> | undefined, action: AutomergeSwarmActions) => AutomergeSwarmState<WikiSwarmArticle>,
   wikiApp: wikiAppReducer,
 });
 

--- a/examples/wiki-swarm/src/reducers.ts
+++ b/examples/wiki-swarm/src/reducers.ts
@@ -1,22 +1,28 @@
-import { combineReducers, CombinedState } from "redux";
-import { WikiSwarmArticle } from "./models";
-import { WikiSwarmActions, SEARCH } from "./actions";
-import { AutomergeSwarmActions, AutomergeSwarmState } from "./utils";
-import { collabswarmReducer } from "@collabswarm/collabswarm-redux";
-import { AutomergeACLProvider, AutomergeJSONSerializer, AutomergeKeychainProvider, AutomergeProvider } from "@collabswarm/collabswarm-automerge";
-import { SubtleCrypto } from "@collabswarm/collabswarm";
+import { combineReducers, CombinedState } from 'redux';
+import { WikiSwarmArticle } from './models';
+import { WikiSwarmActions, SEARCH } from './actions';
+import { AutomergeSwarmActions, AutomergeSwarmState } from './utils';
+import { collabswarmReducer } from '@collabswarm/collabswarm-redux';
+import {
+  AutomergeACLProvider,
+  AutomergeJSONSerializer,
+  AutomergeKeychainProvider,
+  AutomergeProvider,
+} from '@collabswarm/collabswarm-automerge';
+import { SubtleCrypto } from '@collabswarm/collabswarm';
 
-export interface WikiAppState {
-}
+export interface WikiAppState {}
 
-export const wikiAppInitialState: WikiAppState = {
-};
+export const wikiAppInitialState: WikiAppState = {};
 
-export function wikiAppReducer(state: WikiAppState = wikiAppInitialState, action: any): WikiAppState {
+export function wikiAppReducer(
+  state: WikiAppState = wikiAppInitialState,
+  action: any,
+): WikiAppState {
   switch (action.type) {
     case SEARCH: {
       return {
-        ...state
+        ...state,
       };
     }
     default: {
@@ -28,14 +34,29 @@ export function wikiAppReducer(state: WikiAppState = wikiAppInitialState, action
 export type RootState = CombinedState<{
   automergeSwarm: AutomergeSwarmState<WikiSwarmArticle>;
   wikiApp: WikiAppState;
-}>
+}>;
 
-export const rootReducer: (state: RootState | undefined, action: WikiSwarmActions) => RootState = combineReducers({
+export const rootReducer: (
+  state: RootState | undefined,
+  action: WikiSwarmActions,
+) => RootState = combineReducers({
   // automergeSwarm: collabswarmReducer(new AutomergeProvider<WikiSwarmArticle>()),
-  automergeSwarm: collabswarmReducer(new AutomergeProvider(), new AutomergeJSONSerializer(), new AutomergeJSONSerializer(), new SubtleCrypto(), new AutomergeACLProvider(), new AutomergeKeychainProvider()) as (state: AutomergeSwarmState<WikiSwarmArticle> | undefined, action: AutomergeSwarmActions) => AutomergeSwarmState<WikiSwarmArticle>,
+  automergeSwarm: collabswarmReducer(
+    new AutomergeProvider(),
+    new AutomergeJSONSerializer(),
+    new AutomergeJSONSerializer(),
+    new SubtleCrypto(),
+    new AutomergeACLProvider(),
+    new AutomergeKeychainProvider(),
+  ) as (
+    state: AutomergeSwarmState<WikiSwarmArticle> | undefined,
+    action: AutomergeSwarmActions,
+  ) => AutomergeSwarmState<WikiSwarmArticle>,
   wikiApp: wikiAppReducer,
 });
 
-export function selectAutomergeSwarmState(rootState: RootState): AutomergeSwarmState<WikiSwarmArticle> {
+export function selectAutomergeSwarmState(
+  rootState: RootState,
+): AutomergeSwarmState<WikiSwarmArticle> {
   return rootState.automergeSwarm;
 }

--- a/examples/wiki-swarm/src/utils.ts
+++ b/examples/wiki-swarm/src/utils.ts
@@ -1,19 +1,39 @@
-import { AutomergeSwarmSyncMessage } from "@collabswarm/collabswarm-automerge";
+import { Collabswarm, CollabswarmDocument } from "@collabswarm/collabswarm";
 import {
   CollabswarmActions,
   CollabswarmState,
 } from "@collabswarm/collabswarm-redux";
 import { Doc, BinaryChange } from "automerge";
 
+export type AutomergeSwarm<T = any> = Collabswarm<
+  Doc<T>,
+  BinaryChange[],
+  (doc: T) => void,
+  CryptoKey,
+  CryptoKey,
+  CryptoKey
+>;
+export type AutomergeSwarmDocument<T = any> = CollabswarmDocument<
+  Doc<T>,
+  BinaryChange[],
+  (doc: T) => void,
+  CryptoKey,
+  CryptoKey,
+  CryptoKey
+>;
 export type AutomergeSwarmState<T = any> = CollabswarmState<
   Doc<T>,
   BinaryChange[],
   (doc: T) => void,
-  AutomergeSwarmSyncMessage
+  CryptoKey,
+  CryptoKey,
+  CryptoKey
 >;
 export type AutomergeSwarmActions<T = any> = CollabswarmActions<
   Doc<T>,
   BinaryChange[],
   (doc: T) => void,
-  AutomergeSwarmSyncMessage
+  CryptoKey,
+  CryptoKey,
+  CryptoKey
 >;

--- a/examples/wiki-swarm/src/utils.ts
+++ b/examples/wiki-swarm/src/utils.ts
@@ -1,9 +1,9 @@
-import { Collabswarm, CollabswarmDocument } from "@collabswarm/collabswarm";
+import { Collabswarm, CollabswarmDocument } from '@collabswarm/collabswarm';
 import {
   CollabswarmActions,
   CollabswarmState,
-} from "@collabswarm/collabswarm-redux";
-import { Doc, BinaryChange } from "automerge";
+} from '@collabswarm/collabswarm-redux';
+import { Doc, BinaryChange } from 'automerge';
 
 export type AutomergeSwarm<T = any> = Collabswarm<
   Doc<T>,

--- a/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
+++ b/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
-import { CollabswarmNode } from '@collabswarm/collabswarm';
+import { CollabswarmNode, SubtleCrypto } from '@collabswarm/collabswarm';
 import { AutomergeJSONSerializer, AutomergeProvider } from '../src';
 
 console.log('Creating a new swarm node...');
 const crdt = new AutomergeProvider();
 const serializer = new AutomergeJSONSerializer();
-const swarmNode = new CollabswarmNode(crdt, serializer, serializer);
+const auth = new SubtleCrypto();
+const swarmNode = new CollabswarmNode(crdt, serializer, serializer, auth);
 console.log('Starting node...');
 swarmNode.start();

--- a/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
+++ b/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
-import { CollabswarmNode, SubtleCrypto } from '@collabswarm/collabswarm';
+import { CollabswarmNode, CryptoKeySerializer, SubtleCrypto } from '@collabswarm/collabswarm';
 import { AutomergeJSONSerializer, AutomergeProvider } from '../src';
 
 console.log('Creating a new swarm node...');
 const crdt = new AutomergeProvider();
 const serializer = new AutomergeJSONSerializer();
 const auth = new SubtleCrypto();
-const swarmNode = new CollabswarmNode(crdt, serializer, serializer, auth);
+const keySerializer = new CryptoKeySerializer({ name: "AES-GCM" }, ["encrypt", "decrypt"]);
+const swarmNode = new CollabswarmNode(crdt, serializer, serializer, auth, keySerializer);
 console.log('Starting node...');
 swarmNode.start();

--- a/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
+++ b/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
@@ -2,7 +2,10 @@
 
 import { CollabswarmNode, SubtleCrypto } from '@collabswarm/collabswarm';
 import { AutomergeJSONSerializer, AutomergeProvider } from '../src';
-import { AutomergeACLProvider, AutomergeKeychainProvider } from '../src/collabswarm-automerge';
+import {
+  AutomergeACLProvider,
+  AutomergeKeychainProvider,
+} from '../src/collabswarm-automerge';
 
 console.log('Creating a new swarm node...');
 const crdt = new AutomergeProvider();
@@ -10,6 +13,13 @@ const serializer = new AutomergeJSONSerializer();
 const auth = new SubtleCrypto();
 const acl = new AutomergeACLProvider();
 const keychain = new AutomergeKeychainProvider();
-const swarmNode = new CollabswarmNode(crdt, serializer, serializer, auth, acl, keychain);
+const swarmNode = new CollabswarmNode(
+  crdt,
+  serializer,
+  serializer,
+  auth,
+  acl,
+  keychain,
+);
 console.log('Starting node...');
 swarmNode.start();

--- a/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
+++ b/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 
-import { CollabswarmNode, CryptoKeySerializer, SubtleCrypto } from '@collabswarm/collabswarm';
+import { CollabswarmNode, SubtleCrypto } from '@collabswarm/collabswarm';
 import { AutomergeJSONSerializer, AutomergeProvider } from '../src';
+import { AutomergeACLProvider, AutomergeKeychainProvider } from '../src/collabswarm-automerge';
 
 console.log('Creating a new swarm node...');
 const crdt = new AutomergeProvider();
 const serializer = new AutomergeJSONSerializer();
 const auth = new SubtleCrypto();
-const keySerializer = new CryptoKeySerializer({ name: "AES-GCM" }, ["encrypt", "decrypt"]);
-const swarmNode = new CollabswarmNode(crdt, serializer, serializer, auth, keySerializer);
+const acl = new AutomergeACLProvider();
+const keychain = new AutomergeKeychainProvider();
+const swarmNode = new CollabswarmNode(crdt, serializer, serializer, auth, acl, keychain);
 console.log('Starting node...');
 swarmNode.start();

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -20,38 +20,31 @@ import {
 
 export type AutomergeSwarmDocumentChangeHandler<
   T = any
-> = CollabswarmDocumentChangeHandler<Doc<T>>;
+  > = CollabswarmDocumentChangeHandler<Doc<T>>;
 
-export type AutomergeSwarm<T = any> = Collabswarm<
-  Doc<T>,
-  BinaryChange[],
-  (doc: T) => void,
-  AutomergeSwarmSyncMessage
->;
+// export type AutomergeSwarm<T = any> = Collabswarm<
+//   Doc<T>,
+//   BinaryChange[],
+//   (doc: T) => void,
+//   AutomergeSwarmSyncMessage
+// >;
 
-export type AutomergeSwarmDocument<T = any> = CollabswarmDocument<
-  Doc<T>,
-  BinaryChange[],
-  (doc: T) => void,
-  AutomergeSwarmSyncMessage
->;
-
-export interface AutomergeSwarmSyncMessage
-  extends CRDTSyncMessage<BinaryChange[]> {}
+// export type AutomergeSwarmDocument<T = any> = CollabswarmDocument<
+//   Doc<T>,
+//   BinaryChange[],
+//   (doc: T) => void,
+//   AutomergeSwarmSyncMessage
+// >;
 
 export class AutomergeProvider<T = any>
   implements
-    CRDTProvider<
-      Doc<T>,
-      BinaryChange[],
-      (doc: T) => void,
-      AutomergeSwarmSyncMessage
-    > {
+  CRDTProvider<
+  Doc<T>,
+  BinaryChange[],
+  (doc: T) => void
+  > {
   newDocument(): Doc<T> {
     return init();
-  }
-  newMessage(documentId: string): AutomergeSwarmSyncMessage {
-    return { documentId, changes: {} };
   }
   localChange(
     document: Doc<T>,
@@ -73,7 +66,4 @@ export class AutomergeProvider<T = any>
   }
 }
 
-export class AutomergeJSONSerializer extends JSONSerializer<
-  BinaryChange[],
-  AutomergeSwarmSyncMessage
-> {}
+export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> { }

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -1,40 +1,27 @@
 import {
   Doc,
-  Change,
   init,
   change,
   getChanges,
   applyChanges,
   BinaryChange,
   getAllChanges,
+  from,
 } from "automerge";
 
 import {
-  Collabswarm,
-  CollabswarmDocument,
+  ACL,
+  ACLProvider,
   CollabswarmDocumentChangeHandler,
   CRDTProvider,
-  CRDTSyncMessage,
   JSONSerializer,
+  Keychain,
+  KeychainProvider,
 } from "@collabswarm/collabswarm";
 
 export type AutomergeSwarmDocumentChangeHandler<
   T = any
   > = CollabswarmDocumentChangeHandler<Doc<T>>;
-
-// export type AutomergeSwarm<T = any> = Collabswarm<
-//   Doc<T>,
-//   BinaryChange[],
-//   (doc: T) => void,
-//   AutomergeSwarmSyncMessage
-// >;
-
-// export type AutomergeSwarmDocument<T = any> = CollabswarmDocument<
-//   Doc<T>,
-//   BinaryChange[],
-//   (doc: T) => void,
-//   AutomergeSwarmSyncMessage
-// >;
 
 export class AutomergeProvider<T = any>
   implements
@@ -63,6 +50,138 @@ export class AutomergeProvider<T = any>
   }
   getHistory(document: Doc<T>): BinaryChange[] {
     return getAllChanges(document);
+  }
+}
+
+export async function hashKey(publicKey: CryptoKey): Promise<string> {
+  const buf = await crypto.subtle.exportKey("raw", publicKey);
+  let binary = '';
+  let bytes = new Uint8Array(buf);
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return window.btoa(binary);
+}
+
+export async function unhashKey(publicKey: string): Promise<CryptoKey> {
+  let binaryString = window.atob(publicKey);
+  let bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return await crypto.subtle.importKey("raw", bytes, "AES-GCM", true, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+export type AutomergeACLDoc = Doc<{
+  users: { [hash: string]: true };
+}>;
+
+export class AutomergeACL implements ACL<BinaryChange[], CryptoKey> {
+  private _acl: AutomergeACLDoc = from({
+    users: {},
+  });
+
+  async add(publicKey: CryptoKey): Promise<BinaryChange[]> {
+    const hash = await hashKey(publicKey);
+    const aclNew = change(this._acl, doc => {
+      if (!doc.users) {
+        doc.users = {};
+      }
+      doc.users[hash] = true;
+    });
+    const aclChanges = getChanges(this._acl, aclNew);
+    this._acl = aclNew;
+    return aclChanges;
+  }
+  async remove(publicKey: CryptoKey): Promise<BinaryChange[]> {
+    const hash = await hashKey(publicKey);
+    const aclNew = change(this._acl, doc => {
+      if (!doc.users) {
+        doc.users = {};
+      } else {
+        if (doc.users[hash] !== undefined) {
+          delete doc.users[hash];
+        }
+      }
+    });
+    const aclChanges = getChanges(this._acl, aclNew);
+    this._acl = aclNew;
+    return aclChanges;
+  }
+  current(): BinaryChange[] {
+    return getAllChanges(this._acl);
+  }
+  merge(change: BinaryChange[]): void {
+    const [doc] = applyChanges(this._acl, change);
+    this._acl = doc;
+  }
+  async check(publicKey: CryptoKey): Promise<boolean> {
+    const hash = await hashKey(publicKey);
+    return this._acl.users && (this._acl.users[hash] !== undefined);
+  }
+}
+
+export class AutomergeACLProvider implements ACLProvider<BinaryChange[], CryptoKey> {
+  initialize(): AutomergeACL {
+    return new AutomergeACL();
+  }
+}
+
+export type AutomergeKeychainDoc = Doc<{
+  keys: string[];
+}>;
+
+export class AutomergeKeychain implements Keychain<BinaryChange[], CryptoKey> {
+  // TODO: Replace this with a LRU cache of bounded size.
+  private readonly _keyCache = new Map<string, CryptoKey>();
+  private _keychain: AutomergeKeychainDoc = from({
+    keys: [],
+  });
+
+  async add(key: CryptoKey): Promise<BinaryChange[]> {
+    const hash = await hashKey(key);
+    this._keyCache.set(hash, key);
+    const keychainNew = change(this._keychain, doc => {
+      if (!doc.keys) {
+        doc.keys = [];
+      }
+      doc.keys.push(hash);
+    });
+    const keychainChanges = getChanges(this._keychain, keychainNew);
+    this._keychain = keychainNew;
+    return keychainChanges;
+  }
+  history(): BinaryChange[] {
+    return getAllChanges(this._keychain);
+  }
+  merge(change: BinaryChange[]): void {
+    const [doc] = applyChanges(this._keychain, change);
+    this._keychain = doc;
+  }
+  async keys(): Promise<CryptoKey[]> {
+    if (!this._keychain.keys) {
+      return [];
+    }
+
+    return await Promise.all(this._keychain.keys.map(async hash => {
+      let key: CryptoKey | undefined = undefined;
+      if (this._keyCache.has(hash)) {
+        key = this._keyCache.get(hash);
+      }
+      if (!key) {
+        key = await unhashKey(hash);
+      }
+      return key;
+    }));
+  }
+}
+
+export class AutomergeKeychainProvider implements KeychainProvider<BinaryChange[], CryptoKey> {
+  initialize(): AutomergeKeychain {
+    return new AutomergeKeychain();
   }
 }
 

--- a/packages/collabswarm-automerge/src/index.ts
+++ b/packages/collabswarm-automerge/src/index.ts
@@ -1,6 +1,10 @@
-import { AutomergeSwarmDocumentChangeHandler, AutomergeProvider, AutomergeJSONSerializer } from "./collabswarm-automerge";
+import { AutomergeSwarmDocumentChangeHandler, AutomergeProvider, AutomergeJSONSerializer, AutomergeACLProvider, AutomergeKeychainProvider, AutomergeACL, AutomergeKeychain } from "./collabswarm-automerge";
 
 export {
+  AutomergeACL,
+  AutomergeACLProvider,
+  AutomergeKeychain,
+  AutomergeKeychainProvider,
   AutomergeSwarmDocumentChangeHandler,
   AutomergeProvider,
   AutomergeJSONSerializer,

--- a/packages/collabswarm-automerge/src/index.ts
+++ b/packages/collabswarm-automerge/src/index.ts
@@ -1,4 +1,12 @@
-import { AutomergeSwarmDocumentChangeHandler, AutomergeProvider, AutomergeJSONSerializer, AutomergeACLProvider, AutomergeKeychainProvider, AutomergeACL, AutomergeKeychain } from "./collabswarm-automerge";
+import {
+  AutomergeSwarmDocumentChangeHandler,
+  AutomergeProvider,
+  AutomergeJSONSerializer,
+  AutomergeACLProvider,
+  AutomergeKeychainProvider,
+  AutomergeACL,
+  AutomergeKeychain,
+} from './collabswarm-automerge';
 
 export {
   AutomergeACL,

--- a/packages/collabswarm-automerge/src/index.ts
+++ b/packages/collabswarm-automerge/src/index.ts
@@ -1,10 +1,7 @@
-import { AutomergeSwarm, AutomergeSwarmDocument, AutomergeSwarmSyncMessage, AutomergeSwarmDocumentChangeHandler, AutomergeProvider, AutomergeJSONSerializer } from "./collabswarm-automerge";
+import { AutomergeSwarmDocumentChangeHandler, AutomergeProvider, AutomergeJSONSerializer } from "./collabswarm-automerge";
 
 export {
-  AutomergeSwarm,
   AutomergeSwarmDocumentChangeHandler,
-  AutomergeSwarmDocument,
-  AutomergeSwarmSyncMessage,
   AutomergeProvider,
   AutomergeJSONSerializer,
 };

--- a/packages/collabswarm-react/src/hooks.ts
+++ b/packages/collabswarm-react/src/hooks.ts
@@ -1,15 +1,22 @@
-import { ChangesSerializer, Collabswarm, CRDTProvider, CRDTSyncMessage, MessageSerializer } from "@collabswarm/collabswarm";
+import { ACLProvider, AuthProvider, ChangesSerializer, Collabswarm, CRDTProvider, CRDTSyncMessage, KeychainProvider, MessageSerializer } from "@collabswarm/collabswarm";
 import { useEffect, useState } from "react";
 
-export function useCollabswarm<DocType, ChangesType, ChangeFnType, MessageType extends CRDTSyncMessage<ChangesType>>(
-  provider: CRDTProvider<DocType, ChangesType, ChangeFnType, MessageType>,
+export function useCollabswarm<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>(
+  provider: CRDTProvider<DocType, ChangesType, ChangeFnType>,
   changesSerializer: ChangesSerializer<ChangesType>,
-  messageSerializer: MessageSerializer<MessageType>,
+  messageSerializer: MessageSerializer<ChangesType>,
+  authProvider: AuthProvider<
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >,
+  aclProvider: ACLProvider<ChangesType, PublicKey>,
+  keychainProvider: KeychainProvider<ChangesType, DocumentKey>,
 ) {
-  const [collabswarm, setCollabswarm] = useState<Collabswarm<DocType, ChangesType, ChangeFnType, MessageType> | undefined>();
+  const [collabswarm, setCollabswarm] = useState<Collabswarm<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> | undefined>();
 
   useEffect(() => {
-    setCollabswarm(new Collabswarm(provider, changesSerializer, messageSerializer));
+    setCollabswarm(new Collabswarm(provider, changesSerializer, messageSerializer, authProvider, aclProvider, keychainProvider));
   });
 
   return collabswarm;

--- a/packages/collabswarm-react/src/hooks.ts
+++ b/packages/collabswarm-react/src/hooks.ts
@@ -1,22 +1,53 @@
-import { ACLProvider, AuthProvider, ChangesSerializer, Collabswarm, CRDTProvider, CRDTSyncMessage, KeychainProvider, MessageSerializer } from "@collabswarm/collabswarm";
-import { useEffect, useState } from "react";
+import {
+  ACLProvider,
+  AuthProvider,
+  ChangesSerializer,
+  Collabswarm,
+  CRDTProvider,
+  CRDTSyncMessage,
+  KeychainProvider,
+  MessageSerializer,
+} from '@collabswarm/collabswarm';
+import { useEffect, useState } from 'react';
 
-export function useCollabswarm<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>(
+export function useCollabswarm<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+>(
   provider: CRDTProvider<DocType, ChangesType, ChangeFnType>,
   changesSerializer: ChangesSerializer<ChangesType>,
   messageSerializer: MessageSerializer<ChangesType>,
-  authProvider: AuthProvider<
-    PrivateKey,
-    PublicKey,
-    DocumentKey
-  >,
+  authProvider: AuthProvider<PrivateKey, PublicKey, DocumentKey>,
   aclProvider: ACLProvider<ChangesType, PublicKey>,
   keychainProvider: KeychainProvider<ChangesType, DocumentKey>,
 ) {
-  const [collabswarm, setCollabswarm] = useState<Collabswarm<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> | undefined>();
+  const [collabswarm, setCollabswarm] = useState<
+    | Collabswarm<
+        DocType,
+        ChangesType,
+        ChangeFnType,
+        PrivateKey,
+        PublicKey,
+        DocumentKey
+      >
+    | undefined
+  >();
 
   useEffect(() => {
-    setCollabswarm(new Collabswarm(provider, changesSerializer, messageSerializer, authProvider, aclProvider, keychainProvider));
+    setCollabswarm(
+      new Collabswarm(
+        provider,
+        changesSerializer,
+        messageSerializer,
+        authProvider,
+        aclProvider,
+        keychainProvider,
+      ),
+    );
   });
 
   return collabswarm;

--- a/packages/collabswarm-redux/src/actions.ts
+++ b/packages/collabswarm-redux/src/actions.ts
@@ -1,15 +1,66 @@
-import { Action } from "redux";
-import { ThunkAction } from "redux-thunk";
-import { CollabswarmState } from "./reducers";
-import { Collabswarm, CollabswarmDocument, CollabswarmConfig, DEFAULT_CONFIG } from "@collabswarm/collabswarm";
-
+import { Action } from 'redux';
+import { ThunkAction } from 'redux-thunk';
+import { CollabswarmState } from './reducers';
+import {
+  Collabswarm,
+  CollabswarmDocument,
+  CollabswarmConfig,
+  DEFAULT_CONFIG,
+} from '@collabswarm/collabswarm';
 
 // TODO: Add an optional trace option that records the async call-site in the action for debugging purposes.
 
-export function initializeAsync<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>(
+export function initializeAsync<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey,
+  RootStateType = CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >
+>(
   config: CollabswarmConfig = DEFAULT_CONFIG,
-  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> = s => s as any,
-): ThunkAction<Promise<Collabswarm<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>, RootStateType, unknown, InitializeAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> | PeerConnectAction | PeerDisconnectAction> {
+  selectCollabswarmState: (
+    rootState: RootStateType,
+  ) => CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  > = (s) => s as any,
+): ThunkAction<
+  Promise<
+    Collabswarm<
+      DocType,
+      ChangesType,
+      ChangeFnType,
+      PrivateKey,
+      PublicKey,
+      DocumentKey
+    >
+  >,
+  RootStateType,
+  unknown,
+  | InitializeAction<
+      DocType,
+      ChangesType,
+      ChangeFnType,
+      PrivateKey,
+      PublicKey,
+      DocumentKey
+    >
+  | PeerConnectAction
+  | PeerDisconnectAction
+> {
   return async (dispatch, getState) => {
     const { node } = selectCollabswarmState(getState());
     node.subscribeToPeerConnect('peer-connect', (address: string) => {
@@ -17,7 +68,7 @@ export function initializeAsync<DocType, ChangesType, ChangeFnType, PrivateKey, 
     });
     node.subscribeToPeerDisconnect('peer-disconnect', (address: string) => {
       dispatch(peerDisconnect(address));
-    })
+    });
     await node.initialize(config);
     dispatch(initialize(node));
     console.log('Node information:', node);
@@ -26,24 +77,85 @@ export function initializeAsync<DocType, ChangesType, ChangeFnType, PrivateKey, 
 }
 
 export const INITIALIZE = 'COLLABSWARM_INITIALIZE';
-export interface InitializeAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> extends Action<typeof INITIALIZE> {
-  node: Collabswarm<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>
+export interface InitializeAction<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+> extends Action<typeof INITIALIZE> {
+  node: Collabswarm<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >;
 }
-export function initialize<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>(
-  node: Collabswarm<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>
-): InitializeAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> {
+export function initialize<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+>(
+  node: Collabswarm<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >,
+): InitializeAction<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+> {
   return { type: INITIALIZE, node };
 }
 
-
-export function connectAsync<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>(
+export function connectAsync<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey,
+  RootStateType = CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >
+>(
   addresses: string[],
-  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> = s => s as any
+  selectCollabswarmState: (
+    rootState: RootStateType,
+  ) => CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  > = (s) => s as any,
 ): ThunkAction<Promise<void>, RootStateType, unknown, ConnectAction> {
   return async (dispatch, getState) => {
     const { node } = selectCollabswarmState(getState());
     if (!node) {
-      console.warn('Node not initialized yet! Unable to connect to:', addresses);
+      console.warn(
+        'Node not initialized yet! Unable to connect to:',
+        addresses,
+      );
       return;
     }
     await node.connect(addresses);
@@ -55,33 +167,86 @@ export function connectAsync<DocType, ChangesType, ChangeFnType, PrivateKey, Pub
 
 export const CONNECT = 'COLLABSWARM_CONNECT';
 export interface ConnectAction extends Action<typeof CONNECT> {
-  addresses: string[]
+  addresses: string[];
 }
 export function connect(addresses: string[]): ConnectAction {
   return { type: CONNECT, addresses };
 }
 
-
-export function openDocumentAsync<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>(
+export function openDocumentAsync<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey,
+  RootStateType = CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >
+>(
   documentId: string,
-  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> = s => s as any
-): ThunkAction<Promise<CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> | null>, RootStateType, unknown, OpenDocumentAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> | SyncDocumentAction<DocType>> {
+  selectCollabswarmState: (
+    rootState: RootStateType,
+  ) => CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  > = (s) => s as any,
+): ThunkAction<
+  Promise<CollabswarmDocument<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  > | null>,
+  RootStateType,
+  unknown,
+  | OpenDocumentAction<
+      DocType,
+      ChangesType,
+      ChangeFnType,
+      PrivateKey,
+      PublicKey,
+      DocumentKey
+    >
+  | SyncDocumentAction<DocType>
+> {
   return async (dispatch, getState) => {
     const { node } = selectCollabswarmState(getState());
     if (!node) {
-      console.warn('Node not initialized yet! Unable to open document:', documentId);
+      console.warn(
+        'Node not initialized yet! Unable to open document:',
+        documentId,
+      );
       return null;
     }
     const documentRef = node.doc(documentId);
     // TODO: Close previous document (if any).
     if (documentRef) {
-      documentRef.subscribe(documentId, document => {
-        dispatch(syncDocument(documentId, document));
-      }, 'remote');
+      documentRef.subscribe(
+        documentId,
+        (document) => {
+          dispatch(syncDocument(documentId, document));
+        },
+        'remote',
+      );
       const loaded = await documentRef.open();
       if (!loaded) {
         // Assume this is a new document.
-        console.log('Failed to load document from peers, assuming this is a new document...', documentRef);
+        console.log(
+          'Failed to load document from peers, assuming this is a new document...',
+          documentRef,
+        );
         await documentRef.pin();
       }
       dispatch(openDocument(documentId, documentRef));
@@ -94,19 +259,85 @@ export function openDocumentAsync<DocType, ChangesType, ChangeFnType, PrivateKey
 }
 
 export const OPEN_DOCUMENT = 'COLLABSWARM_OPEN_DOCUMENT';
-export interface OpenDocumentAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> extends Action<typeof OPEN_DOCUMENT> {
+export interface OpenDocumentAction<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+> extends Action<typeof OPEN_DOCUMENT> {
   documentId: string;
-  documentRef: CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>;
+  documentRef: CollabswarmDocument<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >;
 }
-export function openDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>(documentId: string, documentRef: CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>): OpenDocumentAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> {
+export function openDocument<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+>(
+  documentId: string,
+  documentRef: CollabswarmDocument<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >,
+): OpenDocumentAction<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+> {
   return { type: OPEN_DOCUMENT, documentId, documentRef };
 }
 
-
-export function closeDocumentAsync<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>(
+export function closeDocumentAsync<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey,
+  RootStateType = CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >
+>(
   documentId: string,
-  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> = s => s as any
-): ThunkAction<Promise<void>, RootStateType, unknown, CloseDocumentAction | SyncDocumentAction<DocType>> {
+  selectCollabswarmState: (
+    rootState: RootStateType,
+  ) => CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  > = (s) => s as any,
+): ThunkAction<
+  Promise<void>,
+  RootStateType,
+  unknown,
+  CloseDocumentAction | SyncDocumentAction<DocType>
+> {
   return async (dispatch, getState) => {
     const { documents } = selectCollabswarmState(getState());
     if (documents[documentId] && documents[documentId].documentRef) {
@@ -128,46 +359,82 @@ export function closeDocument(documentId: string): CloseDocumentAction {
   return { type: CLOSE_DOCUMENT, documentId };
 }
 
-
 export const SYNC_DOCUMENT = 'COLLABSWARM_SYNC_DOCUMENT';
-export interface SyncDocumentAction<DocType> extends Action<typeof SYNC_DOCUMENT> {
+export interface SyncDocumentAction<DocType>
+  extends Action<typeof SYNC_DOCUMENT> {
   documentId: string;
   document: DocType;
 }
-export function syncDocument<DocType>(documentId: string, document: DocType): SyncDocumentAction<DocType> {
+export function syncDocument<DocType>(
+  documentId: string,
+  document: DocType,
+): SyncDocumentAction<DocType> {
   return { type: SYNC_DOCUMENT, documentId, document };
 }
 
-
-export function changeDocumentAsync<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>(
+export function changeDocumentAsync<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey,
+  RootStateType = CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >
+>(
   documentId: string,
   changeFn: ChangeFnType,
   message?: string,
-  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> = s => s as any
-): ThunkAction<Promise<DocType>, RootStateType, unknown, ChangeDocumentAction<DocType>> {
+  selectCollabswarmState: (
+    rootState: RootStateType,
+  ) => CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  > = (s) => s as any,
+): ThunkAction<
+  Promise<DocType>,
+  RootStateType,
+  unknown,
+  ChangeDocumentAction<DocType>
+> {
   return async (dispatch, getState) => {
     const { documents } = selectCollabswarmState(getState());
     if (documents[documentId] && documents[documentId].documentRef) {
       const documentRef = documents[documentId].documentRef;
       const changePromise = documentRef.change(changeFn, message);
       dispatch(changeDocument(documentId, documentRef.document));
-      await changePromise
+      await changePromise;
       return documentRef.document;
     } else {
-      throw new Error(`Trying to edit a document that is not opened: ${documentId}`);
+      throw new Error(
+        `Trying to edit a document that is not opened: ${documentId}`,
+      );
     }
   };
 }
 
 export const CHANGE_DOCUMENT = 'COLLABSWARM_CHANGE_DOCUMENT';
-export interface ChangeDocumentAction<DocType> extends Action<typeof CHANGE_DOCUMENT> {
+export interface ChangeDocumentAction<DocType>
+  extends Action<typeof CHANGE_DOCUMENT> {
   documentId: string;
   document: DocType;
 }
-export function changeDocument<DocType>(documentId: string, document: DocType): ChangeDocumentAction<DocType> {
+export function changeDocument<DocType>(
+  documentId: string,
+  document: DocType,
+): ChangeDocumentAction<DocType> {
   return { type: CHANGE_DOCUMENT, documentId, document };
 }
-
 
 export const PEER_CONNECT = 'COLLABSWARM_PEER_CONNECT';
 export interface PeerConnectAction extends Action<typeof PEER_CONNECT> {
@@ -177,7 +444,6 @@ export function peerConnect(peerAddress: string): PeerConnectAction {
   return { type: PEER_CONNECT, peerAddress };
 }
 
-
 export const PEER_DISCONNECT = 'COLLABSWARM_PEER_DISCONNECT';
 export interface PeerDisconnectAction extends Action<typeof PEER_DISCONNECT> {
   peerAddress: string;
@@ -186,13 +452,33 @@ export function peerDisconnect(peerAddress: string): PeerDisconnectAction {
   return { type: PEER_DISCONNECT, peerAddress };
 }
 
-
-export type CollabswarmActions<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> =
-  InitializeAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> |
-  ConnectAction |
-  OpenDocumentAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> |
-  CloseDocumentAction |
-  SyncDocumentAction<DocType> |
-  ChangeDocumentAction<DocType> |
-  PeerConnectAction |
-  PeerDisconnectAction;
+export type CollabswarmActions<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+> =
+  | InitializeAction<
+      DocType,
+      ChangesType,
+      ChangeFnType,
+      PrivateKey,
+      PublicKey,
+      DocumentKey
+    >
+  | ConnectAction
+  | OpenDocumentAction<
+      DocType,
+      ChangesType,
+      ChangeFnType,
+      PrivateKey,
+      PublicKey,
+      DocumentKey
+    >
+  | CloseDocumentAction
+  | SyncDocumentAction<DocType>
+  | ChangeDocumentAction<DocType>
+  | PeerConnectAction
+  | PeerDisconnectAction;

--- a/packages/collabswarm-redux/src/actions.ts
+++ b/packages/collabswarm-redux/src/actions.ts
@@ -1,15 +1,15 @@
 import { Action } from "redux";
 import { ThunkAction } from "redux-thunk";
 import { CollabswarmState } from "./reducers";
-import { Collabswarm, CollabswarmDocument, CRDTSyncMessage, CollabswarmConfig, DEFAULT_CONFIG } from "@collabswarm/collabswarm";
+import { Collabswarm, CollabswarmDocument, CollabswarmConfig, DEFAULT_CONFIG } from "@collabswarm/collabswarm";
 
 
 // TODO: Add an optional trace option that records the async call-site in the action for debugging purposes.
 
-export function initializeAsync<DocType, ChangesType, ChangeFnType, MessageType extends CRDTSyncMessage<ChangesType>, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, MessageType>>(
+export function initializeAsync<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>(
   config: CollabswarmConfig = DEFAULT_CONFIG,
-  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, MessageType> = s => s as any,
-): ThunkAction<Promise<Collabswarm<DocType, ChangesType, ChangeFnType, MessageType>>, RootStateType, unknown, InitializeAction<DocType, ChangesType, ChangeFnType, MessageType> | PeerConnectAction | PeerDisconnectAction> {
+  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> = s => s as any,
+): ThunkAction<Promise<Collabswarm<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>, RootStateType, unknown, InitializeAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> | PeerConnectAction | PeerDisconnectAction> {
   return async (dispatch, getState) => {
     const { node } = selectCollabswarmState(getState());
     node.subscribeToPeerConnect('peer-connect', (address: string) => {
@@ -26,19 +26,19 @@ export function initializeAsync<DocType, ChangesType, ChangeFnType, MessageType 
 }
 
 export const INITIALIZE = 'COLLABSWARM_INITIALIZE';
-export interface InitializeAction<DocType, ChangesType, ChangeFnType, MessageType extends CRDTSyncMessage<ChangesType>> extends Action<typeof INITIALIZE> {
-  node: Collabswarm<DocType, ChangesType, ChangeFnType, MessageType>
+export interface InitializeAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> extends Action<typeof INITIALIZE> {
+  node: Collabswarm<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>
 }
-export function initialize<DocType, ChangesType, ChangeFnType, MessageType extends CRDTSyncMessage<ChangesType>>(
-  node: Collabswarm<DocType, ChangesType, ChangeFnType, MessageType>
-): InitializeAction<DocType, ChangesType, ChangeFnType, MessageType> {
+export function initialize<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>(
+  node: Collabswarm<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>
+): InitializeAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> {
   return { type: INITIALIZE, node };
 }
 
 
-export function connectAsync<DocType, ChangesType, ChangeFnType, MessageType extends CRDTSyncMessage<ChangesType>, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, MessageType>>(
+export function connectAsync<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>(
   addresses: string[],
-  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, MessageType> = s => s as any
+  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> = s => s as any
 ): ThunkAction<Promise<void>, RootStateType, unknown, ConnectAction> {
   return async (dispatch, getState) => {
     const { node } = selectCollabswarmState(getState());
@@ -62,10 +62,10 @@ export function connect(addresses: string[]): ConnectAction {
 }
 
 
-export function openDocumentAsync<DocType, ChangesType, ChangeFnType, MessageType extends CRDTSyncMessage<ChangesType>, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, MessageType>>(
+export function openDocumentAsync<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>(
   documentId: string,
-  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, MessageType> = s => s as any
-): ThunkAction<Promise<CollabswarmDocument<DocType, ChangesType, ChangeFnType, MessageType> | null>, RootStateType, unknown, OpenDocumentAction<DocType, ChangesType, ChangeFnType, MessageType> | SyncDocumentAction<DocType>> {
+  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> = s => s as any
+): ThunkAction<Promise<CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> | null>, RootStateType, unknown, OpenDocumentAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> | SyncDocumentAction<DocType>> {
   return async (dispatch, getState) => {
     const { node } = selectCollabswarmState(getState());
     if (!node) {
@@ -94,18 +94,18 @@ export function openDocumentAsync<DocType, ChangesType, ChangeFnType, MessageTyp
 }
 
 export const OPEN_DOCUMENT = 'COLLABSWARM_OPEN_DOCUMENT';
-export interface OpenDocumentAction<DocType, ChangesType, ChangeFnType, MessageType extends CRDTSyncMessage<ChangesType>> extends Action<typeof OPEN_DOCUMENT> {
+export interface OpenDocumentAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> extends Action<typeof OPEN_DOCUMENT> {
   documentId: string;
-  documentRef: CollabswarmDocument<DocType, ChangesType, ChangeFnType, MessageType>;
+  documentRef: CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>;
 }
-export function openDocument<DocType, ChangesType, ChangeFnType, MessageType extends CRDTSyncMessage<ChangesType>>(documentId: string, documentRef: CollabswarmDocument<DocType, ChangesType, ChangeFnType, MessageType>): OpenDocumentAction<DocType, ChangesType, ChangeFnType, MessageType> {
+export function openDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>(documentId: string, documentRef: CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>): OpenDocumentAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> {
   return { type: OPEN_DOCUMENT, documentId, documentRef };
 }
 
 
-export function closeDocumentAsync<DocType, ChangesType, ChangeFnType, MessageType extends CRDTSyncMessage<ChangesType>, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, MessageType>>(
+export function closeDocumentAsync<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>(
   documentId: string,
-  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, MessageType> = s => s as any
+  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> = s => s as any
 ): ThunkAction<Promise<void>, RootStateType, unknown, CloseDocumentAction | SyncDocumentAction<DocType>> {
   return async (dispatch, getState) => {
     const { documents } = selectCollabswarmState(getState());
@@ -139,11 +139,11 @@ export function syncDocument<DocType>(documentId: string, document: DocType): Sy
 }
 
 
-export function changeDocumentAsync<DocType, ChangesType, ChangeFnType, MessageType extends CRDTSyncMessage<ChangesType>, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, MessageType>>(
+export function changeDocumentAsync<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey, RootStateType = CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>>(
   documentId: string,
   changeFn: ChangeFnType,
   message?: string,
-  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, MessageType> = s => s as any
+  selectCollabswarmState: (rootState: RootStateType) => CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> = s => s as any
 ): ThunkAction<Promise<DocType>, RootStateType, unknown, ChangeDocumentAction<DocType>> {
   return async (dispatch, getState) => {
     const { documents } = selectCollabswarmState(getState());
@@ -187,10 +187,10 @@ export function peerDisconnect(peerAddress: string): PeerDisconnectAction {
 }
 
 
-export type CollabswarmActions<DocType, ChangesType, ChangeFnType, MessageType extends CRDTSyncMessage<ChangesType>> =
-  InitializeAction<DocType, ChangesType, ChangeFnType, MessageType> |
+export type CollabswarmActions<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> =
+  InitializeAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> |
   ConnectAction |
-  OpenDocumentAction<DocType, ChangesType, ChangeFnType, MessageType> |
+  OpenDocumentAction<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> |
   CloseDocumentAction |
   SyncDocumentAction<DocType> |
   ChangeDocumentAction<DocType> |

--- a/packages/collabswarm-redux/src/reducers.ts
+++ b/packages/collabswarm-redux/src/reducers.ts
@@ -1,71 +1,175 @@
-import { CollabswarmActions, CONNECT, OPEN_DOCUMENT, SYNC_DOCUMENT, CHANGE_DOCUMENT, INITIALIZE, CLOSE_DOCUMENT, PEER_CONNECT, PEER_DISCONNECT } from "./actions";
-import { ACLProvider, AuthProvider, ChangesSerializer, Collabswarm, CollabswarmDocument, CRDTProvider, CRDTSyncMessage, KeychainProvider, MessageSerializer } from "@collabswarm/collabswarm";
-
+import {
+  CollabswarmActions,
+  CONNECT,
+  OPEN_DOCUMENT,
+  SYNC_DOCUMENT,
+  CHANGE_DOCUMENT,
+  INITIALIZE,
+  CLOSE_DOCUMENT,
+  PEER_CONNECT,
+  PEER_DISCONNECT,
+} from './actions';
+import {
+  ACLProvider,
+  AuthProvider,
+  ChangesSerializer,
+  Collabswarm,
+  CollabswarmDocument,
+  CRDTProvider,
+  CRDTSyncMessage,
+  KeychainProvider,
+  MessageSerializer,
+} from '@collabswarm/collabswarm';
 
 // user id should be the same as peer id.
 
-export interface CollabswarmDocumentState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> {
-  documentRef: CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>
+export interface CollabswarmDocumentState<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+> {
+  documentRef: CollabswarmDocument<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >;
   document: DocType;
 
   // TODO: Add peers list.
 }
 
-export interface CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> {
-  node: Collabswarm<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>;
-  documents: { [documentPath: string]: CollabswarmDocumentState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> };
-  peers: string[];
-}
-
-export function initialState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>(
-  provider: CRDTProvider<DocType, ChangesType, ChangeFnType>,
-  changesSerializer: ChangesSerializer<ChangesType>,
-  messageSerializer: MessageSerializer<ChangesType>,
-  authProvider: AuthProvider<
+export interface CollabswarmState<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+> {
+  node: Collabswarm<
+    DocType,
+    ChangesType,
+    ChangeFnType,
     PrivateKey,
     PublicKey,
     DocumentKey
-  >,
+  >;
+  documents: {
+    [documentPath: string]: CollabswarmDocumentState<
+      DocType,
+      ChangesType,
+      ChangeFnType,
+      PrivateKey,
+      PublicKey,
+      DocumentKey
+    >;
+  };
+  peers: string[];
+}
+
+export function initialState<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+>(
+  provider: CRDTProvider<DocType, ChangesType, ChangeFnType>,
+  changesSerializer: ChangesSerializer<ChangesType>,
+  messageSerializer: MessageSerializer<ChangesType>,
+  authProvider: AuthProvider<PrivateKey, PublicKey, DocumentKey>,
   aclProvider: ACLProvider<ChangesType, PublicKey>,
   keychainProvider: KeychainProvider<ChangesType, DocumentKey>,
-): CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> {
+): CollabswarmState<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+> {
   return {
-    node: new Collabswarm(provider, changesSerializer, messageSerializer, authProvider, aclProvider, keychainProvider),
+    node: new Collabswarm(
+      provider,
+      changesSerializer,
+      messageSerializer,
+      authProvider,
+      aclProvider,
+      keychainProvider,
+    ),
     documents: {},
-    peers: []
+    peers: [],
   };
 }
 
 // export function automergeSwarmReducer<T>(state: AutomergeSwarmState<T> = initialState, action: AutomergeSwarmActions): AutomergeSwarmState<T> {
-export function collabswarmReducer<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>(
+export function collabswarmReducer<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+>(
   provider: CRDTProvider<DocType, ChangesType, ChangeFnType>,
   changesSerializer: ChangesSerializer<ChangesType>,
   messageSerializer: MessageSerializer<ChangesType>,
-  authProvider: AuthProvider<
-    PrivateKey,
-    PublicKey,
-    DocumentKey
-  >,
+  authProvider: AuthProvider<PrivateKey, PublicKey, DocumentKey>,
   aclProvider: ACLProvider<ChangesType, PublicKey>,
   keychainProvider: KeychainProvider<ChangesType, DocumentKey>,
 ) {
   return (
-    state: CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> = initialState(provider, changesSerializer, messageSerializer, authProvider, aclProvider, keychainProvider),
-    action: CollabswarmActions<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>,
-  ): CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> => {
+    state: CollabswarmState<
+      DocType,
+      ChangesType,
+      ChangeFnType,
+      PrivateKey,
+      PublicKey,
+      DocumentKey
+    > = initialState(
+      provider,
+      changesSerializer,
+      messageSerializer,
+      authProvider,
+      aclProvider,
+      keychainProvider,
+    ),
+    action: CollabswarmActions<
+      DocType,
+      ChangesType,
+      ChangeFnType,
+      PrivateKey,
+      PublicKey,
+      DocumentKey
+    >,
+  ): CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  > => {
     switch (action.type) {
       // Initialization
       case INITIALIZE: {
         // Changes happen within the node, force a change to redux by creating a new object.
         return {
-          ...state
+          ...state,
         };
       }
       // Connection
       case CONNECT: {
         // Changes happen within the node, force a change to redux by creating a new object.
         return {
-          ...state
+          ...state,
         };
       }
       // Open Document (two options: 1. Overwrite the "current" document, 2. ???)
@@ -79,17 +183,20 @@ export function collabswarmReducer<DocType, ChangesType, ChangeFnType, PrivateKe
         const documents = { ...state.documents };
         documents[action.documentId] = {
           documentRef: action.documentRef,
-          document: action.documentRef.document
-        }
+          document: action.documentRef.document,
+        };
 
         return {
           ...state,
-          documents
+          documents,
         };
       }
       case CLOSE_DOCUMENT: {
         if (!state.documents[action.documentId]) {
-          console.warn('Trying to close a document that is not currently open:', action.documentId);
+          console.warn(
+            'Trying to close a document that is not currently open:',
+            action.documentId,
+          );
           console.warn('Action:', action);
           console.warn('State:', state);
           return state;
@@ -100,14 +207,18 @@ export function collabswarmReducer<DocType, ChangesType, ChangeFnType, PrivateKe
 
         return {
           ...state,
-          documents
+          documents,
         };
       }
       // Document Sync
       case CHANGE_DOCUMENT:
       case SYNC_DOCUMENT: {
         if (!state.documents[action.documentId]) {
-          console.warn('Trying to sync document that is not open', action, state);
+          console.warn(
+            'Trying to sync document that is not open',
+            action,
+            state,
+          );
           return state;
         }
         const documents = { ...state.documents };
@@ -116,7 +227,7 @@ export function collabswarmReducer<DocType, ChangesType, ChangeFnType, PrivateKe
         documents[action.documentId] = documentState;
         return {
           ...state,
-          documents
+          documents,
         };
       }
       case PEER_CONNECT: {
@@ -128,17 +239,17 @@ export function collabswarmReducer<DocType, ChangesType, ChangeFnType, PrivateKe
         const peers = [...currentPeers];
         return {
           ...state,
-          peers
+          peers,
         };
       }
       case PEER_DISCONNECT: {
-        const peers = state.peers.filter(addr => addr !== action.peerAddress);
+        const peers = state.peers.filter((addr) => addr !== action.peerAddress);
         if (state.peers.length === peers.length) {
           return state;
         }
         return {
           ...state,
-          peers
+          peers,
         };
       }
       default: {
@@ -147,5 +258,5 @@ export function collabswarmReducer<DocType, ChangesType, ChangeFnType, PrivateKe
         return state;
       }
     }
-  }
+  };
 }

--- a/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
+++ b/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
-import { CollabswarmNode } from '@collabswarm/collabswarm';
+import { CollabswarmNode, SubtleCrypto } from '@collabswarm/collabswarm';
 import { YjsJSONSerializer, YjsProvider } from '../src';
 
 console.log('Creating a new swarm node...');
 const crdt = new YjsProvider();
 const serializer = new YjsJSONSerializer();
-const swarmNode = new CollabswarmNode(crdt, serializer, serializer);
+const auth = new SubtleCrypto();
+const swarmNode = new CollabswarmNode(crdt, serializer, serializer, auth);
 console.log('Starting node...');
 swarmNode.start();

--- a/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
+++ b/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 
-import { CollabswarmNode, CryptoKeySerializer, SubtleCrypto } from '@collabswarm/collabswarm';
+import { CollabswarmNode, SubtleCrypto } from '@collabswarm/collabswarm';
 import { YjsJSONSerializer, YjsProvider } from '../src';
 
 console.log('Creating a new swarm node...');
 const crdt = new YjsProvider();
 const serializer = new YjsJSONSerializer();
 const auth = new SubtleCrypto();
-const keySerializer = new CryptoKeySerializer({ name: "AES-GCM" }, ["encrypt", "decrypt"]);
-const swarmNode = new CollabswarmNode(crdt, serializer, serializer, auth, keySerializer);
+const swarmNode = new CollabswarmNode(crdt, serializer, serializer, auth);
 console.log('Starting node...');
 swarmNode.start();

--- a/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
+++ b/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
-import { CollabswarmNode, SubtleCrypto } from '@collabswarm/collabswarm';
+import { CollabswarmNode, CryptoKeySerializer, SubtleCrypto } from '@collabswarm/collabswarm';
 import { YjsJSONSerializer, YjsProvider } from '../src';
 
 console.log('Creating a new swarm node...');
 const crdt = new YjsProvider();
 const serializer = new YjsJSONSerializer();
 const auth = new SubtleCrypto();
-const swarmNode = new CollabswarmNode(crdt, serializer, serializer, auth);
+const keySerializer = new CryptoKeySerializer({ name: "AES-GCM" }, ["encrypt", "decrypt"]);
+const swarmNode = new CollabswarmNode(crdt, serializer, serializer, auth, keySerializer);
 console.log('Starting node...');
 swarmNode.start();

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -20,7 +20,6 @@ import {
 
 export type YjsSwarmDocumentChangeHandler = CollabswarmDocumentChangeHandler<Doc>;
 
-
 // export type YjsSwarmDocument = CollabswarmDocument<Doc, Uint8Array, (doc: Doc) => void, YjsSwarmSyncMessage>;
 
 export class YjsProvider

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -20,7 +20,6 @@ import {
 
 export type YjsSwarmDocumentChangeHandler = CollabswarmDocumentChangeHandler<Doc>;
 
-// export type YjsSwarmDocument = CollabswarmDocument<Doc, Uint8Array, (doc: Doc) => void, YjsSwarmSyncMessage>;
 
 export class YjsProvider
   implements CRDTProvider<Doc, Uint8Array, (doc: Doc) => void> {

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -4,18 +4,13 @@ import { applyUpdateV2, Doc, encodeStateAsUpdateV2 } from "yjs";
 
 export type YjsSwarmDocumentChangeHandler = CollabswarmDocumentChangeHandler<Doc>;
 
-export type YjsSwarm = Collabswarm<Doc, Uint8Array, (doc: Doc) => void, YjsSwarmSyncMessage>;
+// export type YjsSwarm = Collabswarm<Doc, Uint8Array, (doc: Doc) => void, YjsSwarmSyncMessage>;
 
-export type YjsSwarmDocument = CollabswarmDocument<Doc, Uint8Array, (doc: Doc) => void, YjsSwarmSyncMessage>;
+// export type YjsSwarmDocument = CollabswarmDocument<Doc, Uint8Array, (doc: Doc) => void, YjsSwarmSyncMessage>;
 
-export interface YjsSwarmSyncMessage extends CRDTSyncMessage<Uint8Array> {}
-
-export class YjsProvider implements CRDTProvider<Doc, Uint8Array, (doc: Doc) => void, YjsSwarmSyncMessage> {
+export class YjsProvider implements CRDTProvider<Doc, Uint8Array, (doc: Doc) => void> {
   newDocument(): Doc {
     return new Doc();
-  }
-  newMessage(documentId: string): YjsSwarmSyncMessage {
-    return { documentId, changes: { } };
   }
   localChange(document: Doc, message: string, changeFn: (doc: Doc) => void): [Doc, Uint8Array] {
     // TODO: This might send the whole document state. Trim this down to only changes not sent yet.
@@ -36,4 +31,4 @@ export class YjsProvider implements CRDTProvider<Doc, Uint8Array, (doc: Doc) => 
   }
 }
 
-export class YjsJSONSerializer extends JSONSerializer<Uint8Array, YjsSwarmSyncMessage> {}
+export class YjsJSONSerializer extends JSONSerializer<Uint8Array> { }

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -20,7 +20,6 @@ import {
 
 export type YjsSwarmDocumentChangeHandler = CollabswarmDocumentChangeHandler<Doc>;
 
-
 export class YjsProvider
   implements CRDTProvider<Doc, Uint8Array, (doc: Doc) => void> {
   newDocument(): Doc {

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -1,6 +1,22 @@
-import { ACL, ACLProvider, Collabswarm, CollabswarmDocument, CollabswarmDocumentChangeHandler, CRDTProvider, CRDTSyncMessage, JSONSerializer, Keychain, KeychainProvider } from "@collabswarm/collabswarm";
-import { applyUpdateV2, Doc, Map as YMap, Array as YArray, encodeStateAsUpdateV2 } from "yjs";
-
+import {
+  ACL,
+  ACLProvider,
+  Collabswarm,
+  CollabswarmDocument,
+  CollabswarmDocumentChangeHandler,
+  CRDTProvider,
+  CRDTSyncMessage,
+  JSONSerializer,
+  Keychain,
+  KeychainProvider,
+} from '@collabswarm/collabswarm';
+import {
+  applyUpdateV2,
+  Doc,
+  Map as YMap,
+  Array as YArray,
+  encodeStateAsUpdateV2,
+} from 'yjs';
 
 export type YjsSwarmDocumentChangeHandler = CollabswarmDocumentChangeHandler<Doc>;
 
@@ -8,11 +24,16 @@ export type YjsSwarmDocumentChangeHandler = CollabswarmDocumentChangeHandler<Doc
 
 // export type YjsSwarmDocument = CollabswarmDocument<Doc, Uint8Array, (doc: Doc) => void, YjsSwarmSyncMessage>;
 
-export class YjsProvider implements CRDTProvider<Doc, Uint8Array, (doc: Doc) => void> {
+export class YjsProvider
+  implements CRDTProvider<Doc, Uint8Array, (doc: Doc) => void> {
   newDocument(): Doc {
     return new Doc();
   }
-  localChange(document: Doc, message: string, changeFn: (doc: Doc) => void): [Doc, Uint8Array] {
+  localChange(
+    document: Doc,
+    message: string,
+    changeFn: (doc: Doc) => void,
+  ): [Doc, Uint8Array] {
     changeFn(document);
 
     // TODO: This might send the whole document state. Trim this down to only changes not sent yet.
@@ -34,7 +55,7 @@ export class YjsProvider implements CRDTProvider<Doc, Uint8Array, (doc: Doc) => 
 }
 
 export async function hashKey(publicKey: CryptoKey): Promise<string> {
-  const buf = await crypto.subtle.exportKey("raw", publicKey);
+  const buf = await crypto.subtle.exportKey('raw', publicKey);
   let binary = '';
   let bytes = new Uint8Array(buf);
   for (let i = 0; i < bytes.byteLength; i++) {
@@ -49,9 +70,9 @@ export async function unhashKey(publicKey: string): Promise<CryptoKey> {
   for (let i = 0; i < binaryString.length; i++) {
     bytes[i] = binaryString.charCodeAt(i);
   }
-  return await crypto.subtle.importKey("raw", bytes, "AES-GCM", true, [
-    "encrypt",
-    "decrypt",
+  return await crypto.subtle.importKey('raw', bytes, 'AES-GCM', true, [
+    'encrypt',
+    'decrypt',
   ]);
 }
 
@@ -66,15 +87,15 @@ export class YjsACL implements ACL<Uint8Array, CryptoKey> {
 
   async add(publicKey: CryptoKey): Promise<Uint8Array> {
     const hash = await hashKey(publicKey);
-    this._acl.getMap("users").set(hash, true);
+    this._acl.getMap('users').set(hash, true);
     // TODO: This might send the whole document state. Trim this down to only changes not sent yet.
     const aclChanges = encodeStateAsUpdateV2(this._acl);
     return aclChanges;
   }
   async remove(publicKey: CryptoKey): Promise<Uint8Array> {
     const hash = await hashKey(publicKey);
-    if (this._acl.getMap("users").has(hash)) {
-      this._acl.getMap("users").delete(hash);
+    if (this._acl.getMap('users').has(hash)) {
+      this._acl.getMap('users').delete(hash);
     }
     // TODO: This might send the whole document state. Trim this down to only changes not sent yet.
     const aclChanges = encodeStateAsUpdateV2(this._acl);
@@ -88,7 +109,7 @@ export class YjsACL implements ACL<Uint8Array, CryptoKey> {
   }
   async check(publicKey: CryptoKey): Promise<boolean> {
     const hash = await hashKey(publicKey);
-    return this._acl.getMap("users").has(hash);
+    return this._acl.getMap('users').has(hash);
   }
 }
 
@@ -100,7 +121,7 @@ export class YjsKeychain implements Keychain<Uint8Array, CryptoKey> {
   async add(key: CryptoKey): Promise<Uint8Array> {
     const hash = await hashKey(key);
     this._keyCache.set(hash, key);
-    this._keychain.getArray<string>("keys").push([hash]);
+    this._keychain.getArray<string>('keys').push([hash]);
     // TODO: This might send the whole document state. Trim this down to only changes not sent yet.
     const keychainChanges = encodeStateAsUpdateV2(this._keychain);
     return keychainChanges;
@@ -112,30 +133,33 @@ export class YjsKeychain implements Keychain<Uint8Array, CryptoKey> {
     applyUpdateV2(this._keychain, change);
   }
   async keys(): Promise<CryptoKey[]> {
-    const yarr = this._keychain.getArray<string>("keys");
+    const yarr = this._keychain.getArray<string>('keys');
     const promises: Promise<CryptoKey>[] = [];
     for (let i = 0; i < yarr.length; i++) {
       const hash = yarr.get(i);
-      promises.push((async () => {
-        let key: CryptoKey | undefined = undefined;
-        if (this._keyCache.has(hash)) {
-          key = this._keyCache.get(hash);
-        }
-        if (!key) {
-          key = await unhashKey(hash);
-        }
-        return key;
-      })());
+      promises.push(
+        (async () => {
+          let key: CryptoKey | undefined = undefined;
+          if (this._keyCache.has(hash)) {
+            key = this._keyCache.get(hash);
+          }
+          if (!key) {
+            key = await unhashKey(hash);
+          }
+          return key;
+        })(),
+      );
     }
 
     return await Promise.all(promises);
   }
 }
 
-export class YjsKeychainProvider implements KeychainProvider<Uint8Array, CryptoKey> {
+export class YjsKeychainProvider
+  implements KeychainProvider<Uint8Array, CryptoKey> {
   initialize(): YjsKeychain {
     return new YjsKeychain();
   }
 }
 
-export class YjsJSONSerializer extends JSONSerializer<Uint8Array> { }
+export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {}

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -20,7 +20,6 @@ import {
 
 export type YjsSwarmDocumentChangeHandler = CollabswarmDocumentChangeHandler<Doc>;
 
-// export type YjsSwarm = Collabswarm<Doc, Uint8Array, (doc: Doc) => void, YjsSwarmSyncMessage>;
 
 // export type YjsSwarmDocument = CollabswarmDocument<Doc, Uint8Array, (doc: Doc) => void, YjsSwarmSyncMessage>;
 

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -1,5 +1,5 @@
-import { Collabswarm, CollabswarmDocument, CollabswarmDocumentChangeHandler, CRDTProvider, CRDTSyncMessage, JSONSerializer } from "@collabswarm/collabswarm";
-import { applyUpdateV2, Doc, encodeStateAsUpdateV2 } from "yjs";
+import { ACL, ACLProvider, Collabswarm, CollabswarmDocument, CollabswarmDocumentChangeHandler, CRDTProvider, CRDTSyncMessage, JSONSerializer, Keychain, KeychainProvider } from "@collabswarm/collabswarm";
+import { applyUpdateV2, Doc, Map as YMap, Array as YArray, encodeStateAsUpdateV2 } from "yjs";
 
 
 export type YjsSwarmDocumentChangeHandler = CollabswarmDocumentChangeHandler<Doc>;
@@ -13,6 +13,8 @@ export class YjsProvider implements CRDTProvider<Doc, Uint8Array, (doc: Doc) => 
     return new Doc();
   }
   localChange(document: Doc, message: string, changeFn: (doc: Doc) => void): [Doc, Uint8Array] {
+    changeFn(document);
+
     // TODO: This might send the whole document state. Trim this down to only changes not sent yet.
     const changes = encodeStateAsUpdateV2(document);
 
@@ -28,6 +30,111 @@ export class YjsProvider implements CRDTProvider<Doc, Uint8Array, (doc: Doc) => 
   getHistory(document: Doc): Uint8Array {
     // TODO: This might send the whole document state. Trim this down to only changes not sent yet.
     return encodeStateAsUpdateV2(document);
+  }
+}
+
+export async function hashKey(publicKey: CryptoKey): Promise<string> {
+  const buf = await crypto.subtle.exportKey("raw", publicKey);
+  let binary = '';
+  let bytes = new Uint8Array(buf);
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return window.btoa(binary);
+}
+
+export async function unhashKey(publicKey: string): Promise<CryptoKey> {
+  let binaryString = window.atob(publicKey);
+  let bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return await crypto.subtle.importKey("raw", bytes, "AES-GCM", true, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+export class YjsACLProvider implements ACLProvider<Uint8Array, CryptoKey> {
+  initialize(): ACL<Uint8Array, CryptoKey> {
+    return new YjsACL();
+  }
+}
+
+export class YjsACL implements ACL<Uint8Array, CryptoKey> {
+  private readonly _acl = new Doc();
+
+  async add(publicKey: CryptoKey): Promise<Uint8Array> {
+    const hash = await hashKey(publicKey);
+    this._acl.getMap("users").set(hash, true);
+    // TODO: This might send the whole document state. Trim this down to only changes not sent yet.
+    const aclChanges = encodeStateAsUpdateV2(this._acl);
+    return aclChanges;
+  }
+  async remove(publicKey: CryptoKey): Promise<Uint8Array> {
+    const hash = await hashKey(publicKey);
+    if (this._acl.getMap("users").has(hash)) {
+      this._acl.getMap("users").delete(hash);
+    }
+    // TODO: This might send the whole document state. Trim this down to only changes not sent yet.
+    const aclChanges = encodeStateAsUpdateV2(this._acl);
+    return aclChanges;
+  }
+  current(): Uint8Array {
+    return encodeStateAsUpdateV2(this._acl);
+  }
+  merge(change: Uint8Array): void {
+    applyUpdateV2(this._acl, change);
+  }
+  async check(publicKey: CryptoKey): Promise<boolean> {
+    const hash = await hashKey(publicKey);
+    return this._acl.getMap("users").has(hash);
+  }
+}
+
+export class YjsKeychain implements Keychain<Uint8Array, CryptoKey> {
+  // TODO: Replace this with a LRU cache of bounded size.
+  private readonly _keyCache = new Map<string, CryptoKey>();
+  private readonly _keychain = new Doc();
+
+  async add(key: CryptoKey): Promise<Uint8Array> {
+    const hash = await hashKey(key);
+    this._keyCache.set(hash, key);
+    this._keychain.getArray<string>("keys").push([hash]);
+    // TODO: This might send the whole document state. Trim this down to only changes not sent yet.
+    const keychainChanges = encodeStateAsUpdateV2(this._keychain);
+    return keychainChanges;
+  }
+  history(): Uint8Array {
+    return encodeStateAsUpdateV2(this._keychain);
+  }
+  merge(change: Uint8Array): void {
+    applyUpdateV2(this._keychain, change);
+  }
+  async keys(): Promise<CryptoKey[]> {
+    const yarr = this._keychain.getArray<string>("keys");
+    const promises: Promise<CryptoKey>[] = [];
+    for (let i = 0; i < yarr.length; i++) {
+      const hash = yarr.get(i);
+      promises.push((async () => {
+        let key: CryptoKey | undefined = undefined;
+        if (this._keyCache.has(hash)) {
+          key = this._keyCache.get(hash);
+        }
+        if (!key) {
+          key = await unhashKey(hash);
+        }
+        return key;
+      })());
+    }
+
+    return await Promise.all(promises);
+  }
+}
+
+export class YjsKeychainProvider implements KeychainProvider<Uint8Array, CryptoKey> {
+  initialize(): YjsKeychain {
+    return new YjsKeychain();
   }
 }
 

--- a/packages/collabswarm-yjs/src/index.ts
+++ b/packages/collabswarm-yjs/src/index.ts
@@ -1,4 +1,12 @@
-import { YjsSwarmDocumentChangeHandler, YjsProvider, YjsJSONSerializer, YjsACL, YjsACLProvider, YjsKeychain, YjsKeychainProvider } from "./collabswarm-yjs";
+import {
+  YjsSwarmDocumentChangeHandler,
+  YjsProvider,
+  YjsJSONSerializer,
+  YjsACL,
+  YjsACLProvider,
+  YjsKeychain,
+  YjsKeychainProvider,
+} from './collabswarm-yjs';
 
 export {
   YjsSwarmDocumentChangeHandler,

--- a/packages/collabswarm-yjs/src/index.ts
+++ b/packages/collabswarm-yjs/src/index.ts
@@ -1,10 +1,11 @@
-import { YjsSwarm, YjsSwarmDocument, YjsSwarmSyncMessage, YjsSwarmDocumentChangeHandler, YjsProvider, YjsJSONSerializer } from "./collabswarm-yjs";
+import { YjsSwarmDocumentChangeHandler, YjsProvider, YjsJSONSerializer, YjsACL, YjsACLProvider, YjsKeychain, YjsKeychainProvider } from "./collabswarm-yjs";
 
 export {
-  YjsSwarm,
   YjsSwarmDocumentChangeHandler,
-  YjsSwarmDocument,
-  YjsSwarmSyncMessage,
   YjsProvider,
+  YjsACL,
+  YjsACLProvider,
+  YjsKeychain,
+  YjsKeychainProvider,
   YjsJSONSerializer,
 };

--- a/packages/collabswarm/src/acl-provider.ts
+++ b/packages/collabswarm/src/acl-provider.ts
@@ -1,4 +1,4 @@
-import { ACL } from "./acl";
+import { ACL } from './acl';
 
 export interface ACLProvider<ChangesType, PublicKey> {
   initialize(): ACL<ChangesType, PublicKey>;

--- a/packages/collabswarm/src/acl-provider.ts
+++ b/packages/collabswarm/src/acl-provider.ts
@@ -1,0 +1,5 @@
+import { ACL } from "./acl";
+
+export interface ACLProvider<ChangesType, PublicKey> {
+  initialize(): ACL<ChangesType, PublicKey>;
+}

--- a/packages/collabswarm/src/acl.ts
+++ b/packages/collabswarm/src/acl.ts
@@ -1,0 +1,7 @@
+export interface ACL<ChangesType, PublicKey> {
+  add(publicKey: PublicKey): Promise<ChangesType>;
+  remove(publicKey: PublicKey): Promise<ChangesType>;
+  current(): ChangesType;
+  merge(change: ChangesType): void;
+  check(publicKey: PublicKey): Promise<boolean>;
+}

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -12,7 +12,8 @@ import { CRDTProvider } from './crdt-provider';
 import { MessageSerializer } from './message-serializer';
 import { ChangesSerializer } from './changes-serializer';
 import { AuthProvider } from './auth-provider';
-import { KeySerializer } from './key-serializer';
+import { ACLProvider } from './acl-provider';
+import { KeychainProvider } from './keychain-provider';
 
 export const DEFAULT_NODE_CONFIG: CollabswarmConfig = {
   ipfs: {
@@ -51,7 +52,8 @@ export class CollabswarmNode<
     this.changesSerializer,
     this.messageSerializer,
     this.authProvider,
-    this.documentKeySerializer,
+    this.aclProvider,
+    this.keychainProvider,
   );
   public get swarm(): Collabswarm<
     DocType,
@@ -85,7 +87,8 @@ export class CollabswarmNode<
       PublicKey,
       DocumentKey
     >,
-    public readonly documentKeySerializer: KeySerializer<DocumentKey>,
+    private readonly aclProvider: ACLProvider<ChangesType, PublicKey>,
+    private readonly keychainProvider: KeychainProvider<ChangesType, DocumentKey>,
     public readonly config: CollabswarmConfig = DEFAULT_NODE_CONFIG,
   ) { }
 
@@ -132,7 +135,6 @@ export class CollabswarmNode<
         if (thisNodeId !== senderNodeId) {
           const message = this.messageSerializer.deserializeMessage(
             rawMessage.data,
-            this.documentKeySerializer,
           );
           console.log('Received Document Publish message:', rawMessage);
           const docRef = this.swarm.doc(message.documentId);

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -6,13 +6,13 @@ import {
   CollabswarmConfig,
   DEFAULT_CONFIG,
 } from './collabswarm-config';
-import { CRDTSyncMessage } from './crdt-sync-message';
 import { Collabswarm } from './collabswarm';
 import { CollabswarmDocument } from './collabswarm-document';
 import { CRDTProvider } from './crdt-provider';
 import { MessageSerializer } from './message-serializer';
 import { ChangesSerializer } from './changes-serializer';
 import { AuthProvider } from './auth-provider';
+import { KeySerializer } from './key-serializer';
 
 export const DEFAULT_NODE_CONFIG: CollabswarmConfig = {
   ipfs: {
@@ -51,6 +51,7 @@ export class CollabswarmNode<
     this.changesSerializer,
     this.messageSerializer,
     this.authProvider,
+    this.documentKeySerializer,
   );
   public get swarm(): Collabswarm<
     DocType,
@@ -84,6 +85,7 @@ export class CollabswarmNode<
       PublicKey,
       DocumentKey
     >,
+    public readonly documentKeySerializer: KeySerializer<DocumentKey>,
     public readonly config: CollabswarmConfig = DEFAULT_NODE_CONFIG,
   ) { }
 
@@ -130,6 +132,7 @@ export class CollabswarmNode<
         if (thisNodeId !== senderNodeId) {
           const message = this.messageSerializer.deserializeMessage(
             rawMessage.data,
+            this.documentKeySerializer,
           );
           console.log('Received Document Publish message:', rawMessage);
           const docRef = this.swarm.doc(message.documentId);

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -46,7 +46,7 @@ export class CollabswarmNode<
   PrivateKey,
   PublicKey,
   DocumentKey
-  > {
+> {
   private _swarm = new Collabswarm(
     this.provider,
     this.changesSerializer,
@@ -68,18 +68,21 @@ export class CollabswarmNode<
 
   private readonly _subscriptions = new Map<
     string,
-    CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>
+    CollabswarmDocument<
+      DocType,
+      ChangesType,
+      ChangeFnType,
+      PrivateKey,
+      PublicKey,
+      DocumentKey
+    >
   >();
   private readonly _seenCids = new Set<string>();
 
   private _docPublishHandler: MessageHandlerFn | null = null;
 
   constructor(
-    public readonly provider: CRDTProvider<
-      DocType,
-      ChangesType,
-      ChangeFnType
-    >,
+    public readonly provider: CRDTProvider<DocType, ChangesType, ChangeFnType>,
     public readonly changesSerializer: ChangesSerializer<ChangesType>,
     public readonly messageSerializer: MessageSerializer<ChangesType>,
     public readonly authProvider: AuthProvider<
@@ -88,9 +91,12 @@ export class CollabswarmNode<
       DocumentKey
     >,
     private readonly aclProvider: ACLProvider<ChangesType, PublicKey>,
-    private readonly keychainProvider: KeychainProvider<ChangesType, DocumentKey>,
+    private readonly keychainProvider: KeychainProvider<
+      ChangesType,
+      DocumentKey
+    >,
     public readonly config: CollabswarmConfig = DEFAULT_NODE_CONFIG,
-  ) { }
+  ) {}
 
   // Start
   public async start() {

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -12,6 +12,7 @@ import { CollabswarmDocument } from './collabswarm-document';
 import { CRDTProvider } from './crdt-provider';
 import { MessageSerializer } from './message-serializer';
 import { ChangesSerializer } from './changes-serializer';
+import { AuthProvider } from './auth-provider';
 
 export const DEFAULT_NODE_CONFIG: CollabswarmConfig = {
   ipfs: {
@@ -41,25 +42,30 @@ export class CollabswarmNode<
   DocType,
   ChangesType,
   ChangeFnType,
-  MessageType extends CRDTSyncMessage<ChangesType>
-> {
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+  > {
   private _swarm = new Collabswarm(
     this.provider,
     this.changesSerializer,
     this.messageSerializer,
+    this.authProvider,
   );
   public get swarm(): Collabswarm<
     DocType,
     ChangesType,
     ChangeFnType,
-    MessageType
+    PrivateKey,
+    PublicKey,
+    DocumentKey
   > {
     return this._swarm;
   }
 
   private readonly _subscriptions = new Map<
     string,
-    CollabswarmDocument<DocType, ChangesType, ChangeFnType, MessageType>
+    CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>
   >();
   private readonly _seenCids = new Set<string>();
 
@@ -69,13 +75,17 @@ export class CollabswarmNode<
     public readonly provider: CRDTProvider<
       DocType,
       ChangesType,
-      ChangeFnType,
-      MessageType
+      ChangeFnType
     >,
     public readonly changesSerializer: ChangesSerializer<ChangesType>,
-    public readonly messageSerializer: MessageSerializer<MessageType>,
+    public readonly messageSerializer: MessageSerializer<ChangesType>,
+    public readonly authProvider: AuthProvider<
+      PrivateKey,
+      PublicKey,
+      DocumentKey
+    >,
     public readonly config: CollabswarmConfig = DEFAULT_NODE_CONFIG,
-  ) {}
+  ) { }
 
   // Start
   public async start() {

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -19,6 +19,7 @@ import { IDResult } from 'ipfs-core-types/src/root';
 import { CollabswarmDocument } from './collabswarm-document';
 import { MessageSerializer } from './message-serializer';
 import { ChangesSerializer } from './changes-serializer';
+import { KeySerializer } from './key-serializer';
 
 /**
  * Handler type for peer-connect and peer-disconnect events.
@@ -75,6 +76,7 @@ export class Collabswarm<
       PublicKey,
       DocumentKey
     >,
+    private readonly _documentKeySerializer: KeySerializer<DocumentKey>,
   ) { }
 
   // configs for the swarm, thus passing its config to all documents opened in a swarm
@@ -212,6 +214,7 @@ export class Collabswarm<
       this._authProvider,
       this._changesSerializer,
       this._messageSerializer,
+      this._documentKeySerializer,
     );
   }
 

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -14,7 +14,6 @@ import IPFS from 'ipfs';
 import Libp2p from 'libp2p';
 import { AuthProvider } from './auth-provider';
 import { CRDTProvider } from './crdt-provider';
-import { CRDTSyncMessage } from './crdt-sync-message';
 import { CollabswarmConfig, DEFAULT_CONFIG } from './collabswarm-config';
 import { IDResult } from 'ipfs-core-types/src/root';
 import { CollabswarmDocument } from './collabswarm-document';
@@ -54,32 +53,29 @@ export type CollabswarmPeersHandler = (
  * @tparam DocType The CRDT document type
  * @tparam ChangesType A block of CRDT change(s)
  * @tparam ChangeFnType A function for applying changes to a document
- * @tparam MessageType The sync message that gets sent when changes are made to a document
  */
 export class Collabswarm<
   DocType,
   ChangesType,
   ChangeFnType,
-  MessageType extends CRDTSyncMessage<ChangesType>,
   PrivateKey, // TODO (eric) if it's here it's not per document?
   PublicKey,
   DocumentKey
-> {
+  > {
   constructor(
     private readonly _crdtProvider: CRDTProvider<
       DocType,
       ChangesType,
-      ChangeFnType,
-      MessageType
+      ChangeFnType
     >,
     private readonly _changesSerializer: ChangesSerializer<ChangesType>,
-    private readonly _messageSerializer: MessageSerializer<MessageType>,
+    private readonly _messageSerializer: MessageSerializer<ChangesType>,
     private readonly _authProvider: AuthProvider<
       PrivateKey,
       PublicKey,
       DocumentKey
     >,
-  ) {}
+  ) { }
 
   // configs for the swarm, thus passing its config to all documents opened in a swarm
   protected _config: CollabswarmConfig | null = null;
@@ -204,7 +200,6 @@ export class Collabswarm<
     DocType,
     ChangesType,
     ChangeFnType,
-    MessageType,
     PrivateKey,
     PublicKey,
     DocumentKey

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -19,7 +19,8 @@ import { IDResult } from 'ipfs-core-types/src/root';
 import { CollabswarmDocument } from './collabswarm-document';
 import { MessageSerializer } from './message-serializer';
 import { ChangesSerializer } from './changes-serializer';
-import { KeySerializer } from './key-serializer';
+import { ACLProvider } from './acl-provider';
+import { KeychainProvider } from './keychain-provider';
 
 /**
  * Handler type for peer-connect and peer-disconnect events.
@@ -76,7 +77,8 @@ export class Collabswarm<
       PublicKey,
       DocumentKey
     >,
-    private readonly _documentKeySerializer: KeySerializer<DocumentKey>,
+    private readonly _aclProvider: ACLProvider<ChangesType, PublicKey>,
+    private readonly _keychainProvider: KeychainProvider<ChangesType, DocumentKey>,
   ) { }
 
   // configs for the swarm, thus passing its config to all documents opened in a swarm
@@ -196,7 +198,7 @@ export class Collabswarm<
    * @param documentPath Path identifying the document to open.
    * @returns The requested collabswarm document.
    */
-  doc<T = any>(
+  doc(
     documentPath: string,
   ): CollabswarmDocument<
     DocType,
@@ -212,9 +214,10 @@ export class Collabswarm<
       documentPath,
       this._crdtProvider,
       this._authProvider,
+      this._aclProvider,
+      this._keychainProvider,
       this._changesSerializer,
       this._messageSerializer,
-      this._documentKeySerializer,
     );
   }
 

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -63,7 +63,7 @@ export class Collabswarm<
   PrivateKey, // TODO (eric) if it's here it's not per document?
   PublicKey,
   DocumentKey
-  > {
+> {
   constructor(
     private readonly _crdtProvider: CRDTProvider<
       DocType,
@@ -78,8 +78,11 @@ export class Collabswarm<
       DocumentKey
     >,
     private readonly _aclProvider: ACLProvider<ChangesType, PublicKey>,
-    private readonly _keychainProvider: KeychainProvider<ChangesType, DocumentKey>,
-  ) { }
+    private readonly _keychainProvider: KeychainProvider<
+      ChangesType,
+      DocumentKey
+    >,
+  ) {}
 
   // configs for the swarm, thus passing its config to all documents opened in a swarm
   protected _config: CollabswarmConfig | null = null;

--- a/packages/collabswarm/src/crdt-provider.ts
+++ b/packages/collabswarm/src/crdt-provider.ts
@@ -12,11 +12,7 @@ import { CRDTSyncMessage } from './crdt-sync-message';
  * @tparam ChangeFnType A function for applying changes to a document
  * @tparam MessageType The sync message that gets sent when changes are made to a document
  */
-export interface CRDTProvider<
-  DocType,
-  ChangesType,
-  ChangeFnType,
-  > {
+export interface CRDTProvider<DocType, ChangesType, ChangeFnType> {
   /**
    * Create a new empty (contains the equivalent of `{}`) CRDT document.
    */

--- a/packages/collabswarm/src/crdt-provider.ts
+++ b/packages/collabswarm/src/crdt-provider.ts
@@ -16,20 +16,11 @@ export interface CRDTProvider<
   DocType,
   ChangesType,
   ChangeFnType,
-  MessageType extends CRDTSyncMessage<ChangesType>
-> {
+  > {
   /**
    * Create a new empty (contains the equivalent of `{}`) CRDT document.
    */
   newDocument(): DocType;
-
-  /**
-   * Create a new CRDTSyncMessage from the provided document ID. Implementations
-   * should return an implementation-specific sub-interface of CRDTSyncMessage.
-   *
-   * @param documentId ID of the document new sync message is related to.
-   */
-  newMessage(documentId: string): MessageType;
 
   /**
    * Apply locally made changes to provided CRDT document as defined by `changeFn`.

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -2,7 +2,7 @@
  * CRDTSyncMessage is the message sent over both IPFS pubsub topics and in response to
  * load document requests.
  */
-export type CRDTSyncMessage<ChangesType, DocumentKey> = {
+export type CRDTSyncMessage<ChangesType> = {
   /**
    * ID of a collabswarm document.
    */
@@ -18,9 +18,13 @@ export type CRDTSyncMessage<ChangesType, DocumentKey> = {
    */
   changes: { [hash: string]: ChangesType | null };
 
+  readersChanges?: ChangesType;
+
+  writersChanges?: ChangesType;
+
   /**
    * Optional document keys list. Only populated while loading and receiving a document
    * key update (due to the removal of an ACL reader).
    */
-  keys?: DocumentKey[];
+  keychainChanges?: ChangesType;
 }

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -27,4 +27,4 @@ export type CRDTSyncMessage<ChangesType> = {
    * key update (due to the removal of an ACL reader).
    */
   keychainChanges?: ChangesType;
-}
+};

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -2,7 +2,7 @@
  * CRDTSyncMessage is the message sent over both IPFS pubsub topics and in response to
  * load document requests.
  */
-export type CRDTSyncMessage<ChangesType> = {
+export type CRDTSyncMessage<ChangesType, DocumentKey> = {
   /**
    * ID of a collabswarm document.
    */
@@ -18,11 +18,9 @@ export type CRDTSyncMessage<ChangesType> = {
    */
   changes: { [hash: string]: ChangesType | null };
 
-  // /**
-  //  * Optional document keys list. Only populated while loading and receiving a document
-  //  * key update (due to the removal of an ACL reader).
-  //  * 
-  //  * These are stored as strings currently 
-  //  */
-  // keys?: string[];
+  /**
+   * Optional document keys list. Only populated while loading and receiving a document
+   * key update (due to the removal of an ACL reader).
+   */
+  keys?: DocumentKey[];
 }

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -2,7 +2,7 @@
  * CRDTSyncMessage is the message sent over both IPFS pubsub topics and in response to
  * load document requests.
  */
-export interface CRDTSyncMessage<ChangesType> {
+export type CRDTSyncMessage<ChangesType> = {
   /**
    * ID of a collabswarm document.
    */
@@ -17,4 +17,12 @@ export interface CRDTSyncMessage<ChangesType> {
    * implementation.
    */
   changes: { [hash: string]: ChangesType | null };
+
+  // /**
+  //  * Optional document keys list. Only populated while loading and receiving a document
+  //  * key update (due to the removal of an ACL reader).
+  //  * 
+  //  * These are stored as strings currently 
+  //  */
+  // keys?: string[];
 }

--- a/packages/collabswarm/src/crypto-key-serializer.test.ts
+++ b/packages/collabswarm/src/crypto-key-serializer.test.ts
@@ -1,50 +1,83 @@
-import { describe, expect, test } from "@jest/globals";
-import { CryptoKeySerializer } from "./crypto-key-serializer";
+import { describe, expect, test } from '@jest/globals';
+import { CryptoKeySerializer } from './crypto-key-serializer';
 
-const serializedKey1 = new Uint8Array(
-  [201, 195, 4, 111, 113, 98, 140, 217, 42, 208, 142, 245, 177, 74, 62, 133, 151, 83, 183, 129, 124, 243, 165, 173, 149, 120, 158, 92, 175, 91, 177, 4]
-);
+const serializedKey1 = new Uint8Array([
+  201,
+  195,
+  4,
+  111,
+  113,
+  98,
+  140,
+  217,
+  42,
+  208,
+  142,
+  245,
+  177,
+  74,
+  62,
+  133,
+  151,
+  83,
+  183,
+  129,
+  124,
+  243,
+  165,
+  173,
+  149,
+  120,
+  158,
+  92,
+  175,
+  91,
+  177,
+  4,
+]);
 
 async function importDocumentKey(key: Uint8Array) {
   return await crypto.subtle.importKey(
-    "raw",
+    'raw',
     key,
     {
-      name: "AES-GCM"
+      name: 'AES-GCM',
     },
     true,
-    ["encrypt", "decrypt"]
+    ['encrypt', 'decrypt'],
   );
 }
 
-describe("serialize CryptoKey to Uint8Array", () => {
-  test.each([
-    [serializedKey1],
-  ])(
+describe('serialize CryptoKey to Uint8Array', () => {
+  test.each([[serializedKey1]])(
     `serialize CryptoKey`,
     async (data: Uint8Array) => {
       const testKey = await importDocumentKey(data);
 
-      const cryptoKeySerializer = new CryptoKeySerializer("AES-GCM", ["encrypt", "decrypt"]);
+      const cryptoKeySerializer = new CryptoKeySerializer('AES-GCM', [
+        'encrypt',
+        'decrypt',
+      ]);
       const actual = await cryptoKeySerializer.serializeKey(testKey);
 
       expect(actual).toStrictEqual(data);
-    }
+    },
   );
 });
 
-describe("deserialize CryptoKey to Uint8Array", () => {
-  test.each([
-    [serializedKey1],
-  ])(
+describe('deserialize CryptoKey to Uint8Array', () => {
+  test.each([[serializedKey1]])(
     `deserialize CryptoKey`,
     async (data: Uint8Array) => {
       const testKey = await importDocumentKey(data);
 
-      const cryptoKeySerializer = new CryptoKeySerializer("AES-GCM", ["encrypt", "decrypt"]);
+      const cryptoKeySerializer = new CryptoKeySerializer('AES-GCM', [
+        'encrypt',
+        'decrypt',
+      ]);
       const actual = await cryptoKeySerializer.deserializeKey(data);
 
       expect(actual).toStrictEqual(testKey);
-    }
+    },
   );
 });

--- a/packages/collabswarm/src/crypto-key-serializer.test.ts
+++ b/packages/collabswarm/src/crypto-key-serializer.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "@jest/globals";
+import { CryptoKeySerializer } from "./crypto-key-serializer";
+
+const serializedKey1 = new Uint8Array(
+  [201, 195, 4, 111, 113, 98, 140, 217, 42, 208, 142, 245, 177, 74, 62, 133, 151, 83, 183, 129, 124, 243, 165, 173, 149, 120, 158, 92, 175, 91, 177, 4]
+);
+
+async function importDocumentKey(key: Uint8Array) {
+  return await crypto.subtle.importKey(
+    "raw",
+    key,
+    {
+      name: "AES-GCM"
+    },
+    true,
+    ["encrypt", "decrypt"]
+  );
+}
+
+describe("serialize CryptoKey to Uint8Array", () => {
+  test.each([
+    [serializedKey1],
+  ])(
+    `serialize CryptoKey`,
+    async (data: Uint8Array) => {
+      const testKey = await importDocumentKey(data);
+
+      const cryptoKeySerializer = new CryptoKeySerializer("AES-GCM", ["encrypt", "decrypt"]);
+      const actual = await cryptoKeySerializer.serializeKey(testKey);
+
+      expect(actual).toStrictEqual(data);
+    }
+  );
+});
+
+describe("deserialize CryptoKey to Uint8Array", () => {
+  test.each([
+    [serializedKey1],
+  ])(
+    `deserialize CryptoKey`,
+    async (data: Uint8Array) => {
+      const testKey = await importDocumentKey(data);
+
+      const cryptoKeySerializer = new CryptoKeySerializer("AES-GCM", ["encrypt", "decrypt"]);
+      const actual = await cryptoKeySerializer.deserializeKey(data);
+
+      expect(actual).toStrictEqual(testKey);
+    }
+  );
+});

--- a/packages/collabswarm/src/crypto-key-serializer.ts
+++ b/packages/collabswarm/src/crypto-key-serializer.ts
@@ -1,0 +1,16 @@
+import { KeySerializer } from "./key-serializer";
+
+export class CryptoKeySerializer implements KeySerializer<CryptoKey> {
+  constructor(
+    public readonly algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | DhImportKeyParams | AesKeyAlgorithm,
+    public readonly keyUsages: KeyUsage[],
+  ) { }
+
+  async serializeKey(key: CryptoKey): Promise<Uint8Array> {
+    const buf = await crypto.subtle.exportKey("raw", key);
+    return new Uint8Array(buf);
+  }
+  async deserializeKey(key: Uint8Array): Promise<CryptoKey> {
+    return await crypto.subtle.importKey("raw", key, this.algorithm, true, this.keyUsages);
+  }
+}

--- a/packages/collabswarm/src/crypto-key-serializer.ts
+++ b/packages/collabswarm/src/crypto-key-serializer.ts
@@ -1,16 +1,28 @@
-import { KeySerializer } from "./key-serializer";
+import { KeySerializer } from './key-serializer';
 
 export class CryptoKeySerializer implements KeySerializer<CryptoKey> {
   constructor(
-    public readonly algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | DhImportKeyParams | AesKeyAlgorithm,
+    public readonly algorithm:
+      | AlgorithmIdentifier
+      | RsaHashedImportParams
+      | EcKeyImportParams
+      | HmacImportParams
+      | DhImportKeyParams
+      | AesKeyAlgorithm,
     public readonly keyUsages: KeyUsage[],
-  ) { }
+  ) {}
 
   async serializeKey(key: CryptoKey): Promise<Uint8Array> {
-    const buf = await crypto.subtle.exportKey("raw", key);
+    const buf = await crypto.subtle.exportKey('raw', key);
     return new Uint8Array(buf);
   }
   async deserializeKey(key: Uint8Array): Promise<CryptoKey> {
-    return await crypto.subtle.importKey("raw", key, this.algorithm, true, this.keyUsages);
+    return await crypto.subtle.importKey(
+      'raw',
+      key,
+      this.algorithm,
+      true,
+      this.keyUsages,
+    );
   }
 }

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -1,23 +1,23 @@
-import { Collabswarm, CollabswarmPeersHandler } from "./collabswarm";
-import { CollabswarmConfig, DEFAULT_CONFIG } from "./collabswarm-config";
+import { Collabswarm, CollabswarmPeersHandler } from './collabswarm';
+import { CollabswarmConfig, DEFAULT_CONFIG } from './collabswarm-config';
 import {
   CollabswarmDocument,
   CollabswarmDocumentChangeHandler,
-} from "./collabswarm-document";
-import { CRDTSyncMessage } from "./crdt-sync-message";
-import { CollabswarmNode, DEFAULT_NODE_CONFIG } from "./collabswarm-node";
-import { CRDTProvider } from "./crdt-provider";
-import { MessageSerializer } from "./message-serializer";
-import { ChangesSerializer } from "./changes-serializer";
-import { JSONSerializer } from "./json-serializer";
-import { AuthProvider } from "./auth-provider";
-import { SubtleCrypto } from "./auth-subtlecrypto";
-import { KeySerializer } from "./key-serializer";
-import { CryptoKeySerializer } from "./crypto-key-serializer";
-import { ACLProvider } from "./acl-provider";
-import { KeychainProvider } from "./keychain-provider";
-import { ACL } from "./acl";
-import { Keychain } from "./keychain";
+} from './collabswarm-document';
+import { CRDTSyncMessage } from './crdt-sync-message';
+import { CollabswarmNode, DEFAULT_NODE_CONFIG } from './collabswarm-node';
+import { CRDTProvider } from './crdt-provider';
+import { MessageSerializer } from './message-serializer';
+import { ChangesSerializer } from './changes-serializer';
+import { JSONSerializer } from './json-serializer';
+import { AuthProvider } from './auth-provider';
+import { SubtleCrypto } from './auth-subtlecrypto';
+import { KeySerializer } from './key-serializer';
+import { CryptoKeySerializer } from './crypto-key-serializer';
+import { ACLProvider } from './acl-provider';
+import { KeychainProvider } from './keychain-provider';
+import { ACL } from './acl';
+import { Keychain } from './keychain';
 
 export {
   ACL,

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -10,8 +10,12 @@ import { CRDTProvider } from "./crdt-provider";
 import { MessageSerializer } from "./message-serializer";
 import { ChangesSerializer } from "./changes-serializer";
 import { JSONSerializer } from "./json-serializer";
+import { AuthProvider } from "./auth-provider";
+import { SubtleCrypto } from "./auth-subtlecrypto";
 
 export {
+  AuthProvider,
+  SubtleCrypto,
   Collabswarm,
   CollabswarmPeersHandler,
   CollabswarmConfig,

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -12,6 +12,8 @@ import { ChangesSerializer } from "./changes-serializer";
 import { JSONSerializer } from "./json-serializer";
 import { AuthProvider } from "./auth-provider";
 import { SubtleCrypto } from "./auth-subtlecrypto";
+import { KeySerializer } from "./key-serializer";
+import { CryptoKeySerializer } from "./crypto-key-serializer";
 
 export {
   AuthProvider,
@@ -24,7 +26,9 @@ export {
   CollabswarmNode,
   CRDTSyncMessage,
   CRDTProvider,
+  CryptoKeySerializer,
   ChangesSerializer,
+  KeySerializer,
   MessageSerializer,
   JSONSerializer,
   DEFAULT_CONFIG,

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -14,8 +14,14 @@ import { AuthProvider } from "./auth-provider";
 import { SubtleCrypto } from "./auth-subtlecrypto";
 import { KeySerializer } from "./key-serializer";
 import { CryptoKeySerializer } from "./crypto-key-serializer";
+import { ACLProvider } from "./acl-provider";
+import { KeychainProvider } from "./keychain-provider";
+import { ACL } from "./acl";
+import { Keychain } from "./keychain";
 
 export {
+  ACL,
+  ACLProvider,
   AuthProvider,
   SubtleCrypto,
   Collabswarm,
@@ -29,6 +35,8 @@ export {
   CryptoKeySerializer,
   ChangesSerializer,
   KeySerializer,
+  Keychain,
+  KeychainProvider,
   MessageSerializer,
   JSONSerializer,
   DEFAULT_CONFIG,

--- a/packages/collabswarm/src/json-serializer.test.ts
+++ b/packages/collabswarm/src/json-serializer.test.ts
@@ -1,31 +1,29 @@
-import { expect, test } from "@jest/globals";
-import { JSONSerializer } from "./json-serializer";
+import { expect, test } from '@jest/globals';
+import { JSONSerializer } from './json-serializer';
 
 const jsonSerializer = new JSONSerializer<any>();
 
-let testObject = { key: "val" };
+let testObject = { key: 'val' };
 let testObjectSerialized = '{"key":"val"}';
-let testString = "Hello";
+let testString = 'Hello';
 let testStringAsUint8Array = Uint8Array.from([72, 101, 108, 108, 111]);
 
-test("serialize json object to string", () => {
-  expect(jsonSerializer.serialize(testObject)).toMatch(
-    testObjectSerialized
-  );
+test('serialize json object to string', () => {
+  expect(jsonSerializer.serialize(testObject)).toMatch(testObjectSerialized);
 });
 
-test("deserialize string to json object", () => {
+test('deserialize string to json object', () => {
   expect(jsonSerializer.deserialize(testObjectSerialized)).toMatchObject(
-    testObject
+    testObject,
   );
 });
 
-test("encode string to Uint8Array", () => {
+test('encode string to Uint8Array', () => {
   expect(jsonSerializer.encode(testString)).toStrictEqual(
-    testStringAsUint8Array
+    testStringAsUint8Array,
   );
 });
 
-test("decode Uint8Array to string", () => {
+test('decode Uint8Array to string', () => {
   expect(jsonSerializer.decode(testStringAsUint8Array)).toMatch(testString);
 });

--- a/packages/collabswarm/src/json-serializer.test.ts
+++ b/packages/collabswarm/src/json-serializer.test.ts
@@ -1,31 +1,31 @@
 import { expect, test } from "@jest/globals";
 import { JSONSerializer } from "./json-serializer";
 
-const json_serializer = new JSONSerializer<any>();
+const jsonSerializer = new JSONSerializer<any>();
 
-let test_object = { key: "val" };
-let test_object_serialized = '{"key":"val"}';
-let test_string = "Hello";
-let test_string_as_u8_array = Uint8Array.from([72, 101, 108, 108, 111]);
+let testObject = { key: "val" };
+let testObjectSerialized = '{"key":"val"}';
+let testString = "Hello";
+let testStringAsUint8Array = Uint8Array.from([72, 101, 108, 108, 111]);
 
 test("serialize json object to string", () => {
-  expect(json_serializer.serialize(test_object)).toMatch(
-    test_object_serialized
+  expect(jsonSerializer.serialize(testObject)).toMatch(
+    testObjectSerialized
   );
 });
 
 test("deserialize string to json object", () => {
-  expect(json_serializer.deserialize(test_object_serialized)).toMatchObject(
-    test_object
+  expect(jsonSerializer.deserialize(testObjectSerialized)).toMatchObject(
+    testObject
   );
 });
 
 test("encode string to Uint8Array", () => {
-  expect(json_serializer.encode(test_string)).toStrictEqual(
-    test_string_as_u8_array
+  expect(jsonSerializer.encode(testString)).toStrictEqual(
+    testStringAsUint8Array
   );
 });
 
 test("decode Uint8Array to string", () => {
-  expect(json_serializer.decode(test_string_as_u8_array)).toMatch(test_string);
+  expect(jsonSerializer.decode(testStringAsUint8Array)).toMatch(testString);
 });

--- a/packages/collabswarm/src/json-serializer.test.ts
+++ b/packages/collabswarm/src/json-serializer.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@jest/globals";
 import { JSONSerializer } from "./json-serializer";
 
-const json_serializer = new JSONSerializer<any, any>();
+const json_serializer = new JSONSerializer<any>();
 
 let test_object = { key: "val" };
 let test_object_serialized = '{"key":"val"}';

--- a/packages/collabswarm/src/json-serializer.ts
+++ b/packages/collabswarm/src/json-serializer.ts
@@ -1,6 +1,7 @@
 import { ChangesSerializer } from "./changes-serializer";
 import { CRDTChangeBlock } from "./crdt-change-block";
 import { CRDTSyncMessage } from "./crdt-sync-message";
+import { KeySerializer } from "./key-serializer";
 import { MessageSerializer } from "./message-serializer";
 
 export class JSONSerializer<ChangesType>
@@ -38,10 +39,10 @@ export class JSONSerializer<ChangesType>
   deserializeChangeBlock(changes: string): CRDTChangeBlock<ChangesType> {
     return this.deserialize(changes);
   }
-  serializeMessage(message: CRDTSyncMessage<ChangesType>): Uint8Array {
+  serializeMessage<DocumentKey>(message: CRDTSyncMessage<ChangesType, DocumentKey>): Uint8Array {
     return this.encode(this.serialize(message));
   }
-  deserializeMessage(message: Uint8Array): CRDTSyncMessage<ChangesType> {
+  deserializeMessage<DocumentKey>(message: Uint8Array): CRDTSyncMessage<ChangesType, DocumentKey> {
     return this.deserialize(this.decode(message));
   }
 }

--- a/packages/collabswarm/src/json-serializer.ts
+++ b/packages/collabswarm/src/json-serializer.ts
@@ -1,7 +1,7 @@
-import { ChangesSerializer } from "./changes-serializer";
-import { CRDTChangeBlock } from "./crdt-change-block";
-import { CRDTSyncMessage } from "./crdt-sync-message";
-import { MessageSerializer } from "./message-serializer";
+import { ChangesSerializer } from './changes-serializer';
+import { CRDTChangeBlock } from './crdt-change-block';
+import { CRDTSyncMessage } from './crdt-sync-message';
+import { MessageSerializer } from './message-serializer';
 
 export class JSONSerializer<ChangesType>
   implements ChangesSerializer<ChangesType>, MessageSerializer<ChangesType> {
@@ -12,7 +12,7 @@ export class JSONSerializer<ChangesType>
     try {
       return JSON.parse(message);
     } catch (err) {
-      console.error("Failed to parse message:", message, err);
+      console.error('Failed to parse message:', message, err);
       throw err;
     }
   }

--- a/packages/collabswarm/src/json-serializer.ts
+++ b/packages/collabswarm/src/json-serializer.ts
@@ -1,7 +1,6 @@
 import { ChangesSerializer } from "./changes-serializer";
 import { CRDTChangeBlock } from "./crdt-change-block";
 import { CRDTSyncMessage } from "./crdt-sync-message";
-import { KeySerializer } from "./key-serializer";
 import { MessageSerializer } from "./message-serializer";
 
 export class JSONSerializer<ChangesType>
@@ -39,10 +38,10 @@ export class JSONSerializer<ChangesType>
   deserializeChangeBlock(changes: string): CRDTChangeBlock<ChangesType> {
     return this.deserialize(changes);
   }
-  serializeMessage<DocumentKey>(message: CRDTSyncMessage<ChangesType, DocumentKey>): Uint8Array {
+  serializeMessage(message: CRDTSyncMessage<ChangesType>): Uint8Array {
     return this.encode(this.serialize(message));
   }
-  deserializeMessage<DocumentKey>(message: Uint8Array): CRDTSyncMessage<ChangesType, DocumentKey> {
+  deserializeMessage(message: Uint8Array): CRDTSyncMessage<ChangesType> {
     return this.deserialize(this.decode(message));
   }
 }

--- a/packages/collabswarm/src/json-serializer.ts
+++ b/packages/collabswarm/src/json-serializer.ts
@@ -1,9 +1,10 @@
 import { ChangesSerializer } from "./changes-serializer";
 import { CRDTChangeBlock } from "./crdt-change-block";
+import { CRDTSyncMessage } from "./crdt-sync-message";
 import { MessageSerializer } from "./message-serializer";
 
-export class JSONSerializer<ChangesType, MessageType>
-  implements ChangesSerializer<ChangesType>, MessageSerializer<MessageType> {
+export class JSONSerializer<ChangesType>
+  implements ChangesSerializer<ChangesType>, MessageSerializer<ChangesType> {
   serialize(message: any): string {
     return JSON.stringify(message);
   }
@@ -37,10 +38,10 @@ export class JSONSerializer<ChangesType, MessageType>
   deserializeChangeBlock(changes: string): CRDTChangeBlock<ChangesType> {
     return this.deserialize(changes);
   }
-  serializeMessage(message: MessageType): Uint8Array {
+  serializeMessage(message: CRDTSyncMessage<ChangesType>): Uint8Array {
     return this.encode(this.serialize(message));
   }
-  deserializeMessage(message: Uint8Array): MessageType {
+  deserializeMessage(message: Uint8Array): CRDTSyncMessage<ChangesType> {
     return this.deserialize(this.decode(message));
   }
 }

--- a/packages/collabswarm/src/key-serializer.ts
+++ b/packages/collabswarm/src/key-serializer.ts
@@ -1,0 +1,10 @@
+/**
+ * DocumentKeySerializer provides serialization/deserialization methods for document
+ * encryption keys.
+ *
+ * @tparam DocumentKey Type describing a document encryption key.
+ */
+export interface KeySerializer<DocumentKey> {
+  serializeKey(key: DocumentKey): Promise<Uint8Array>;
+  deserializeKey(key: Uint8Array): Promise<DocumentKey>;
+}

--- a/packages/collabswarm/src/keychain-provider.ts
+++ b/packages/collabswarm/src/keychain-provider.ts
@@ -1,4 +1,4 @@
-import { Keychain } from "./keychain";
+import { Keychain } from './keychain';
 
 export interface KeychainProvider<KeychainChange, DocumentKey> {
   initialize(): Keychain<KeychainChange, DocumentKey>;

--- a/packages/collabswarm/src/keychain-provider.ts
+++ b/packages/collabswarm/src/keychain-provider.ts
@@ -1,0 +1,5 @@
+import { Keychain } from "./keychain";
+
+export interface KeychainProvider<KeychainChange, DocumentKey> {
+  initialize(): Keychain<KeychainChange, DocumentKey>;
+}

--- a/packages/collabswarm/src/keychain.ts
+++ b/packages/collabswarm/src/keychain.ts
@@ -1,0 +1,6 @@
+export interface Keychain<KeychainChange, DocumentKey> {
+  add(key: DocumentKey): Promise<KeychainChange>;
+  history(): KeychainChange;
+  merge(change: KeychainChange): void;
+  keys(): Promise<DocumentKey[]>;
+}

--- a/packages/collabswarm/src/message-serializer.ts
+++ b/packages/collabswarm/src/message-serializer.ts
@@ -1,9 +1,11 @@
+import { CRDTSyncMessage } from "./crdt-sync-message";
+
 /**
  * MessageSerializer provides serialization/deserialization methods for `CRDTSyncMessage`s.
  *
- * @tparam MessageType Type of CRDT document. CRDT implementation dependent.
+ * @tparam ChangesType Type describing changes made to a CRDT document. CRDT implementation dependent.
  */
-export interface MessageSerializer<MessageType> {
-  serializeMessage(message: MessageType): Uint8Array;
-  deserializeMessage(message: Uint8Array): MessageType;
+export interface MessageSerializer<ChangesType> {
+  serializeMessage(message: CRDTSyncMessage<ChangesType>): Uint8Array;
+  deserializeMessage(message: Uint8Array): CRDTSyncMessage<ChangesType>;
 }

--- a/packages/collabswarm/src/message-serializer.ts
+++ b/packages/collabswarm/src/message-serializer.ts
@@ -1,5 +1,4 @@
 import { CRDTSyncMessage } from "./crdt-sync-message";
-import { KeySerializer } from "./key-serializer";
 
 /**
  * MessageSerializer provides serialization/deserialization methods for `CRDTSyncMessage`s.
@@ -7,6 +6,6 @@ import { KeySerializer } from "./key-serializer";
  * @tparam ChangesType Type describing changes made to a CRDT document. CRDT implementation dependent.
  */
 export interface MessageSerializer<ChangesType> {
-  serializeMessage<DocumentKey>(message: CRDTSyncMessage<ChangesType, DocumentKey>, keySerializer: KeySerializer<DocumentKey>): Uint8Array;
-  deserializeMessage<DocumentKey>(message: Uint8Array, keySerializer: KeySerializer<DocumentKey>): CRDTSyncMessage<ChangesType, DocumentKey>;
+  serializeMessage(message: CRDTSyncMessage<ChangesType>): Uint8Array;
+  deserializeMessage(message: Uint8Array): CRDTSyncMessage<ChangesType>;
 }

--- a/packages/collabswarm/src/message-serializer.ts
+++ b/packages/collabswarm/src/message-serializer.ts
@@ -1,4 +1,4 @@
-import { CRDTSyncMessage } from "./crdt-sync-message";
+import { CRDTSyncMessage } from './crdt-sync-message';
 
 /**
  * MessageSerializer provides serialization/deserialization methods for `CRDTSyncMessage`s.

--- a/packages/collabswarm/src/message-serializer.ts
+++ b/packages/collabswarm/src/message-serializer.ts
@@ -1,4 +1,5 @@
 import { CRDTSyncMessage } from "./crdt-sync-message";
+import { KeySerializer } from "./key-serializer";
 
 /**
  * MessageSerializer provides serialization/deserialization methods for `CRDTSyncMessage`s.
@@ -6,6 +7,6 @@ import { CRDTSyncMessage } from "./crdt-sync-message";
  * @tparam ChangesType Type describing changes made to a CRDT document. CRDT implementation dependent.
  */
 export interface MessageSerializer<ChangesType> {
-  serializeMessage(message: CRDTSyncMessage<ChangesType>): Uint8Array;
-  deserializeMessage(message: Uint8Array): CRDTSyncMessage<ChangesType>;
+  serializeMessage<DocumentKey>(message: CRDTSyncMessage<ChangesType, DocumentKey>, keySerializer: KeySerializer<DocumentKey>): Uint8Array;
+  deserializeMessage<DocumentKey>(message: Uint8Array, keySerializer: KeySerializer<DocumentKey>): CRDTSyncMessage<ChangesType, DocumentKey>;
 }

--- a/packages/collabswarm/src/wire-protocols.ts
+++ b/packages/collabswarm/src/wire-protocols.ts
@@ -1,0 +1,2 @@
+export const documentLoadV1 = "/collabswarm/doc-load/1.0.0"
+export const documentKeyUpdateV1 = "/collabswarm/key-update/1.0.0"

--- a/packages/collabswarm/src/wire-protocols.ts
+++ b/packages/collabswarm/src/wire-protocols.ts
@@ -1,2 +1,2 @@
-export const documentLoadV1 = "/collabswarm/doc-load/1.0.0"
-export const documentKeyUpdateV1 = "/collabswarm/key-update/1.0.0"
+export const documentLoadV1 = '/collabswarm/doc-load/1.0.0';
+export const documentKeyUpdateV1 = '/collabswarm/key-update/1.0.0';


### PR DESCRIPTION
These new types provide implementations using CRDTs for ACLs and Keychains. The `*Provider` classes are simple factories for their corresponding ACL/Keychain implementation.

Please note that this does add security concerns to the CRDT ACL implementation. This potentially could open up the door to ACL/Keychain CRDT attacks if the attacker is somehow able to bypass our message encryption/signing.