### PR TITLE
Encrypt/decrypt stored change blocks on IPFS.

### DIFF
--- a/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
+++ b/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
@@ -19,13 +19,13 @@ const keychain = new AutomergeKeychainProvider();
 crypto.subtle
   .generateKey(
     {
-      name: "ECDSA",
-      namedCurve: "P-384",
+      name: 'ECDSA',
+      namedCurve: 'P-384',
     },
     true,
-    ["sign", "verify"]
+    ['sign', 'verify'],
   )
-  .then(keypair => {
+  .then((keypair) => {
     const swarmNode = new CollabswarmNode(
       keypair.privateKey,
       keypair.publicKey,

--- a/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
+++ b/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
@@ -19,15 +19,16 @@ const keychain = new AutomergeKeychainProvider();
 crypto.subtle
   .generateKey(
     {
-      name: "AES-GCM",
-      length: 256,
+      name: "ECDSA",
+      namedCurve: "P-384",
     },
     true,
-    ["encrypt", "decrypt"]
+    ["sign", "verify"]
   )
-  .then(key => {
+  .then(keypair => {
     const swarmNode = new CollabswarmNode(
-      key,
+      keypair.privateKey,
+      keypair.publicKey,
       crdt,
       serializer,
       serializer,

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -179,6 +179,22 @@ export class AutomergeKeychain implements Keychain<BinaryChange[], CryptoKey> {
       }),
     );
   }
+  async current(): Promise<CryptoKey | undefined> {
+    if (!this._keychain.keys) {
+      return;
+    }
+    
+    const hash = this._keychain.keys[this._keychain.keys.length];
+
+    let key: CryptoKey | undefined = undefined;
+    if (this._keyCache.has(hash)) {
+      key = this._keyCache.get(hash);
+    }
+    if (!key) {
+      key = await deserializeKey(hash);
+    }
+    return key;
+  }
 }
 
 export class AutomergeKeychainProvider

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -183,7 +183,7 @@ export class AutomergeKeychain implements Keychain<BinaryChange[], CryptoKey> {
     if (!this._keychain.keys) {
       return;
     }
-    
+
     const hash = this._keychain.keys[this._keychain.keys.length];
 
     let key: CryptoKey | undefined = undefined;

--- a/packages/collabswarm-react/src/hooks.ts
+++ b/packages/collabswarm-react/src/hooks.ts
@@ -8,7 +8,7 @@ import {
   KeychainProvider,
   LoadMessageSerializer,
 } from '@collabswarm/collabswarm';
-import {  } from '@collabswarm/collabswarm/src/load-request-serializer';
+import {} from '@collabswarm/collabswarm/src/load-request-serializer';
 import { useEffect, useState } from 'react';
 
 export function useCollabswarm<

--- a/packages/collabswarm-react/src/hooks.ts
+++ b/packages/collabswarm-react/src/hooks.ts
@@ -20,6 +20,7 @@ export function useCollabswarm<
   DocumentKey
 >(
   privateKey: PrivateKey,
+  publicKey: PublicKey,
   provider: CRDTProvider<DocType, ChangesType, ChangeFnType>,
   changesSerializer: ChangesSerializer<ChangesType>,
   syncMessageSerializer: SyncMessageSerializer<ChangesType>,
@@ -44,6 +45,7 @@ export function useCollabswarm<
     setCollabswarm(
       new Collabswarm(
         privateKey,
+        publicKey,
         provider,
         changesSerializer,
         syncMessageSerializer,

--- a/packages/collabswarm-redux/src/actions.ts
+++ b/packages/collabswarm-redux/src/actions.ts
@@ -247,7 +247,7 @@ export function openDocumentAsync<
           'Failed to load document from peers, assuming this is a new document...',
           documentRef,
         );
-        await documentRef.pin();
+        // await documentRef.pin();
       }
       dispatch(openDocument(documentId, documentRef));
       return documentRef;

--- a/packages/collabswarm-redux/src/reducers.ts
+++ b/packages/collabswarm-redux/src/reducers.ts
@@ -82,6 +82,7 @@ export function initialState<
   DocumentKey
 >(
   privateKey: PrivateKey,
+  publicKey: PublicKey,
   provider: CRDTProvider<DocType, ChangesType, ChangeFnType>,
   changesSerializer: ChangesSerializer<ChangesType>,
   syncMessageSerializer: SyncMessageSerializer<ChangesType>,
@@ -100,6 +101,7 @@ export function initialState<
   return {
     node: new Collabswarm(
       privateKey,
+      publicKey,
       provider,
       changesSerializer,
       syncMessageSerializer,
@@ -123,6 +125,7 @@ export function collabswarmReducer<
   DocumentKey
 >(
   privateKey: PrivateKey,
+  publicKey: PublicKey,
   provider: CRDTProvider<DocType, ChangesType, ChangeFnType>,
   changesSerializer: ChangesSerializer<ChangesType>,
   syncMessageSerializer: SyncMessageSerializer<ChangesType>,
@@ -141,6 +144,7 @@ export function collabswarmReducer<
       DocumentKey
     > = initialState(
       privateKey,
+      publicKey,
       provider,
       changesSerializer,
       syncMessageSerializer,

--- a/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
+++ b/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 
 import { CollabswarmNode, SubtleCrypto } from '@collabswarm/collabswarm';
-import { YjsACLProvider, YjsJSONSerializer, YjsKeychainProvider, YjsProvider } from '../src';
+import {
+  YjsACLProvider,
+  YjsJSONSerializer,
+  YjsKeychainProvider,
+  YjsProvider,
+} from '../src';
 
 global.crypto = require('crypto').webcrypto;
 
@@ -14,14 +19,24 @@ const keychain = new YjsKeychainProvider();
 crypto.subtle
   .generateKey(
     {
-      name: "ECDSA",
-      namedCurve: "P-384",
+      name: 'ECDSA',
+      namedCurve: 'P-384',
     },
     true,
-    ["sign", "verify"]
+    ['sign', 'verify'],
   )
-  .then(keypair => {
-    const swarmNode = new CollabswarmNode(keypair.privateKey, keypair.publicKey, crdt, serializer, serializer, serializer, auth, acl, keychain);
+  .then((keypair) => {
+    const swarmNode = new CollabswarmNode(
+      keypair.privateKey,
+      keypair.publicKey,
+      crdt,
+      serializer,
+      serializer,
+      serializer,
+      auth,
+      acl,
+      keychain,
+    );
     console.log('Starting node...');
     swarmNode.start();
   });

--- a/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
+++ b/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
@@ -14,14 +14,14 @@ const keychain = new YjsKeychainProvider();
 crypto.subtle
   .generateKey(
     {
-      name: "AES-GCM",
-      length: 256,
+      name: "ECDSA",
+      namedCurve: "P-384",
     },
     true,
-    ["encrypt", "decrypt"]
+    ["sign", "verify"]
   )
-  .then(key => {
-    const swarmNode = new CollabswarmNode(key, crdt, serializer, serializer, serializer, auth, acl, keychain);
+  .then(keypair => {
+    const swarmNode = new CollabswarmNode(keypair.privateKey, keypair.publicKey, crdt, serializer, serializer, serializer, auth, acl, keychain);
     console.log('Starting node...');
     swarmNode.start();
   });

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -160,7 +160,7 @@ export class YjsKeychain implements Keychain<Uint8Array, CryptoKey> {
     if (yarr.length === 0) {
       return;
     }
-    
+
     const hash = yarr.get(yarr.length);
 
     let key: CryptoKey | undefined = undefined;

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -155,6 +155,23 @@ export class YjsKeychain implements Keychain<Uint8Array, CryptoKey> {
 
     return await Promise.all(promises);
   }
+  async current(): Promise<CryptoKey | undefined> {
+    const yarr = this._keychain.getArray<string>('keys');
+    if (yarr.length === 0) {
+      return;
+    }
+    
+    const hash = yarr.get(yarr.length);
+
+    let key: CryptoKey | undefined = undefined;
+    if (this._keyCache.has(hash)) {
+      key = this._keyCache.get(hash);
+    }
+    if (!key) {
+      key = await deserializeKey(hash);
+    }
+    return key;
+  }
 }
 
 export class YjsKeychainProvider

--- a/packages/collabswarm/src/auth-provider.ts
+++ b/packages/collabswarm/src/auth-provider.ts
@@ -10,16 +10,16 @@ export interface AuthProvider<PrivateKey, PublicKey, DocumentKey = string> {
   verify(
     data: Uint8Array,
     publicKey: PublicKey,
-    signature: Uint8Array
+    signature: Uint8Array,
   ): Promise<boolean>;
   encrypt(
     data: Uint8Array,
-    documentKey: DocumentKey
+    documentKey: DocumentKey,
   ): Promise<EncryptionResult>;
   decrypt(
     data: Uint8Array,
     documentKey: DocumentKey,
-    nonce?: Uint8Array
+    nonce?: Uint8Array,
   ): Promise<Uint8Array>;
 
   readonly nonceBits: number;

--- a/packages/collabswarm/src/auth-provider.ts
+++ b/packages/collabswarm/src/auth-provider.ts
@@ -21,4 +21,6 @@ export interface AuthProvider<PrivateKey, PublicKey, DocumentKey = string> {
     documentKey: DocumentKey,
     nonce?: Uint8Array
   ): Promise<Uint8Array>;
+
+  readonly nonceBits: number;
 }

--- a/packages/collabswarm/src/auth-subtlecrypto.ts
+++ b/packages/collabswarm/src/auth-subtlecrypto.ts
@@ -1,4 +1,4 @@
-import { AuthProvider } from "./auth-provider";
+import { AuthProvider } from './auth-provider';
 
 /**
  * Used to wrap CryptoKey so that initialized vector used in encryption
@@ -41,8 +41,8 @@ export class SubtleCrypto
       | RsaPssParams
       | EcdsaParams
       | AesCmacParams = {
-      name: "ECDSA",
-      hash: { name: "SHA-384" },
+      name: 'ECDSA',
+      hash: { name: 'SHA-384' },
     },
 
     /**
@@ -52,9 +52,9 @@ export class SubtleCrypto
      * "RSA-OAEP" is not supported at this time because it is a key pair.
      */
     public readonly _encryptionAlgorithmName:
-      | "AES-GCM"
-      | "AES-CTR"
-      | "AES-CBC" = "AES-GCM"
+      | 'AES-GCM'
+      | 'AES-CTR'
+      | 'AES-CBC' = 'AES-GCM',
   ) {}
 
   /**
@@ -70,14 +70,16 @@ export class SubtleCrypto
    */
   _encryptionAlgorithmParams(nonce?: Uint8Array): AesGcmParams {
     switch (this._encryptionAlgorithmName) {
-      case "AES-GCM":
-        const iv = nonce ? nonce : crypto.getRandomValues(new Uint8Array(this.nonceBits));
+      case 'AES-GCM':
+        const iv = nonce
+          ? nonce
+          : crypto.getRandomValues(new Uint8Array(this.nonceBits));
         return {
-          name: "AES-GCM",
+          name: 'AES-GCM',
           iv,
         };
       default:
-        throw "Encryption is only supported with AesGcmParams currently"!;
+        throw 'Encryption is only supported with AesGcmParams currently'!;
     }
   }
 
@@ -90,10 +92,10 @@ export class SubtleCrypto
    */
   public async sign(
     data: Uint8Array,
-    privateKey: CryptoKey
+    privateKey: CryptoKey,
   ): Promise<Uint8Array> {
     return new Uint8Array(
-      await crypto.subtle.sign(this.signingAlgorithm, privateKey, data)
+      await crypto.subtle.sign(this.signingAlgorithm, privateKey, data),
     );
   }
 
@@ -108,13 +110,13 @@ export class SubtleCrypto
   public async verify(
     data: Uint8Array,
     publicKey: CryptoKey,
-    signature: Uint8Array
+    signature: Uint8Array,
   ): Promise<boolean> {
     return await crypto.subtle.verify(
       this.signingAlgorithm,
       publicKey,
       signature,
-      data
+      data,
     );
   }
 
@@ -134,18 +136,18 @@ export class SubtleCrypto
   public async decrypt(
     data: Uint8Array,
     documentKey: CryptoKey,
-    nonce?: Uint8Array
+    nonce?: Uint8Array,
   ): Promise<Uint8Array> {
     try {
       return new Uint8Array(
         await crypto.subtle.decrypt(
           this._encryptionAlgorithmParams(nonce),
           documentKey,
-          data
-        )
+          data,
+        ),
       );
     } catch (err) {
-      console.error("Failed to decrypt data:", err);
+      console.error('Failed to decrypt data:', err);
       throw err;
     }
   }
@@ -160,13 +162,13 @@ export class SubtleCrypto
    */
   public async encrypt(
     data: Uint8Array,
-    documentKey: CryptoKey
+    documentKey: CryptoKey,
   ): Promise<SubtleCryptoEncryptionResult> {
     const algorithmParams = this._encryptionAlgorithmParams();
     const ciphertext = await crypto.subtle.encrypt(
       algorithmParams,
       documentKey,
-      data
+      data,
     );
     return {
       data: new Uint8Array(ciphertext),

--- a/packages/collabswarm/src/auth-subtlecrypto.ts
+++ b/packages/collabswarm/src/auth-subtlecrypto.ts
@@ -29,7 +29,7 @@ export class SubtleCrypto
      *
      * @remarks 96 bits length is recommended in docs; though example uses only 12
      */
-    public readonly _nonceBits = 96,
+    public readonly nonceBits = 96,
 
     /**
      * The type of algorithm used for signature and verification keys.
@@ -71,11 +71,10 @@ export class SubtleCrypto
   _encryptionAlgorithmParams(nonce?: Uint8Array): AesGcmParams {
     switch (this._encryptionAlgorithmName) {
       case "AES-GCM":
-        let iv_value = crypto.getRandomValues(new Uint8Array(this._nonceBits));
-        if (nonce) iv_value = nonce;
+        const iv = nonce ? nonce : crypto.getRandomValues(new Uint8Array(this.nonceBits));
         return {
-          name: this._encryptionAlgorithmName,
-          iv: iv_value,
+          name: "AES-GCM",
+          iv,
         };
       default:
         throw "Encryption is only supported with AesGcmParams currently"!;
@@ -135,7 +134,7 @@ export class SubtleCrypto
   public async decrypt(
     data: Uint8Array,
     documentKey: CryptoKey,
-    nonce: Uint8Array
+    nonce?: Uint8Array
   ): Promise<Uint8Array> {
     try {
       return new Uint8Array(

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -9,14 +9,14 @@ import pipe from 'it-pipe';
 import Libp2p from 'libp2p';
 import { MessageHandlerFn } from 'ipfs-core-types/src/pubsub';
 import { Collabswarm } from './collabswarm';
-import { firstTrue, readUint8Iterable, shuffleArray } from './utils';
+import { concatUint8Arrays, firstTrue, readUint8Iterable, shuffleArray } from './utils';
 import { CRDTProvider } from './crdt-provider';
 import { AuthProvider } from './auth-provider';
 import {
   CRDTChangeNode,
   crdtChangeNodeDeferred,
-  CRDTSyncMessage,
-} from './crdt-sync-message';
+} from './crdt-change-node';
+import { CRDTSyncMessage } from './crdt-sync-message';
 import { ChangesSerializer } from './changes-serializer';
 import { SyncMessageSerializer } from './sync-message-serializer';
 import { documentLoadV1 } from './wire-protocols';
@@ -150,6 +150,11 @@ export class CollabswarmDocument<
     private readonly _userKey: PrivateKey,
 
     /**
+     * Private key identifying the current user.
+     */
+    private readonly _userPublicKey: PublicKey,
+
+    /**
      * CRDTProvider handles reading/writing CRDT document data and metadata.
      */
     private readonly _crdtProvider: CRDTProvider<
@@ -198,9 +203,39 @@ export class CollabswarmDocument<
 
   // Helpers ------------------------------------------------------------------
 
+  private async _decryptBlock(nonce: Uint8Array, data: Uint8Array) {
+    // TODO: Remove this loop by storing a document public key or some other id for it.
+    for (const key of await this._keychain.keys()) {
+      try {
+        return this._authProvider.decrypt(data, key, nonce);
+      } catch {
+        // No-op, continue loop.
+      }
+    }
+    return undefined;
+  }
+
   private async _getBlock(hash: string): Promise<ChangesType> {
     const block = await this.swarm.ipfsNode.block.get(hash);
-    return this._changesSerializer.deserializeChanges(block.data);
+    const blockNonce = block.data.slice(0, this._authProvider.nonceBits);
+    const blockData = block.data.slice(this._authProvider.nonceBits);
+    const content = await this._decryptBlock(blockNonce, blockData);
+    if (!content) {
+      throw new Error(`Failed to decrypt block (CID: ${hash})`);
+    }
+    return this._changesSerializer.deserializeChanges(content);
+  }
+
+  private async _putBlock(block: ChangesType): Promise<string> {
+    const documentKey = await this._keychain.current();
+    if (!documentKey) {
+      throw new Error(`Document ${this.documentPath} has an empty keychain!`);
+    }
+    const content = this._changesSerializer.serializeChanges(block);
+    const { nonce, data } = await this._authProvider.encrypt(content, documentKey);
+    const blockData = nonce ? concatUint8Arrays(nonce, data) : data;
+    const newFileResult = await this.swarm.ipfsNode.block.put(blockData);
+    return newFileResult.cid.toString();
   }
 
   private async _mergeSyncTree(
@@ -735,7 +770,10 @@ export class CollabswarmDocument<
    * @param message An optional change message/description to include.
    */
   public async change(changeFn: ChangeFnType, message?: string) {
-    // TODO: Check that we are a writer (allowed to write to this document).
+    // Check that we are a writer (allowed to write to this document).
+    if (!(await this._writers.check(this._userPublicKey))) {
+      throw new Error(`Current user does not have write permissions for: ${this.documentPath}`);
+    }
 
     const [newDocument, changes] = this._crdtProvider.localChange(
       this.document,
@@ -746,10 +784,7 @@ export class CollabswarmDocument<
     this._document = newDocument;
 
     // Store changes in ipfs.
-    const newFileResult = await this.swarm.ipfsNode.block.put(
-      this._changesSerializer.serializeChanges(changes),
-    );
-    const hash = newFileResult.cid.toString();
+    const hash = await this._putBlock(changes);
     this._hashes.add(hash);
 
     // Send new message.

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -9,13 +9,15 @@ import pipe from 'it-pipe';
 import Libp2p from 'libp2p';
 import { MessageHandlerFn } from 'ipfs-core-types/src/pubsub';
 import { Collabswarm } from './collabswarm';
-import { concatUint8Arrays, firstTrue, readUint8Iterable, shuffleArray } from './utils';
+import {
+  concatUint8Arrays,
+  firstTrue,
+  readUint8Iterable,
+  shuffleArray,
+} from './utils';
 import { CRDTProvider } from './crdt-provider';
 import { AuthProvider } from './auth-provider';
-import {
-  CRDTChangeNode,
-  crdtChangeNodeDeferred,
-} from './crdt-change-node';
+import { CRDTChangeNode, crdtChangeNodeDeferred } from './crdt-change-node';
 import { CRDTSyncMessage } from './crdt-sync-message';
 import { ChangesSerializer } from './changes-serializer';
 import { SyncMessageSerializer } from './sync-message-serializer';
@@ -232,7 +234,10 @@ export class CollabswarmDocument<
       throw new Error(`Document ${this.documentPath} has an empty keychain!`);
     }
     const content = this._changesSerializer.serializeChanges(block);
-    const { nonce, data } = await this._authProvider.encrypt(content, documentKey);
+    const { nonce, data } = await this._authProvider.encrypt(
+      content,
+      documentKey,
+    );
     const blockData = nonce ? concatUint8Arrays(nonce, data) : data;
     const newFileResult = await this.swarm.ipfsNode.block.put(blockData);
     return newFileResult.cid.toString();
@@ -772,7 +777,9 @@ export class CollabswarmDocument<
   public async change(changeFn: ChangeFnType, message?: string) {
     // Check that we are a writer (allowed to write to this document).
     if (!(await this._writers.check(this._userPublicKey))) {
-      throw new Error(`Current user does not have write permissions for: ${this.documentPath}`);
+      throw new Error(
+        `Current user does not have write permissions for: ${this.documentPath}`,
+      );
     }
 
     const [newDocument, changes] = this._crdtProvider.localChange(

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -15,6 +15,7 @@ import { AuthProvider } from './auth-provider';
 import { ACLProvider } from './acl-provider';
 import { KeychainProvider } from './keychain-provider';
 import { LoadMessageSerializer } from './load-request-serializer';
+import { CRDTChangeNode, crdtChangeNodeDeferred } from './crdt-change-node';
 
 export const DEFAULT_NODE_CONFIG: CollabswarmConfig = {
   ipfs: {
@@ -50,6 +51,7 @@ export class CollabswarmNode<
 > {
   private _swarm = new Collabswarm(
     this.nodeKey,
+    this.nodePublicKey,
     this.provider,
     this.changesSerializer,
     this.syncMessageSerializer,
@@ -86,6 +88,7 @@ export class CollabswarmNode<
 
   constructor(
     private readonly nodeKey: PrivateKey,
+    private readonly nodePublicKey: PublicKey,
     public readonly provider: CRDTProvider<DocType, ChangesType, ChangeFnType>,
     public readonly changesSerializer: ChangesSerializer<ChangesType>,
     public readonly syncMessageSerializer: SyncMessageSerializer<ChangesType>,
@@ -102,6 +105,27 @@ export class CollabswarmNode<
     >,
     public readonly config: CollabswarmConfig = DEFAULT_NODE_CONFIG,
   ) {}
+
+  private async _pinNewCIDs(cid: string, node: CRDTChangeNode<ChangesType>) {
+    if (!this._seenCids.has(cid)) {
+      // TODO: Handle this operation failing (retry).
+      // TODO: Does this need to be converted to a `CID` from a string first?
+      this.swarm.ipfsNode.pin.add(cid);
+      this._seenCids.add(cid);
+    }
+
+    if (node.children === crdtChangeNodeDeferred) {
+      throw new Error("Currently IPLD deferred nodes are not supported!");
+    }
+
+    const tasks: Promise<void>[] = [];
+    if (node.children !== undefined) {
+      for (const [childHash, childNode] of Object.entries(node.children)) {
+        tasks.push(this._pinNewCIDs(childHash, childNode));
+      }
+    }
+    await Promise.all(tasks);
+  }
 
   // Start
   public async start() {
@@ -167,12 +191,14 @@ export class CollabswarmNode<
             docRef.open();
 
             // Pin all of the files that were received.
-            for (const cid of Object.keys(message.changes)) {
-              if (!this._seenCids.has(cid)) {
-                // TODO: Handle this operation failing (retry).
-                this.swarm.ipfsNode.pin.add(cid);
-                this._seenCids.add(cid);
-              }
+            if (message.changeId && message.changes) {
+              this._pinNewCIDs(message.changeId, message.changes);
+            }
+            if (message.readersChangeId && message.readersChanges) {
+              this._pinNewCIDs(message.readersChangeId, message.readersChanges);
+            }
+            if (message.writersChangeId && message.writersChanges) {
+              this._pinNewCIDs(message.writersChangeId, message.writersChanges);
             }
           } else {
             console.warn(

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -115,7 +115,7 @@ export class CollabswarmNode<
     }
 
     if (node.children === crdtChangeNodeDeferred) {
-      throw new Error("Currently IPLD deferred nodes are not supported!");
+      throw new Error('Currently IPLD deferred nodes are not supported!');
     }
 
     const tasks: Promise<void>[] = [];

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -67,6 +67,7 @@ export class Collabswarm<
 > {
   constructor(
     private readonly _userKey: PrivateKey,
+    private readonly _userPublicKey: PublicKey,
     private readonly _crdtProvider: CRDTProvider<
       DocType,
       ChangesType,
@@ -219,6 +220,7 @@ export class Collabswarm<
       this,
       documentPath,
       this._userKey,
+      this._userPublicKey,
       this._crdtProvider,
       this._authProvider,
       this._aclProvider,

--- a/packages/collabswarm/src/crdt-change-block.ts
+++ b/packages/collabswarm/src/crdt-change-block.ts
@@ -4,9 +4,9 @@
  */
 export interface CRDTChangeBlock<ChangesType> {
   /**
-   * Signature of the changes below. Should be signed using the private key of the change author.
+   * Stored nonce for decryption purposes.
    */
-  signature?: string;
+  nonce: Uint8Array;
 
   /**
    * Changes object describing edits made to a CRDT document. CRDTProvider implementation dependent.

--- a/packages/collabswarm/src/crdt-change-node.ts
+++ b/packages/collabswarm/src/crdt-change-node.ts
@@ -1,0 +1,17 @@
+export type CRDTChangeNodeDeferred = false;
+export const crdtChangeNodeDeferred: CRDTChangeNodeDeferred = false;
+
+/**
+ * A CRDT Change node represents a shadow copy of a Merkle DAG that is sent over sync messages.
+ * 
+ * @tparam ChangesType A block of CRDT change(s).
+ */
+export type CRDTChangeNode<ChangesType> = {
+  // `undefined` changes means that the changes should be fetched from IPFS blockstore.
+  change?: ChangesType;
+
+  // `undefined` means that this node is a leaf node (equivalent to `[]`).
+  children?:
+    | { [hash: string]: CRDTChangeNode<ChangesType> }
+    | CRDTChangeNodeDeferred;
+};

--- a/packages/collabswarm/src/crdt-change-node.ts
+++ b/packages/collabswarm/src/crdt-change-node.ts
@@ -3,7 +3,7 @@ export const crdtChangeNodeDeferred: CRDTChangeNodeDeferred = false;
 
 /**
  * A CRDT Change node represents a shadow copy of a Merkle DAG that is sent over sync messages.
- * 
+ *
  * @tparam ChangesType A block of CRDT change(s).
  */
 export type CRDTChangeNode<ChangesType> = {

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -1,24 +1,10 @@
-export type CRDTChangeNodeDeferred = false;
-export const crdtChangeNodeDeferred: CRDTChangeNodeDeferred = false;
-
-// Change nodes contain the full change
-export type CRDTChangeNode<ChangesType> = {
-  // id: string;
-
-  // `undefined` changes means that the changes should be fetched from IPFS blockstore.
-  change?: ChangesType;
-
-  // `undefined` means that this node is a leaf node (equivalent to `[]`).
-  children?:
-    | { [hash: string]: CRDTChangeNode<ChangesType> }
-    | CRDTChangeNodeDeferred;
-};
+import { CRDTChangeNode } from "./crdt-change-node";
 
 /**
  * CRDTSyncMessage is the message sent over both IPFS pubsub topics and in response to
  * load document requests.
  *
- * @tparam ChangesType Type of a block of change(s).
+ * @tparam ChangesType A block of CRDT change(s).
  */
 export type CRDTSyncMessage<ChangesType> = {
   /**
@@ -39,7 +25,6 @@ export type CRDTSyncMessage<ChangesType> = {
    * Data stored int the IPFS file is deserialized using a `MessageSerializer`
    * implementation.
    */
-  // changes: { [hash: string]: ChangesType | null };
   changes?: CRDTChangeNode<ChangesType>;
 
   /**
@@ -51,7 +36,6 @@ export type CRDTSyncMessage<ChangesType> = {
    * An optional block of change(s) made to the reader ACL. `undefined` means no change
    * was made to the reader ACL.
    */
-  // readersChanges: { [hash: string]: ChangesType | null };
   readersChanges?: CRDTChangeNode<ChangesType>;
 
   /**
@@ -63,7 +47,6 @@ export type CRDTSyncMessage<ChangesType> = {
    * An optional block of change(s) made to the writer ACL. `undefined` means no change
    * was made to the writer ACL.
    */
-  // writersChanges: { [hash: string]: ChangesType | null };
   writersChanges?: CRDTChangeNode<ChangesType>;
 
   /**

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -1,4 +1,4 @@
-import { CRDTChangeNode } from "./crdt-change-node";
+import { CRDTChangeNode } from './crdt-change-node';
 
 /**
  * CRDTSyncMessage is the message sent over both IPFS pubsub topics and in response to

--- a/packages/collabswarm/src/keychain.ts
+++ b/packages/collabswarm/src/keychain.ts
@@ -33,4 +33,9 @@ export interface Keychain<KeychainChange, DocumentKey> {
    * @return all document encryption keys.
    */
   keys(): Promise<DocumentKey[]>;
+
+  /**
+   * Gets the current encryption key that should be used to encrypt new changes.
+   */
+  current(): Promise<DocumentKey | undefined>;
 }

--- a/packages/collabswarm/src/utils.ts
+++ b/packages/collabswarm/src/utils.ts
@@ -18,6 +18,17 @@ export function firstTrue(promises: Promise<boolean>[]) {
   return Promise.race(newPromises);
 }
 
+export function concatUint8Arrays(...arrs: Uint8Array[]): Uint8Array {
+  const length = arrs.reduce((a, b) => a + b.length, 0);
+  const newArr = new Uint8Array(length);
+  let currentIndex = 0;
+  for (const arr of arrs) {
+    newArr.set(arr, currentIndex);
+    currentIndex += arr.length;
+  }
+  return newArr;
+}
+
 // HACK:
 export function isBufferList(input: Uint8Array | BufferList): boolean {
   return !!Object.getOwnPropertySymbols(input).find((s) => {


### PR DESCRIPTION
I think we can skip encrypting/decrypting sync messages and rely upon libp2p pipe encryption (otherwise we'd be double encoding). Data that goes over the pubsub topic does still need to be encrypted/decrypted (coming in next change).