### PR TITLE
Shortcuts for CLI access to workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,12 @@
     "packages/collabswarm-redux",
     "examples/browser-test",
     "examples/wiki-swarm"
-  ]
+  ],
+  "scripts": {
+    "collabswarm": "yarn workspace @collabswarm/collabswarm",
+    "automerge": "yarn workspace @collabswarm/collabswarm-automerge",
+    "yjs": "yarn workspace @collabswarm/collabswarm-yjs",
+    "react": "yarn workspace @collabswarm/collabswarm-react",
+    "redux": "yarn workspace @collabswarm/collabswarm-redux"
+  }
 }


### PR DESCRIPTION
PROPOSAL
Is it a bad idea to implement something like this? As in: one more place to maintain name changes.

The plus is being able to type from CLI directly without copy/paste from the readme. As a specific example,
`yarn workspace @collabswarm/collabswarm-yjs tsc` becomes `yarn yjs tsc`