### PR TITLE
Adds reader/writer ACL and keychain to CollabswarmDocument.

### DIFF
--- a/packages/collabswarm/src/crdt-provider.ts
+++ b/packages/collabswarm/src/crdt-provider.ts
@@ -12,24 +12,11 @@ import { CRDTSyncMessage } from './crdt-sync-message';
  * @tparam ChangeFnType A function for applying changes to a document
  * @tparam MessageType The sync message that gets sent when changes are made to a document
  */
-export interface CRDTProvider<
-  DocType,
-  ChangesType,
-  ChangeFnType,
-  MessageType extends CRDTSyncMessage<ChangesType>
-> {
+export interface CRDTProvider<DocType, ChangesType, ChangeFnType> {
   /**
    * Create a new empty (contains the equivalent of `{}`) CRDT document.
    */
   newDocument(): DocType;
-
-  /**
-   * Create a new CRDTSyncMessage from the provided document ID. Implementations
-   * should return an implementation-specific sub-interface of CRDTSyncMessage.
-   *
-   * @param documentId ID of the document new sync message is related to.
-   */
-  newMessage(documentId: string): MessageType;
 
   /**
    * Apply locally made changes to provided CRDT document as defined by `changeFn`.

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -2,7 +2,7 @@
  * CRDTSyncMessage is the message sent over both IPFS pubsub topics and in response to
  * load document requests.
  */
-export interface CRDTSyncMessage<ChangesType> {
+export type CRDTSyncMessage<ChangesType> = {
   /**
    * ID of a collabswarm document.
    */
@@ -17,4 +17,14 @@ export interface CRDTSyncMessage<ChangesType> {
    * implementation.
    */
   changes: { [hash: string]: ChangesType | null };
-}
+
+  readersChanges?: ChangesType;
+
+  writersChanges?: ChangesType;
+
+  /**
+   * Optional document keys list. Only populated while loading and receiving a document
+   * key update (due to the removal of an ACL reader).
+   */
+  keychainChanges?: ChangesType;
+};

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -1,17 +1,29 @@
-import { Collabswarm, CollabswarmPeersHandler } from "./collabswarm";
-import { CollabswarmConfig, DEFAULT_CONFIG } from "./collabswarm-config";
+import { Collabswarm, CollabswarmPeersHandler } from './collabswarm';
+import { CollabswarmConfig, DEFAULT_CONFIG } from './collabswarm-config';
 import {
   CollabswarmDocument,
   CollabswarmDocumentChangeHandler,
-} from "./collabswarm-document";
-import { CRDTSyncMessage } from "./crdt-sync-message";
-import { CollabswarmNode, DEFAULT_NODE_CONFIG } from "./collabswarm-node";
-import { CRDTProvider } from "./crdt-provider";
-import { MessageSerializer } from "./message-serializer";
-import { ChangesSerializer } from "./changes-serializer";
-import { JSONSerializer } from "./json-serializer";
+} from './collabswarm-document';
+import { CRDTSyncMessage } from './crdt-sync-message';
+import { CollabswarmNode, DEFAULT_NODE_CONFIG } from './collabswarm-node';
+import { CRDTProvider } from './crdt-provider';
+import { MessageSerializer } from './message-serializer';
+import { ChangesSerializer } from './changes-serializer';
+import { JSONSerializer } from './json-serializer';
+import { AuthProvider } from './auth-provider';
+import { SubtleCrypto } from './auth-subtlecrypto';
+import { KeySerializer } from './key-serializer';
+import { CryptoKeySerializer } from './crypto-key-serializer';
+import { ACLProvider } from './acl-provider';
+import { KeychainProvider } from './keychain-provider';
+import { ACL } from './acl';
+import { Keychain } from './keychain';
 
 export {
+  ACL,
+  ACLProvider,
+  AuthProvider,
+  SubtleCrypto,
   Collabswarm,
   CollabswarmPeersHandler,
   CollabswarmConfig,
@@ -20,7 +32,11 @@ export {
   CollabswarmNode,
   CRDTSyncMessage,
   CRDTProvider,
+  CryptoKeySerializer,
   ChangesSerializer,
+  KeySerializer,
+  Keychain,
+  KeychainProvider,
   MessageSerializer,
   JSONSerializer,
   DEFAULT_CONFIG,

--- a/packages/collabswarm/src/json-serializer.test.ts
+++ b/packages/collabswarm/src/json-serializer.test.ts
@@ -1,31 +1,29 @@
-import { expect, test } from "@jest/globals";
-import { JSONSerializer } from "./json-serializer";
+import { expect, test } from '@jest/globals';
+import { JSONSerializer } from './json-serializer';
 
-const json_serializer = new JSONSerializer<any, any>();
+const jsonSerializer = new JSONSerializer<any>();
 
-let test_object = { key: "val" };
-let test_object_serialized = '{"key":"val"}';
-let test_string = "Hello";
-let test_string_as_u8_array = Uint8Array.from([72, 101, 108, 108, 111]);
+let testObject = { key: 'val' };
+let testObjectSerialized = '{"key":"val"}';
+let testString = 'Hello';
+let testStringAsUint8Array = Uint8Array.from([72, 101, 108, 108, 111]);
 
-test("serialize json object to string", () => {
-  expect(json_serializer.serialize(test_object)).toMatch(
-    test_object_serialized
+test('serialize json object to string', () => {
+  expect(jsonSerializer.serialize(testObject)).toMatch(testObjectSerialized);
+});
+
+test('deserialize string to json object', () => {
+  expect(jsonSerializer.deserialize(testObjectSerialized)).toMatchObject(
+    testObject,
   );
 });
 
-test("deserialize string to json object", () => {
-  expect(json_serializer.deserialize(test_object_serialized)).toMatchObject(
-    test_object
+test('encode string to Uint8Array', () => {
+  expect(jsonSerializer.encode(testString)).toStrictEqual(
+    testStringAsUint8Array,
   );
 });
 
-test("encode string to Uint8Array", () => {
-  expect(json_serializer.encode(test_string)).toStrictEqual(
-    test_string_as_u8_array
-  );
-});
-
-test("decode Uint8Array to string", () => {
-  expect(json_serializer.decode(test_string_as_u8_array)).toMatch(test_string);
+test('decode Uint8Array to string', () => {
+  expect(jsonSerializer.decode(testStringAsUint8Array)).toMatch(testString);
 });

--- a/packages/collabswarm/src/json-serializer.ts
+++ b/packages/collabswarm/src/json-serializer.ts
@@ -1,9 +1,10 @@
-import { ChangesSerializer } from "./changes-serializer";
-import { CRDTChangeBlock } from "./crdt-change-block";
-import { MessageSerializer } from "./message-serializer";
+import { ChangesSerializer } from './changes-serializer';
+import { CRDTChangeBlock } from './crdt-change-block';
+import { CRDTSyncMessage } from './crdt-sync-message';
+import { MessageSerializer } from './message-serializer';
 
-export class JSONSerializer<ChangesType, MessageType>
-  implements ChangesSerializer<ChangesType>, MessageSerializer<MessageType> {
+export class JSONSerializer<ChangesType>
+  implements ChangesSerializer<ChangesType>, MessageSerializer<ChangesType> {
   serialize(message: any): string {
     return JSON.stringify(message);
   }
@@ -11,7 +12,7 @@ export class JSONSerializer<ChangesType, MessageType>
     try {
       return JSON.parse(message);
     } catch (err) {
-      console.error("Failed to parse message:", message, err);
+      console.error('Failed to parse message:', message, err);
       throw err;
     }
   }
@@ -37,10 +38,10 @@ export class JSONSerializer<ChangesType, MessageType>
   deserializeChangeBlock(changes: string): CRDTChangeBlock<ChangesType> {
     return this.deserialize(changes);
   }
-  serializeMessage(message: MessageType): Uint8Array {
+  serializeMessage(message: CRDTSyncMessage<ChangesType>): Uint8Array {
     return this.encode(this.serialize(message));
   }
-  deserializeMessage(message: Uint8Array): MessageType {
+  deserializeMessage(message: Uint8Array): CRDTSyncMessage<ChangesType> {
     return this.deserialize(this.decode(message));
   }
 }

--- a/packages/collabswarm/src/message-serializer.ts
+++ b/packages/collabswarm/src/message-serializer.ts
@@ -1,9 +1,11 @@
+import { CRDTSyncMessage } from './crdt-sync-message';
+
 /**
  * MessageSerializer provides serialization/deserialization methods for `CRDTSyncMessage`s.
  *
- * @tparam MessageType Type of CRDT document. CRDT implementation dependent.
+ * @tparam ChangesType Type describing changes made to a CRDT document. CRDT implementation dependent.
  */
-export interface MessageSerializer<MessageType> {
-  serializeMessage(message: MessageType): Uint8Array;
-  deserializeMessage(message: Uint8Array): MessageType;
+export interface MessageSerializer<ChangesType> {
+  serializeMessage(message: CRDTSyncMessage<ChangesType>): Uint8Array;
+  deserializeMessage(message: Uint8Array): CRDTSyncMessage<ChangesType>;
 }

--- a/packages/collabswarm/src/wire-protocols.ts
+++ b/packages/collabswarm/src/wire-protocols.ts
@@ -1,0 +1,2 @@
+export const documentLoadV1 = '/collabswarm/doc-load/1.0.0';
+export const documentKeyUpdateV1 = '/collabswarm/key-update/1.0.0';


### PR DESCRIPTION
This integrates ACLs and a Keychain into the CollabswarmDocument. Load requests are now responded to with the document keys.

There are still no `(add|remove)(Writer|Reader)` methods (and their corresponding key-exchange process), but that will come in the future. Load requests need to also send user identity for verification by the receiving party (verifying that they're a reader)