### PR TITLE
Improve document load, transaction API, peer selection, and key distribution

### DIFF
--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -1823,11 +1823,8 @@ export class CollabswarmDocument<
     }
   }
 
-  // TODO: Unit tests for the transaction API (startChange/addChange/endChange) and
-  // load() preferredPeer parameter are deferred pending test infrastructure. The
-  // core package has no test harness yet — CollabswarmDocument requires mocking
-  // libp2p, IPFS/Helia, CRDTProvider, AuthProvider, and ACLProvider, which is
-  // non-trivial to set up. See: https://github.com/swarmbase/swarmbase/pull/176
+  // TODO: Unit tests for CollabswarmDocument require mocking libp2p, IPFS/Helia,
+  // and all providers — deferred to integration testing (see e2e/).
 
   /**
    * Start a change transaction. Changes made via `addChange()` will be batched


### PR DESCRIPTION
## Summary

- **Connection reuse:** Document that libp2p v2 dialProtocol already reuses connections; all peers from `getConnections()` are already connected
- **Transaction API:** Add `startChange()`/`addChange()`/`endChange()` for atomic multi-field changes sent as a single sync message, with rollback on failure
- **Smart peer selection:** Extract sender PeerId from pubsub messages and prefer them when falling back to `load()` on decryption failure
- **Key distribution to new readers:** Deferred to BeeKEM Welcome flow — `_distributeKeyUpdate()` encrypts with the existing key that new readers don't possess yet

## Test plan

- [x] Build passes
- [ ] Unit test transaction API: startChange/addChange/endChange flow
- [ ] Test endChange rollback on _makeChange failure
- [ ] Test change() throws during active transaction
- [ ] Verify load() preferred peer moves to front of peer list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a transaction API to batch multiple local edits into a single atomic synchronized operation (start/add/end workflow).
  * Single-edit calls are blocked while a transaction is active to enforce batching and ensure rollback on failures.

* **Improvements**
  * Load now accepts an optional preferred peer and tries peers in prioritized order.
  * Improved recovery on decryption failure by preferring the original sender for retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->