### PR TITLE
Adds ACL/ACLProvider.

### DIFF
--- a/packages/collabswarm/src/acl-provider.ts
+++ b/packages/collabswarm/src/acl-provider.ts
@@ -3,7 +3,7 @@ import { ACL } from './acl';
 /**
  * Factory for ACL objects.
  * 
- * @tparam ChangesType Type of a change record.
+ * @tparam ChangesType A block of CRDT change(s).
  * @tparam PublicKey Type of a user's public key.
  */
 export interface ACLProvider<ChangesType, PublicKey> {

--- a/packages/collabswarm/src/acl-provider.ts
+++ b/packages/collabswarm/src/acl-provider.ts
@@ -2,14 +2,14 @@ import { ACL } from './acl';
 
 /**
  * Factory for ACL objects.
- * 
+ *
  * @tparam ChangesType A block of CRDT change(s).
  * @tparam PublicKey Type of a user's public key.
  */
 export interface ACLProvider<ChangesType, PublicKey> {
   /**
    * Construct a new ACL object.
-   * 
+   *
    * @return A new ACL object.
    */
   initialize(): ACL<ChangesType, PublicKey>;

--- a/packages/collabswarm/src/acl-provider.ts
+++ b/packages/collabswarm/src/acl-provider.ts
@@ -1,0 +1,16 @@
+import { ACL } from './acl';
+
+/**
+ * Factory for ACL objects.
+ * 
+ * @tparam ChangesType Type of a change record.
+ * @tparam PublicKey Type of a user's public key.
+ */
+export interface ACLProvider<ChangesType, PublicKey> {
+  /**
+   * Construct a new ACL object.
+   * 
+   * @return A new ACL object.
+   */
+  initialize(): ACL<ChangesType, PublicKey>;
+}

--- a/packages/collabswarm/src/acl.ts
+++ b/packages/collabswarm/src/acl.ts
@@ -1,7 +1,7 @@
 /**
  * An ACL keeps track of a list of user's public keys and produces changes that
  * can be sent to other swarm peers.
- * 
+ *
  * @tparam ChangesType A block of CRDT change(s).
  * @tparam PublicKey Type of a user's public key.
  */
@@ -16,7 +16,7 @@ export interface ACL<ChangesType, PublicKey> {
 
   /**
    * Remove a user from the ACL.
-   * 
+   *
    * @param publicKey User's public key.
    * @return A block of change(s) for the removal from the ACL.
    */
@@ -24,21 +24,21 @@ export interface ACL<ChangesType, PublicKey> {
 
   /**
    * Gets a block of change(s) describing the current state of the ACL.
-   * 
+   *
    * @return A block of change(s) describing the whole ACL.
    */
   current(): ChangesType;
 
   /**
    * Applies a block of change(s) to the ACL.
-   * 
+   *
    * @param changes A block of change(s) to apply.
    */
   merge(changes: ChangesType): void;
 
   /**
    * Checks to see if the specified user is in the ACL already.
-   * 
+   *
    * @param publicKey User's public key.
    * @return true if the user is in the ACL.
    */

--- a/packages/collabswarm/src/acl.ts
+++ b/packages/collabswarm/src/acl.ts
@@ -2,7 +2,7 @@
  * An ACL keeps track of a list of user's public keys and produces changes that
  * can be sent to other swarm peers.
  * 
- * @tparam ChangesType Type of a change record.
+ * @tparam ChangesType A block of CRDT change(s).
  * @tparam PublicKey Type of a user's public key.
  */
 export interface ACL<ChangesType, PublicKey> {
@@ -10,7 +10,7 @@ export interface ACL<ChangesType, PublicKey> {
    * Add a new user to the ACL.
    *
    * @param publicKey User's public key.
-   * @return A change record for the addition to the ACL.
+   * @return A block of change(s) for the addition to the ACL.
    */
   add(publicKey: PublicKey): Promise<ChangesType>;
 
@@ -18,23 +18,23 @@ export interface ACL<ChangesType, PublicKey> {
    * Remove a user from the ACL.
    * 
    * @param publicKey User's public key.
-   * @return A change record for the removal from the ACL.
+   * @return A block of change(s) for the removal from the ACL.
    */
   remove(publicKey: PublicKey): Promise<ChangesType>;
 
   /**
-   * Gets a change record describing the current state of the ACL.
+   * Gets a block of change(s) describing the current state of the ACL.
    * 
-   * @return A change record describing the whole ACL.
+   * @return A block of change(s) describing the whole ACL.
    */
   current(): ChangesType;
 
   /**
-   * Applies a change record to the ACL.
+   * Applies a block of change(s) to the ACL.
    * 
-   * @param change A change record to apply.
+   * @param changes A block of change(s) to apply.
    */
-  merge(change: ChangesType): void;
+  merge(changes: ChangesType): void;
 
   /**
    * Checks to see if the specified user is in the ACL already.

--- a/packages/collabswarm/src/acl.ts
+++ b/packages/collabswarm/src/acl.ts
@@ -1,0 +1,46 @@
+/**
+ * An ACL keeps track of a list of user's public keys and produces changes that
+ * can be sent to other swarm peers.
+ * 
+ * @tparam ChangesType Type of a change record.
+ * @tparam PublicKey Type of a user's public key.
+ */
+export interface ACL<ChangesType, PublicKey> {
+  /**
+   * Add a new user to the ACL.
+   *
+   * @param publicKey User's public key.
+   * @return A change record for the addition to the ACL.
+   */
+  add(publicKey: PublicKey): Promise<ChangesType>;
+
+  /**
+   * Remove a user from the ACL.
+   * 
+   * @param publicKey User's public key.
+   * @return A change record for the removal from the ACL.
+   */
+  remove(publicKey: PublicKey): Promise<ChangesType>;
+
+  /**
+   * Gets a change record describing the current state of the ACL.
+   * 
+   * @return A change record describing the whole ACL.
+   */
+  current(): ChangesType;
+
+  /**
+   * Applies a change record to the ACL.
+   * 
+   * @param change A change record to apply.
+   */
+  merge(change: ChangesType): void;
+
+  /**
+   * Checks to see if the specified user is in the ACL already.
+   * 
+   * @param publicKey User's public key.
+   * @return true if the user is in the ACL.
+   */
+  check(publicKey: PublicKey): Promise<boolean>;
+}


### PR DESCRIPTION
These interfaces get implemented in each CRDT specific implementation (`@collabswarm/collabswarm-automerge`, `@collabswarm/collabswarm-yjs`.

NOTE: Using a CRDT for ACLs does mean we need to make sure that this doesn't open up new attack vectors for taking over/eavesdropping on documents