### PR TITLE
Update browser-test example to display ACL info

### DIFF
--- a/examples/browser-test/src/App.tsx
+++ b/examples/browser-test/src/App.tsx
@@ -102,7 +102,10 @@ class App extends React.Component<
       // Serialize each CryptoKey to { fullHex, displayHex }.
       // fullHex is the complete SHA-256 hash used for de-duplication;
       // displayHex is the truncated 8-byte prefix shown in the UI.
-      const serializeKeys = async (keys: CryptoKey[]) => {
+      // Promise.allSettled is ES2020. The tsconfig targets ES5 but includes
+      // "esnext" in `lib`, and CRA's default browserslist polyfills it for
+      // older browsers, so this is safe at runtime.
+      const serializeKeys = async (keys: CryptoKey[], fallbackPrefix: string) => {
         const results = await Promise.allSettled(
           keys.map(async (k) => {
             const raw = await crypto.subtle.exportKey('raw', k);
@@ -123,11 +126,11 @@ class App extends React.Component<
         return results.map((r, index) =>
           r.status === 'fulfilled'
             ? r.value
-            : { fullHex: `<unexportable-${index}>`, displayHex: '<unexportable>' },
+            : { fullHex: `<unexportable-${fallbackPrefix}-${index}>`, displayHex: '<unexportable>' },
         );
       };
-      const writerEntries = await serializeKeys(writers);
-      const allReaderEntries = await serializeKeys(readers);
+      const writerEntries = await serializeKeys(writers, 'writer');
+      const allReaderEntries = await serializeKeys(readers, 'reader');
 
       // Final guard: a newer refresh may have started during serializeKeys.
       if (this._refreshCounters[documentPath] !== thisRefresh) return;
@@ -285,8 +288,10 @@ class App extends React.Component<
                 <button
                   onClick={() => {
                     this.props.onDocumentClose(documentPath);
-                    // Invalidate any in-flight refreshACL calls for this document.
+                    // Invalidate any in-flight refreshACL calls for this document,
+                    // then clean up the counter to avoid leaking entries.
                     this._refreshCounters[documentPath] = (this._refreshCounters[documentPath] ?? 0) + 1;
+                    delete this._refreshCounters[documentPath];
                     this.setState((prev) => {
                       const { [documentPath]: _r, ...remainingReaders } = prev.aclReaders;
                       const { [documentPath]: _w, ...remainingWriters } = prev.aclWriters;


### PR DESCRIPTION
## Summary
- Add ACL reader/writer display to each open document in the browser-test example
- Show truncated key hashes (first 8 bytes) for readability
- Add "Refresh ACL" button to fetch current readers/writers from document

Closes #12

## Test plan
- [ ] Open browser-test, create/open a document
- [ ] Click "Refresh ACL" to see current readers/writers
- [ ] Verify writer list shows the current user's key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-document ACL UI: a "Refresh ACL" button to fetch and display reader and writer lists with short identifiers; unexportable keys are marked.
  * Shows reader/writer counts and short IDs for each open document; closing a document clears its ACL entries.

* **Bug Fixes**
  * Removes duplicate reader IDs that also appear as writers, safely handles missing documents during refresh, and logs failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->