### PR TITLE
Consolidate per-document libp2p stream handlers into shared handler

### DIFF
--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -2580,6 +2580,17 @@ export class CollabswarmDocument<
       const message =
         this._syncMessageSerializer.deserializeSyncMessage(rawContent);
 
+      // Validate that the deserialized message targets this document.
+      // This can happen when a V1-format payload is broadcast to all
+      // registered documents as a fallback (see shared key-update handler).
+      if (message.documentId && message.documentId !== this.documentPath) {
+        console.warn(
+          `Ignoring key-update for wrong document ` +
+          `(${message.documentId} !== ${this.documentPath})`,
+        );
+        return;
+      }
+
       // Verify the sender is an authorized writer.
       if (this._isSigningEnabled()) {
         if (message.signature) {

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -1577,6 +1577,12 @@ export class CollabswarmDocument<
       );
     };
 
+    // Register this document with the swarm BEFORE subscribing to pubsub.
+    // registerDocument() throws on duplicate document paths; doing this first
+    // avoids subscribing to a topic that would then be unsubscribed by close()
+    // on failure, which could disrupt an already-open instance for the same path.
+    this.swarm.registerDocument(this.documentPath, this);
+
     // Subscribe to pubsub topic and register protocol handlers.
     const pubsub = this.swarm.heliaNode.libp2p.services
       .pubsub as PubSubBaseProtocol;
@@ -1590,10 +1596,6 @@ export class CollabswarmDocument<
     // failure, preventing leaked registry entries, protocol handlers, or
     // pubsub subscriptions.
     try {
-    // Register this document with the swarm so incoming V2 protocol requests
-    // are routed here by the shared protocol handlers registered during
-    // Collabswarm.initialize().
-    this.swarm.registerDocument(this.documentPath, this);
 
     // Register GossipSub topic validator for authorization enforcement.
     // When enabled, messages from unauthorized peers are rejected at the
@@ -2384,6 +2386,12 @@ export class CollabswarmDocument<
       ?.map((x) => x.remoteAddr);
 
     const pathBytes = this._encoder.encode(this.documentPath);
+    if (pathBytes.length === 0 || pathBytes.length > 4096) {
+      throw new Error(
+        `Document path "${this.documentPath}" encoded length (${pathBytes.length}) exceeds ` +
+        'the maximum allowed path length (4096 bytes) for the V2 key-update protocol',
+      );
+    }
     const pathHeader = new Uint8Array(4);
     pathHeader[0] = (pathBytes.length >> 24) & 0xff;
     pathHeader[1] = (pathBytes.length >> 16) & 0xff;

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -7,7 +7,7 @@
 
 import { pipe } from 'it-pipe';
 import { Libp2p } from 'libp2p';
-import { Collabswarm } from './collabswarm';
+import { Collabswarm, MAX_DOCUMENT_PATH_LENGTH } from './collabswarm';
 import {
   concatUint8Arrays,
   firstTrue,
@@ -193,6 +193,11 @@ export class CollabswarmDocument<
   // Handler for listening for sync messages on the document topic. Is `undefined` until
   // the document is `.open()`-ed.
   private _pubsubHandler: EventHandler<CustomEvent<Message>> | undefined;
+
+  // Whether this instance has successfully subscribed to the pubsub topic.
+  // Used in close() to avoid unsubscribing when open() failed before subscribing,
+  // which would break other instances listening on the same topic.
+  private _subscribed = false;
 
   // Cached pubsub topic string. Initialized in constructor via _computeTopic()
   // so that callers that invoke _makeChange() before open() (e.g. via load())
@@ -1058,6 +1063,8 @@ export class CollabswarmDocument<
       await stream.sink([assembled] as Iterable<Uint8Array>);
     } catch (err: unknown) {
       console.error(`Error handling doc-load request for ${this.documentPath}:`, err);
+      // Ensure the stream is closed so the requester doesn't hang.
+      try { await stream.sink([] as Iterable<Uint8Array>); } catch { /* already closed */ }
     }
   }
 
@@ -1596,6 +1603,7 @@ export class CollabswarmDocument<
     // addEventListener due to duplicate @libp2p/interface versions in the dependency tree
     pubsub.addEventListener('message', this._pubsubHandler as EventListener);
     pubsub.subscribe(this._topic);
+    this._subscribed = true;
 
     // Register GossipSub topic validator for authorization enforcement.
     // When enabled, messages from unauthorized peers are rejected at the
@@ -1696,7 +1704,14 @@ export class CollabswarmDocument<
     if (this._pubsubHandler) {
       const pubsub = this.swarm.heliaNode.libp2p.services
         .pubsub as PubSubBaseProtocol;
-      pubsub.unsubscribe(topic);
+
+      // Only unsubscribe if this instance actually subscribed. If open()
+      // failed before pubsub.subscribe() completed, unsubscribing here
+      // would remove a subscription belonging to another instance.
+      if (this._subscribed) {
+        pubsub.unsubscribe(topic);
+        this._subscribed = false;
+      }
 
       // Cast required: see addEventListener comment above
       pubsub.removeEventListener('message', this._pubsubHandler as EventListener);
@@ -2386,10 +2401,10 @@ export class CollabswarmDocument<
       ?.map((x) => x.remoteAddr);
 
     const pathBytes = this._encoder.encode(this.documentPath);
-    if (pathBytes.length === 0 || pathBytes.length > 4096) {
+    if (pathBytes.length === 0 || pathBytes.length > MAX_DOCUMENT_PATH_LENGTH) {
       throw new Error(
         `Document path "${this.documentPath}" encoded length (${pathBytes.length}) exceeds ` +
-        'the maximum allowed path length (4096 bytes) for the V2 key-update protocol',
+        `the maximum allowed path length (${MAX_DOCUMENT_PATH_LENGTH} bytes) for the V2 key-update protocol`,
       );
     }
     const pathHeader = new Uint8Array(4);

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -45,7 +45,7 @@ import { Uint8ArrayList } from 'uint8arraylist';
 import { CID } from 'multiformats';
 import { UnixFS, unixfs } from '@helia/unixfs';
 import { PubSubBaseProtocol } from '@libp2p/pubsub';
-import { EventHandler, Message, PeerId } from '@libp2p/interface';
+import { EventHandler, Message, PeerId, StreamHandler } from '@libp2p/interface';
 
 /**
  * Controls what historical data new members receive when joining a document.
@@ -219,6 +219,29 @@ export class CollabswarmDocument<
     return this.swarm.heliaNode.libp2p;
   }
 
+  /**
+   * Per-document V1 protocol ID for doc-load requests.
+   * Legacy peers register and dial this protocol string.
+   */
+  public get protocolLoadV1() {
+    return `${documentLoadV1}${this.documentPath}`;
+  }
+
+  /**
+   * Per-document V1 protocol ID for key-update requests.
+   * Legacy peers register and dial this protocol string.
+   */
+  public get protocolKeyUpdateV1() {
+    return `${documentKeyUpdateV1}${this.documentPath}`;
+  }
+
+  /**
+   * Per-document V1 protocol ID for snapshot-load requests.
+   * Legacy peers register and dial this protocol string.
+   */
+  public get protocolSnapshotLoadV1() {
+    return `${snapshotLoadV1}${this.documentPath}`;
+  }
 
   private heliaFs: UnixFS;
 
@@ -951,6 +974,75 @@ export class CollabswarmDocument<
   }
 
   /**
+   * Registers per-document V1 protocol handlers on libp2p. These handle
+   * incoming requests from legacy peers that dial protocol IDs suffixed
+   * with the document path (e.g., `${documentLoadV1}${documentPath}`).
+   *
+   * @internal
+   */
+  private _registerPerDocumentV1Handlers(): void {
+    // V1 doc-load handler: legacy peers send the same payload format, so we
+    // reuse handleLoadRequestData directly.
+    const v1DocLoadHandler: StreamHandler = ({ stream }) => {
+      pipe(
+        stream.source,
+        async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
+          const assembled = await readUint8Iterable(source);
+          await this.handleLoadRequestData(assembled, stream);
+          return [];
+        },
+      ).catch((err: unknown) => {
+        console.error(`Error in V1 doc-load handler for ${this.documentPath}:`, err);
+      });
+    };
+
+    // V1 snapshot-load handler.
+    const v1SnapshotLoadHandler: StreamHandler = ({ stream }) => {
+      pipe(
+        stream.source,
+        async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
+          const assembled = await readUint8Iterable(source);
+          await this.handleSnapshotLoadRequestData(assembled, stream);
+          return [];
+        },
+      ).catch((err: unknown) => {
+        console.error(`Error in V1 snapshot-load handler for ${this.documentPath}:`, err);
+      });
+    };
+
+    // V1 key-update handler: legacy peers send the raw encrypted payload
+    // WITHOUT a document-path header. Since this handler is per-document,
+    // we already know the target document and pass the payload directly.
+    const v1KeyUpdateHandler: StreamHandler = ({ stream }) => {
+      pipe(
+        stream.source,
+        async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
+          const assembled = await readUint8Iterable(source);
+          await this.handleKeyUpdateRequestData(assembled);
+          return [];
+        },
+      ).catch((err: unknown) => {
+        console.error(`Error in V1 key-update handler for ${this.documentPath}:`, err);
+      });
+    };
+
+    this.libp2p.handle(this.protocolLoadV1, v1DocLoadHandler);
+    this.libp2p.handle(this.protocolSnapshotLoadV1, v1SnapshotLoadHandler);
+    this.libp2p.handle(this.protocolKeyUpdateV1, v1KeyUpdateHandler);
+  }
+
+  /**
+   * Unregisters per-document V1 protocol handlers from libp2p.
+   *
+   * @internal
+   */
+  private async _unregisterPerDocumentV1Handlers(): Promise<void> {
+    await this.libp2p.unhandle(this.protocolLoadV1).catch(() => {});
+    await this.libp2p.unhandle(this.protocolKeyUpdateV1).catch(() => {});
+    await this.libp2p.unhandle(this.protocolSnapshotLoadV1).catch(() => {});
+  }
+
+  /**
    * Handles a doc-load request with pre-read stream data. Called by the
    * shared protocol handler in Collabswarm after reading and routing.
    *
@@ -1441,13 +1533,14 @@ export class CollabswarmDocument<
     // Try snapshot-load first for faster initial sync.
     // If the peer returns an empty response (no snapshot available),
     // fall back to the regular doc-load protocol.
-    // For each protocol, try V2 (shared handler) first, then V1
-    // (per-document handler) for backward compatibility with older peers.
+    // For each protocol, try V2 (shared handler) first, then fall back to
+    // the legacy per-document V1 protocol ID for backward compatibility
+    // with older peers that registered handlers with the document path suffix.
     for (const peer of orderedPeers) {
       try {
         console.log('Trying snapshot-load from peer:', peer.toString());
         const snapshotStream = await this.libp2p.dialProtocol(peer, [
-          snapshotLoadV2, snapshotLoadV1,
+          snapshotLoadV2, this.protocolSnapshotLoadV1,
         ]);
         const loaded = await this._sendLoadRequestAndSync(snapshotStream, serializedRequest);
         if (loaded) return true;
@@ -1459,13 +1552,13 @@ export class CollabswarmDocument<
       try {
         console.log('Trying doc-load from peer:', peer.toString());
         const docStream = await this.libp2p.dialProtocol(peer, [
-          documentLoadV2, documentLoadV1,
+          documentLoadV2, this.protocolLoadV1,
         ]);
         const loaded = await this._sendLoadRequestAndSync(docStream, serializedRequest);
         if (loaded) return true;
       } catch (err) {
         console.warn(
-          `Failed to load document from (${documentLoadV2}/${documentLoadV1}): `,
+          `Failed to load document from (${documentLoadV2}/${this.protocolLoadV1}): `,
           peer.toString(),
           err,
         );
@@ -1589,11 +1682,16 @@ export class CollabswarmDocument<
     pubsub.addEventListener('message', this._pubsubHandler as EventListener);
     pubsub.subscribe(this._topic);
 
-    // Register this document with the swarm so incoming protocol requests
+    // Register this document with the swarm so incoming V2 protocol requests
     // are routed here by the shared protocol handlers registered during
-    // Collabswarm.initialize(). This replaces per-document libp2p.handle()
-    // calls, reducing protocol handler overhead.
+    // Collabswarm.initialize().
     this.swarm.registerDocument(this.documentPath, this);
+
+    // Register per-document V1 protocol handlers for backward compatibility
+    // with legacy peers that dial per-document protocol IDs (e.g.,
+    // `${documentLoadV1}${documentPath}`). These handlers wrap the same
+    // logic used by the shared V2 handlers.
+    this._registerPerDocumentV1Handlers();
 
     // Register GossipSub topic validator for authorization enforcement.
     // When enabled, messages from unauthorized peers are rejected at the
@@ -1706,7 +1804,10 @@ export class CollabswarmDocument<
       gossipsub.topicValidators.delete(topic);
     }
 
-    // Unregister this document from the shared protocol handler registry.
+    // Unregister per-document V1 protocol handlers.
+    await this._unregisterPerDocumentV1Handlers();
+
+    // Unregister this document from the shared V2 protocol handler registry.
     this.swarm.unregisterDocument(this.documentPath);
   }
 
@@ -2370,9 +2471,11 @@ export class CollabswarmDocument<
       throw new Error(`Failed to encrypt key update! Nonce cannot be empty`);
     }
 
-    // Send to all connected peers via the shared key-update protocol.
-    // Prepend a 4-byte big-endian length + UTF-8 document path header
-    // so the shared handler in Collabswarm can route to the correct document.
+    // Send to all connected peers via key-update protocol.
+    // Try V2 (shared handler) first, then fall back to the legacy per-document
+    // V1 protocol ID. The payload format differs:
+    //   V2: 4-byte big-endian path length + UTF-8 path + encrypted payload
+    //   V1 (per-document): encrypted payload only (no path header needed)
     const peers = this.swarm.heliaNode.libp2p
       .getConnections()
       ?.map((x) => x.remoteAddr);
@@ -2384,6 +2487,10 @@ export class CollabswarmDocument<
     pathHeader[2] = (pathBytes.length >> 8) & 0xff;
     pathHeader[3] = pathBytes.length & 0xff;
 
+    // Pre-build both payload formats.
+    const v2Payload = concatUint8Arrays(pathHeader, pathBytes, previousKeyID, nonce, data);
+    const v1Payload = concatUint8Arrays(previousKeyID, nonce, data);
+
     // WARNING: If some peers fail to receive this update, they will be unable
     // to decrypt future messages encrypted with the new key. They will need to
     // perform a fresh document load to recover the keychain state.
@@ -2391,10 +2498,17 @@ export class CollabswarmDocument<
     for (const peer of peers) {
       try {
         const stream = await this.libp2p.dialProtocol(peer, [
-          documentKeyUpdateV2, documentKeyUpdateV1,
+          documentKeyUpdateV2, this.protocolKeyUpdateV1,
         ]);
+        // Check which protocol was negotiated. If the peer selected the
+        // per-document V1 protocol, send the legacy payload without the
+        // document-path header. Otherwise send the V2 payload with header.
+        const negotiatedProtocol = stream.protocol;
+        const payload = negotiatedProtocol === documentKeyUpdateV2
+          ? v2Payload
+          : v1Payload;
         await pipe(
-          [concatUint8Arrays(pathHeader, pathBytes, previousKeyID, nonce, data)],
+          [payload],
           stream.sink,
         );
       } catch (err) {

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -1174,6 +1174,8 @@ export class CollabswarmDocument<
         `Error handling snapshot-load request for ${this.documentPath}:`,
         err,
       );
+      // Ensure the stream is closed so the requester doesn't hang.
+      try { await stream.sink([] as Iterable<Uint8Array>); } catch { /* already closed */ }
     }
   }
 
@@ -1577,25 +1579,23 @@ export class CollabswarmDocument<
       );
     };
 
+    // All registration and subscription steps are inside try/catch so that
+    // close() cleans up any partially-registered state on failure.
+    const pubsub = this.swarm.heliaNode.libp2p.services
+      .pubsub as PubSubBaseProtocol;
+
+    try {
     // Register this document with the swarm BEFORE subscribing to pubsub.
     // registerDocument() throws on duplicate document paths; doing this first
     // avoids subscribing to a topic that would then be unsubscribed by close()
     // on failure, which could disrupt an already-open instance for the same path.
     this.swarm.registerDocument(this.documentPath, this);
 
-    // Subscribe to pubsub topic and register protocol handlers.
-    const pubsub = this.swarm.heliaNode.libp2p.services
-      .pubsub as PubSubBaseProtocol;
+    // Subscribe to pubsub topic.
     // Cast required: EventHandler<CustomEvent<Message>> is incompatible with PubSubBaseProtocol's
     // addEventListener due to duplicate @libp2p/interface versions in the dependency tree
     pubsub.addEventListener('message', this._pubsubHandler as EventListener);
     pubsub.subscribe(this._topic);
-
-    // The remaining setup steps register handlers and state that must be
-    // cleaned up if any step fails. Wrap in try/catch to call close() on
-    // failure, preventing leaked registry entries, protocol handlers, or
-    // pubsub subscriptions.
-    try {
 
     // Register GossipSub topic validator for authorization enforcement.
     // When enabled, messages from unauthorized peers are rejected at the

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -28,7 +28,6 @@ import { CRDTSyncMessage } from './crdt-sync-message';
 import { ChangesSerializer } from './changes-serializer';
 import { SyncMessageSerializer } from './sync-message-serializer';
 import {
-  documentKeyUpdateV1, documentLoadV1, snapshotLoadV1,
   documentKeyUpdateV2, documentLoadV2, snapshotLoadV2,
 } from './wire-protocols';
 import { CRDTSnapshotNode } from './snapshot-node';
@@ -45,7 +44,7 @@ import { Uint8ArrayList } from 'uint8arraylist';
 import { CID } from 'multiformats';
 import { UnixFS, unixfs } from '@helia/unixfs';
 import { PubSubBaseProtocol } from '@libp2p/pubsub';
-import { EventHandler, Message, PeerId, StreamHandler } from '@libp2p/interface';
+import { EventHandler, Message, PeerId } from '@libp2p/interface';
 
 /**
  * Controls what historical data new members receive when joining a document.
@@ -217,30 +216,6 @@ export class CollabswarmDocument<
 
   public get libp2p(): Libp2p {
     return this.swarm.heliaNode.libp2p;
-  }
-
-  /**
-   * Per-document V1 protocol ID for doc-load requests.
-   * Legacy peers register and dial this protocol string.
-   */
-  public get protocolLoadV1() {
-    return `${documentLoadV1}${this.documentPath}`;
-  }
-
-  /**
-   * Per-document V1 protocol ID for key-update requests.
-   * Legacy peers register and dial this protocol string.
-   */
-  public get protocolKeyUpdateV1() {
-    return `${documentKeyUpdateV1}${this.documentPath}`;
-  }
-
-  /**
-   * Per-document V1 protocol ID for snapshot-load requests.
-   * Legacy peers register and dial this protocol string.
-   */
-  public get protocolSnapshotLoadV1() {
-    return `${snapshotLoadV1}${this.documentPath}`;
   }
 
   private heliaFs: UnixFS;
@@ -974,75 +949,6 @@ export class CollabswarmDocument<
   }
 
   /**
-   * Registers per-document V1 protocol handlers on libp2p. These handle
-   * incoming requests from legacy peers that dial protocol IDs suffixed
-   * with the document path (e.g., `${documentLoadV1}${documentPath}`).
-   *
-   * @internal
-   */
-  private _registerPerDocumentV1Handlers(): void {
-    // V1 doc-load handler: legacy peers send the same payload format, so we
-    // reuse handleLoadRequestData directly.
-    const v1DocLoadHandler: StreamHandler = ({ stream }) => {
-      pipe(
-        stream.source,
-        async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
-          const assembled = await readUint8Iterable(source);
-          await this.handleLoadRequestData(assembled, stream);
-          return [];
-        },
-      ).catch((err: unknown) => {
-        console.error(`Error in V1 doc-load handler for ${this.documentPath}:`, err);
-      });
-    };
-
-    // V1 snapshot-load handler.
-    const v1SnapshotLoadHandler: StreamHandler = ({ stream }) => {
-      pipe(
-        stream.source,
-        async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
-          const assembled = await readUint8Iterable(source);
-          await this.handleSnapshotLoadRequestData(assembled, stream);
-          return [];
-        },
-      ).catch((err: unknown) => {
-        console.error(`Error in V1 snapshot-load handler for ${this.documentPath}:`, err);
-      });
-    };
-
-    // V1 key-update handler: legacy peers send the raw encrypted payload
-    // WITHOUT a document-path header. Since this handler is per-document,
-    // we already know the target document and pass the payload directly.
-    const v1KeyUpdateHandler: StreamHandler = ({ stream }) => {
-      pipe(
-        stream.source,
-        async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
-          const assembled = await readUint8Iterable(source);
-          await this.handleKeyUpdateRequestData(assembled);
-          return [];
-        },
-      ).catch((err: unknown) => {
-        console.error(`Error in V1 key-update handler for ${this.documentPath}:`, err);
-      });
-    };
-
-    this.libp2p.handle(this.protocolLoadV1, v1DocLoadHandler);
-    this.libp2p.handle(this.protocolSnapshotLoadV1, v1SnapshotLoadHandler);
-    this.libp2p.handle(this.protocolKeyUpdateV1, v1KeyUpdateHandler);
-  }
-
-  /**
-   * Unregisters per-document V1 protocol handlers from libp2p.
-   *
-   * @internal
-   */
-  private async _unregisterPerDocumentV1Handlers(): Promise<void> {
-    await this.libp2p.unhandle(this.protocolLoadV1).catch(() => {});
-    await this.libp2p.unhandle(this.protocolKeyUpdateV1).catch(() => {});
-    await this.libp2p.unhandle(this.protocolSnapshotLoadV1).catch(() => {});
-  }
-
-  /**
    * Handles a doc-load request with pre-read stream data. Called by the
    * shared protocol handler in Collabswarm after reading and routing.
    *
@@ -1533,14 +1439,11 @@ export class CollabswarmDocument<
     // Try snapshot-load first for faster initial sync.
     // If the peer returns an empty response (no snapshot available),
     // fall back to the regular doc-load protocol.
-    // For each protocol, try V2 (shared handler) first, then fall back to
-    // the legacy per-document V1 protocol ID for backward compatibility
-    // with older peers that registered handlers with the document path suffix.
     for (const peer of orderedPeers) {
       try {
         console.log('Trying snapshot-load from peer:', peer.toString());
         const snapshotStream = await this.libp2p.dialProtocol(peer, [
-          snapshotLoadV2, this.protocolSnapshotLoadV1,
+          snapshotLoadV2,
         ]);
         const loaded = await this._sendLoadRequestAndSync(snapshotStream, serializedRequest);
         if (loaded) return true;
@@ -1552,13 +1455,13 @@ export class CollabswarmDocument<
       try {
         console.log('Trying doc-load from peer:', peer.toString());
         const docStream = await this.libp2p.dialProtocol(peer, [
-          documentLoadV2, this.protocolLoadV1,
+          documentLoadV2,
         ]);
         const loaded = await this._sendLoadRequestAndSync(docStream, serializedRequest);
         if (loaded) return true;
       } catch (err) {
         console.warn(
-          `Failed to load document from (${documentLoadV2}/${this.protocolLoadV1}): `,
+          `Failed to load document via ${documentLoadV2}:`,
           peer.toString(),
           err,
         );
@@ -1692,12 +1595,6 @@ export class CollabswarmDocument<
     // Collabswarm.initialize().
     this.swarm.registerDocument(this.documentPath, this);
 
-    // Register per-document V1 protocol handlers for backward compatibility
-    // with legacy peers that dial per-document protocol IDs (e.g.,
-    // `${documentLoadV1}${documentPath}`). These handlers wrap the same
-    // logic used by the shared V2 handlers.
-    this._registerPerDocumentV1Handlers();
-
     // Register GossipSub topic validator for authorization enforcement.
     // When enabled, messages from unauthorized peers are rejected at the
     // transport layer with a P4 penalty in peer scoring.
@@ -1815,9 +1712,6 @@ export class CollabswarmDocument<
     if (gossipsub?.topicValidators) {
       gossipsub.topicValidators.delete(topic);
     }
-
-    // Unregister per-document V1 protocol handlers.
-    await this._unregisterPerDocumentV1Handlers();
 
     // Unregister this document from the shared V2 protocol handler registry.
     this.swarm.unregisterDocument(this.documentPath);
@@ -2483,11 +2377,8 @@ export class CollabswarmDocument<
       throw new Error(`Failed to encrypt key update! Nonce cannot be empty`);
     }
 
-    // Send to all connected peers via key-update protocol.
-    // Try V2 (shared handler) first, then fall back to the legacy per-document
-    // V1 protocol ID. The payload format differs:
-    //   V2: 4-byte big-endian path length + UTF-8 path + encrypted payload
-    //   V1 (per-document): encrypted payload only (no path header needed)
+    // Send to all connected peers via the V2 key-update protocol.
+    // V2 payload format: 4-byte big-endian path length + UTF-8 path + encrypted payload
     const peers = this.swarm.heliaNode.libp2p
       .getConnections()
       ?.map((x) => x.remoteAddr);
@@ -2499,9 +2390,7 @@ export class CollabswarmDocument<
     pathHeader[2] = (pathBytes.length >> 8) & 0xff;
     pathHeader[3] = pathBytes.length & 0xff;
 
-    // Pre-build both payload formats.
     const v2Payload = concatUint8Arrays(pathHeader, pathBytes, previousKeyID, nonce, data);
-    const v1Payload = concatUint8Arrays(previousKeyID, nonce, data);
 
     // WARNING: If some peers fail to receive this update, they will be unable
     // to decrypt future messages encrypted with the new key. They will need to
@@ -2510,17 +2399,10 @@ export class CollabswarmDocument<
     for (const peer of peers) {
       try {
         const stream = await this.libp2p.dialProtocol(peer, [
-          documentKeyUpdateV2, this.protocolKeyUpdateV1,
+          documentKeyUpdateV2,
         ]);
-        // Check which protocol was negotiated. If the peer selected the
-        // per-document V1 protocol, send the legacy payload without the
-        // document-path header. Otherwise send the V2 payload with header.
-        const negotiatedProtocol = stream.protocol;
-        const payload = negotiatedProtocol === documentKeyUpdateV2
-          ? v2Payload
-          : v1Payload;
         await pipe(
-          [payload],
+          [v2Payload],
           stream.sink,
         );
       } catch (err) {
@@ -2642,7 +2524,7 @@ export class CollabswarmDocument<
       }
     } catch (err: unknown) {
       console.error(
-        `Error handling ${documentKeyUpdateV1} request:`,
+        `Error handling key update request for document ${this.documentPath}:`,
         err,
       );
     }

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -958,19 +958,16 @@ export class CollabswarmDocument<
    * shared protocol handler in Collabswarm after reading and routing.
    *
    * @internal
-   * @param assembledRequest The raw request bytes already read from the stream.
+   * @param message The deserialized load request (already parsed by the shared handler).
    * @param stream The stream object for sending the response.
    */
   public async handleLoadRequestData(
-    assembledRequest: Uint8Array,
+    message: CRDTLoadRequest,
     stream: { sink: (data: Iterable<Uint8Array>) => Promise<void> },
   ): Promise<void> {
     try {
-      const message =
-        this._loadMessageSerializer.deserializeLoadRequest(assembledRequest);
       console.log(
         `received doc-load request for ${this.documentPath}:`,
-        assembledRequest,
         message,
       );
 
@@ -1073,19 +1070,16 @@ export class CollabswarmDocument<
    * the shared protocol handler in Collabswarm after reading and routing.
    *
    * @internal
-   * @param assembledRequest The raw request bytes already read from the stream.
+   * @param message The deserialized load request (already parsed by the shared handler).
    * @param stream The stream object for sending the response.
    */
   public async handleSnapshotLoadRequestData(
-    assembledRequest: Uint8Array,
+    message: CRDTLoadRequest,
     stream: { sink: (data: Iterable<Uint8Array>) => Promise<void> },
   ): Promise<void> {
     try {
-      const message =
-        this._loadMessageSerializer.deserializeLoadRequest(assembledRequest);
       console.log(
         `received snapshot-load request for ${this.documentPath}:`,
-        assembledRequest,
         message,
       );
 
@@ -1731,7 +1725,8 @@ export class CollabswarmDocument<
     }
 
     // Unregister this document from the shared V2 protocol handler registry.
-    this.swarm.unregisterDocument(this.documentPath);
+    // Pass `this` so only this instance is removed (instance-safe).
+    this.swarm.unregisterDocument(this.documentPath, this);
   }
 
   /**

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -1586,92 +1586,91 @@ export class CollabswarmDocument<
       .pubsub as PubSubBaseProtocol;
 
     try {
-    // Register this document with the swarm BEFORE subscribing to pubsub.
-    // registerDocument() throws on duplicate document paths; doing this first
-    // avoids subscribing to a topic that would then be unsubscribed by close()
-    // on failure, which could disrupt an already-open instance for the same path.
-    this.swarm.registerDocument(this.documentPath, this);
+      // Register this document with the swarm BEFORE subscribing to pubsub.
+      // registerDocument() throws on duplicate document paths; doing this first
+      // avoids subscribing to a topic that would then be unsubscribed by close()
+      // on failure, which could disrupt an already-open instance for the same path.
+      this.swarm.registerDocument(this.documentPath, this);
 
-    // Subscribe to pubsub topic.
-    // Cast required: EventHandler<CustomEvent<Message>> is incompatible with PubSubBaseProtocol's
-    // addEventListener due to duplicate @libp2p/interface versions in the dependency tree
-    pubsub.addEventListener('message', this._pubsubHandler as EventListener);
-    pubsub.subscribe(this._topic);
-    this._subscribed = true;
+      // Subscribe to pubsub topic.
+      // Cast required: EventHandler<CustomEvent<Message>> is incompatible with PubSubBaseProtocol's
+      // addEventListener due to duplicate @libp2p/interface versions in the dependency tree
+      pubsub.addEventListener('message', this._pubsubHandler as EventListener);
+      pubsub.subscribe(this._topic);
+      this._subscribed = true;
 
-    // Register GossipSub topic validator for authorization enforcement.
-    // When enabled, messages from unauthorized peers are rejected at the
-    // transport layer with a P4 penalty in peer scoring.
-    // Skip entirely when signing is disabled to avoid unnecessary per-message decryption.
-    if (this.swarm.config?.enableTopicValidators && this._isSigningEnabled()) {
-      const gossipsubService = pubsub as any;
-      if (typeof gossipsubService.topicValidators?.set === 'function') {
-        gossipsubService.topicValidators.set(
-          this._topic,
-          async (
-            _peerIdStr: string,
-            message: { data: Uint8Array },
-          ): Promise<'Accept' | 'Reject' | 'Ignore'> => {
-            try {
-              // Decrypt the message to access the signature.
-              const blockKeyID = message.data.slice(
-                0,
-                this._keychainProvider.keyIDLength,
-              );
-              const blockNonce = message.data.slice(
-                this._keychainProvider.keyIDLength,
-                this._keychainProvider.keyIDLength + this._authProvider.nonceBits,
-              );
-              const blockData = message.data.slice(
-                this._keychainProvider.keyIDLength + this._authProvider.nonceBits,
-              );
-              const rawContent = await this._decryptBlock(
-                blockKeyID,
-                blockNonce,
-                blockData,
-              );
-              if (!rawContent) {
-                // Decryption failed -- key may not be in keychain yet
-                console.warn(`[${this.documentPath}] Topic validator: decryption failed, ignoring message`);
+      // Register GossipSub topic validator for authorization enforcement.
+      // When enabled, messages from unauthorized peers are rejected at the
+      // transport layer with a P4 penalty in peer scoring.
+      // Skip entirely when signing is disabled to avoid unnecessary per-message decryption.
+      if (this.swarm.config?.enableTopicValidators && this._isSigningEnabled()) {
+        const gossipsubService = pubsub as any;
+        if (typeof gossipsubService.topicValidators?.set === 'function') {
+          gossipsubService.topicValidators.set(
+            this._topic,
+            async (
+              _peerIdStr: string,
+              message: { data: Uint8Array },
+            ): Promise<'Accept' | 'Reject' | 'Ignore'> => {
+              try {
+                // Decrypt the message to access the signature.
+                const blockKeyID = message.data.slice(
+                  0,
+                  this._keychainProvider.keyIDLength,
+                );
+                const blockNonce = message.data.slice(
+                  this._keychainProvider.keyIDLength,
+                  this._keychainProvider.keyIDLength + this._authProvider.nonceBits,
+                );
+                const blockData = message.data.slice(
+                  this._keychainProvider.keyIDLength + this._authProvider.nonceBits,
+                );
+                const rawContent = await this._decryptBlock(
+                  blockKeyID,
+                  blockNonce,
+                  blockData,
+                );
+                if (!rawContent) {
+                  // Decryption failed -- key may not be in keychain yet
+                  console.warn(`[${this.documentPath}] Topic validator: decryption failed, ignoring message`);
+                  return 'Ignore';
+                }
+
+                const syncMessage =
+                  this._syncMessageSerializer.deserializeSyncMessage(rawContent);
+
+                if (!syncMessage.signature) {
+                  return 'Reject';
+                }
+
+                const { signature, ...messageWithoutSignature } = syncMessage;
+                const raw =
+                  this._syncMessageSerializer.serializeSyncMessage(
+                    messageWithoutSignature,
+                  );
+
+                // Verify the message was signed by an authorized writer for this document
+                if (await this._verifyWriterSignature(raw, signature)) {
+                  return 'Accept';
+                }
+                return 'Reject';
+              } catch {
+                console.warn(`[${this.documentPath}] Topic validator: unexpected error, ignoring message`);
                 return 'Ignore';
               }
-
-              const syncMessage =
-                this._syncMessageSerializer.deserializeSyncMessage(rawContent);
-
-              if (!syncMessage.signature) {
-                return 'Reject';
-              }
-
-              const { signature, ...messageWithoutSignature } = syncMessage;
-              const raw =
-                this._syncMessageSerializer.serializeSyncMessage(
-                  messageWithoutSignature,
-                );
-
-              // Verify the message was signed by an authorized writer for this document
-              if (await this._verifyWriterSignature(raw, signature)) {
-                return 'Accept';
-              }
-              return 'Reject';
-            } catch {
-              console.warn(`[${this.documentPath}] Topic validator: unexpected error, ignoring message`);
-              return 'Ignore';
-            }
-          },
-        );
+            },
+          );
+        }
       }
-    }
 
-    if (!isExisting) {
-      // Add current user as a writer.
-      await this._writers.add(this._userPublicKey);
+      if (!isExisting) {
+        // Add current user as a writer.
+        await this._writers.add(this._userPublicKey);
 
-      // Add initial document key.
-      console.log(`Adding a key to ${this.documentPath}`);
-      await this._keychain.add();
-    }
-
+        // Add initial document key.
+        console.log(`Adding a key to ${this.documentPath}`);
+        await this._keychain.add();
+      }
     } catch (err) {
       // Clean up any partially-registered state to avoid leaked handlers,
       // subscriptions, or registry entries.

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -1058,7 +1058,7 @@ export class CollabswarmDocument<
       const message =
         this._loadMessageSerializer.deserializeLoadRequest(assembledRequest);
       console.log(
-        `received ${documentLoadV1} request:`,
+        `received doc-load request for ${this.documentPath}:`,
         assembledRequest,
         message,
       );
@@ -1171,7 +1171,7 @@ export class CollabswarmDocument<
       const message =
         this._loadMessageSerializer.deserializeLoadRequest(assembledRequest);
       console.log(
-        `received ${snapshotLoadV1} request:`,
+        `received snapshot-load request for ${this.documentPath}:`,
         assembledRequest,
         message,
       );
@@ -2544,8 +2544,6 @@ export class CollabswarmDocument<
     payload: Uint8Array,
   ): Promise<void> {
     try {
-      console.log(`received ${documentKeyUpdateV1} dial for ${this.documentPath}`);
-
       // Decrypt the key update message.
       const blockKeyID = payload.slice(
         0,
@@ -2612,6 +2610,8 @@ export class CollabswarmDocument<
           return;
         }
       }
+
+      console.log(`received key-update for ${this.documentPath}`);
 
       // Merge keychain changes.
       if (message.keychainChanges) {

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -27,7 +27,10 @@ import {
 import { CRDTSyncMessage } from './crdt-sync-message';
 import { ChangesSerializer } from './changes-serializer';
 import { SyncMessageSerializer } from './sync-message-serializer';
-import { documentKeyUpdateV1, documentLoadV1, snapshotLoadV1 } from './wire-protocols';
+import {
+  documentKeyUpdateV1, documentLoadV1, snapshotLoadV1,
+  documentKeyUpdateV2, documentLoadV2, snapshotLoadV2,
+} from './wire-protocols';
 import { CRDTSnapshotNode } from './snapshot-node';
 import { CompactionConfig, defaultCompactionConfig } from './compaction-config';
 import { documentTopic } from './document-topic';
@@ -951,6 +954,7 @@ export class CollabswarmDocument<
    * Handles a doc-load request with pre-read stream data. Called by the
    * shared protocol handler in Collabswarm after reading and routing.
    *
+   * @internal
    * @param assembledRequest The raw request bytes already read from the stream.
    * @param stream The stream object for sending the response.
    */
@@ -1063,6 +1067,7 @@ export class CollabswarmDocument<
    * Handles a snapshot-load request with pre-read stream data. Called by
    * the shared protocol handler in Collabswarm after reading and routing.
    *
+   * @internal
    * @param assembledRequest The raw request bytes already read from the stream.
    * @param stream The stream object for sending the response.
    */
@@ -1436,11 +1441,13 @@ export class CollabswarmDocument<
     // Try snapshot-load first for faster initial sync.
     // If the peer returns an empty response (no snapshot available),
     // fall back to the regular doc-load protocol.
+    // For each protocol, try V2 (shared handler) first, then V1
+    // (per-document handler) for backward compatibility with older peers.
     for (const peer of orderedPeers) {
       try {
         console.log('Trying snapshot-load from peer:', peer.toString());
         const snapshotStream = await this.libp2p.dialProtocol(peer, [
-          snapshotLoadV1,
+          snapshotLoadV2, snapshotLoadV1,
         ]);
         const loaded = await this._sendLoadRequestAndSync(snapshotStream, serializedRequest);
         if (loaded) return true;
@@ -1452,13 +1459,13 @@ export class CollabswarmDocument<
       try {
         console.log('Trying doc-load from peer:', peer.toString());
         const docStream = await this.libp2p.dialProtocol(peer, [
-          documentLoadV1,
+          documentLoadV2, documentLoadV1,
         ]);
         const loaded = await this._sendLoadRequestAndSync(docStream, serializedRequest);
         if (loaded) return true;
       } catch (err) {
         console.warn(
-          `Failed to load document from (${documentLoadV1}): `,
+          `Failed to load document from (${documentLoadV2}/${documentLoadV1}): `,
           peer.toString(),
           err,
         );
@@ -2384,7 +2391,7 @@ export class CollabswarmDocument<
     for (const peer of peers) {
       try {
         const stream = await this.libp2p.dialProtocol(peer, [
-          documentKeyUpdateV1,
+          documentKeyUpdateV2, documentKeyUpdateV1,
         ]);
         await pipe(
           [concatUint8Arrays(pathHeader, pathBytes, previousKeyID, nonce, data)],
@@ -2411,14 +2418,11 @@ export class CollabswarmDocument<
   }
 
   /**
-   * Handle incoming key-update protocol messages.
-   * Verifies the sender is an authorized writer, then merges the keychain changes.
-   */
-  /**
    * Handles a key-update request with pre-read payload data. Called by
    * the shared protocol handler in Collabswarm after reading the document
    * path header and routing.
    *
+   * @internal
    * @param payload The encrypted key-update payload (without the document
    *   path header that was already stripped by the shared handler).
    */

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -42,7 +42,7 @@ import { Uint8ArrayList } from 'uint8arraylist';
 import { CID } from 'multiformats';
 import { UnixFS, unixfs } from '@helia/unixfs';
 import { PubSubBaseProtocol } from '@libp2p/pubsub';
-import { EventHandler, Message, PeerId, StreamHandler } from '@libp2p/interface';
+import { EventHandler, Message, PeerId } from '@libp2p/interface';
 
 /**
  * Controls what historical data new members receive when joining a document.
@@ -216,22 +216,6 @@ export class CollabswarmDocument<
     return this.swarm.heliaNode.libp2p;
   }
 
-  public get protocolLoadV1() {
-    return `${documentLoadV1}${this.documentPath}`;
-  }
-
-  public get protocolKeyUpdateV1() {
-    return `${documentKeyUpdateV1}${this.documentPath}`;
-  }
-
-  /**
-   * Returns the versioned snapshot-load protocol string for this document.
-   * Used to register and dial the `/collabswarm/snapshot-load/1.0.0` handler
-   * scoped to this document's path.
-   */
-  public get protocolSnapshotLoadV1() {
-    return `${snapshotLoadV1}${this.documentPath}`;
-  }
 
   private heliaFs: UnixFS;
 
@@ -963,224 +947,232 @@ export class CollabswarmDocument<
     );
   }
 
-  private _handleLoadRequest: StreamHandler = ({ stream }) => {
-    console.log(`received ${this.protocolLoadV1} dial`);
-    pipe(
-      stream.source,
-      async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
-        const assembledRequest = await readUint8Iterable(source);
-        const message =
-          this._loadMessageSerializer.deserializeLoadRequest(assembledRequest);
-        console.log(
-          `received ${this.protocolLoadV1} request:`,
-          assembledRequest,
-          message,
-        );
+  /**
+   * Handles a doc-load request with pre-read stream data. Called by the
+   * shared protocol handler in Collabswarm after reading and routing.
+   *
+   * @param assembledRequest The raw request bytes already read from the stream.
+   * @param stream The stream object for sending the response.
+   */
+  public async handleLoadRequestData(
+    assembledRequest: Uint8Array,
+    stream: { sink: (data: Iterable<Uint8Array>) => Promise<void> },
+  ): Promise<void> {
+    try {
+      const message =
+        this._loadMessageSerializer.deserializeLoadRequest(assembledRequest);
+      console.log(
+        `received ${documentLoadV1} request:`,
+        assembledRequest,
+        message,
+      );
 
-        if (message.documentId !== this.documentPath) {
+      if (message.documentId !== this.documentPath) {
+        console.warn(
+          `Received a load request for the wrong document (${message.documentId} !== ${this.documentPath})`,
+        );
+        await stream.sink([] as Iterable<Uint8Array>);
+        return;
+      }
+
+      // Authorize the requestor. When signing is disabled, skip ACL/signature
+      // checks entirely -- any peer is treated as authorized.
+      let authorized = false;
+      if (!this._isSigningEnabled()) {
+        // Bypass: signing disabled, no signature verification needed.
+        authorized = true;
+      } else {
+        if (!message.signature) {
+          // Reject requests with missing/empty signatures (e.g. from peers
+          // that have signing disabled -- they cannot interoperate).
           console.warn(
-            `Received a load request for the wrong document (${message.documentId} !== ${this.documentPath})`,
+            `Rejected load request for ${message.documentId}: missing signature`,
           );
           await stream.sink([] as Iterable<Uint8Array>);
-          return [];
+          return;
         }
-
-        // Authorize the requestor. When signing is disabled, skip ACL/signature
-        // checks entirely -- any peer is treated as authorized.
-        let authorized = false;
-        if (!this._isSigningEnabled()) {
-          // Bypass: signing disabled, no signature verification needed.
-          authorized = true;
-        } else {
-          if (!message.signature) {
-            // Reject requests with missing/empty signatures (e.g. from peers
-            // that have signing disabled -- they cannot interoperate).
-            console.warn(
-              `Rejected load request for ${message.documentId}: missing signature`,
-            );
-            await stream.sink([] as Iterable<Uint8Array>);
-            return [];
-          }
-          const readers = (
-            await Promise.all([this._readers.users(), this._writers.users()])
-          ).flat();
-          for (const reader of readers) {
-            if (
-              await this._authProvider.verify(
-                this._encoder.encode(message.documentId),
-                reader,
-                this._deserializeSignature(message.signature),
-              )
-            ) {
-              authorized = true;
-              break;
-            }
-          }
-        }
-
-        if (!authorized) {
-          console.warn(
-            `Detected an unauthorized load request for ${message.documentId}`,
-          );
-          await stream.sink([] as Iterable<Uint8Array>);
-          return [];
-        }
-
-        // Construct load response based on history visibility setting.
-        const loadMessage = this._createSyncMessage();
-
-        loadMessage.keychainChanges = await this._keychainChangesForVisibility();
-
-        // Include the latest snapshot if available, to accelerate initial sync.
-        if (this._latestSnapshot) {
-          loadMessage.snapshot = this._latestSnapshot;
-        }
-
-        // Sign new message.
-        loadMessage.signature = await this._signAsWriter(loadMessage);
-
-        const serializedLoad =
-          this._syncMessageSerializer.serializeSyncMessage(loadMessage);
-
-        // Encrypt the load response so keychain is not sent in plaintext.
-        // NOTE: This uses the current key, which works for existing peers requesting
-        // a reload (they already have the key). For NEW members being onboarded for
-        // the first time, the key must be delivered out-of-band via BeeKEM Welcome
-        // message -- they cannot decrypt this load response without the key.
-        const [documentKeyID, documentKey] = await this._keychain.current();
-        if (!documentKey) {
-          throw new Error(`Document ${this.documentPath} has an empty keychain!`);
-        }
-        const { nonce, data } = await this._authProvider.encrypt(
-          serializedLoad,
-          documentKey,
-        );
-        if (!nonce) {
-          throw new Error(`Failed to encrypt sync message! Nonce cannot be empty`);
-        }
-        const assembled = concatUint8Arrays(documentKeyID, nonce, data);
-        console.log(
-          `sending ${this.protocolLoadV1} response (encrypted)`,
-        );
-
-        await stream.sink([assembled] as Iterable<Uint8Array>);
-        return [];
-      },
-    ).catch((err: unknown) => {
-      console.error(`Error handling ${this.protocolLoadV1} load request:`, err);
-    });
-  };
-
-  private _handleSnapshotLoadRequest: StreamHandler = ({ stream }) => {
-    console.log(`received ${this.protocolSnapshotLoadV1} dial`);
-    pipe(
-      stream.source,
-      async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
-        const assembledRequest = await readUint8Iterable(source);
-        const message =
-          this._loadMessageSerializer.deserializeLoadRequest(assembledRequest);
-        console.log(
-          `received ${this.protocolSnapshotLoadV1} request:`,
-          assembledRequest,
-          message,
-        );
-
-        if (message.documentId !== this.documentPath) {
-          console.warn(
-            `Received a snapshot load request for the wrong document (${message.documentId} !== ${this.documentPath})`,
-          );
-          await stream.sink([] as Iterable<Uint8Array>);
-          return [];
-        }
-
-        // Authorize the requestor. When signing is disabled, skip ACL/signature
-        // checks entirely -- any peer is treated as authorized.
-        let authorized = false;
-        if (!this._isSigningEnabled()) {
-          // Bypass: signing disabled, no signature verification needed.
-          authorized = true;
-        } else {
-          if (!message.signature) {
-            // Reject requests with missing/empty signatures (e.g. from peers
-            // that have signing disabled -- they cannot interoperate).
-            console.warn(
-              `Rejected snapshot load request for ${message.documentId}: missing signature`,
-            );
-            await stream.sink([] as Iterable<Uint8Array>);
-            return [];
-          }
-          const readers = (
-            await Promise.all([this._readers.users(), this._writers.users()])
-          ).flat();
-          for (const reader of readers) {
-            if (
-              await this._authProvider.verify(
-                this._encoder.encode(message.documentId),
-                reader,
-                this._deserializeSignature(message.signature),
-              )
-            ) {
-              authorized = true;
-              break;
-            }
+        const readers = (
+          await Promise.all([this._readers.users(), this._writers.users()])
+        ).flat();
+        for (const reader of readers) {
+          if (
+            await this._authProvider.verify(
+              this._encoder.encode(message.documentId),
+              reader,
+              this._deserializeSignature(message.signature),
+            )
+          ) {
+            authorized = true;
+            break;
           }
         }
+      }
 
-        if (!authorized) {
+      if (!authorized) {
+        console.warn(
+          `Detected an unauthorized load request for ${message.documentId}`,
+        );
+        await stream.sink([] as Iterable<Uint8Array>);
+        return;
+      }
+
+      // Construct load response based on history visibility setting.
+      const loadMessage = this._createSyncMessage();
+
+      loadMessage.keychainChanges = await this._keychainChangesForVisibility();
+
+      // Include the latest snapshot if available, to accelerate initial sync.
+      if (this._latestSnapshot) {
+        loadMessage.snapshot = this._latestSnapshot;
+      }
+
+      // Sign new message.
+      loadMessage.signature = await this._signAsWriter(loadMessage);
+
+      const serializedLoad =
+        this._syncMessageSerializer.serializeSyncMessage(loadMessage);
+
+      // Encrypt the load response so keychain is not sent in plaintext.
+      // NOTE: This uses the current key, which works for existing peers requesting
+      // a reload (they already have the key). For NEW members being onboarded for
+      // the first time, the key must be delivered out-of-band via BeeKEM Welcome
+      // message -- they cannot decrypt this load response without the key.
+      const [documentKeyID, documentKey] = await this._keychain.current();
+      if (!documentKey) {
+        throw new Error(`Document ${this.documentPath} has an empty keychain!`);
+      }
+      const { nonce, data } = await this._authProvider.encrypt(
+        serializedLoad,
+        documentKey,
+      );
+      if (!nonce) {
+        throw new Error(`Failed to encrypt sync message! Nonce cannot be empty`);
+      }
+      const assembled = concatUint8Arrays(documentKeyID, nonce, data);
+      console.log(
+        `sending ${documentLoadV1} response (encrypted)`,
+      );
+
+      await stream.sink([assembled] as Iterable<Uint8Array>);
+    } catch (err: unknown) {
+      console.error(`Error handling ${documentLoadV1} load request:`, err);
+    }
+  }
+
+  /**
+   * Handles a snapshot-load request with pre-read stream data. Called by
+   * the shared protocol handler in Collabswarm after reading and routing.
+   *
+   * @param assembledRequest The raw request bytes already read from the stream.
+   * @param stream The stream object for sending the response.
+   */
+  public async handleSnapshotLoadRequestData(
+    assembledRequest: Uint8Array,
+    stream: { sink: (data: Iterable<Uint8Array>) => Promise<void> },
+  ): Promise<void> {
+    try {
+      const message =
+        this._loadMessageSerializer.deserializeLoadRequest(assembledRequest);
+      console.log(
+        `received ${snapshotLoadV1} request:`,
+        assembledRequest,
+        message,
+      );
+
+      if (message.documentId !== this.documentPath) {
+        console.warn(
+          `Received a snapshot load request for the wrong document (${message.documentId} !== ${this.documentPath})`,
+        );
+        await stream.sink([] as Iterable<Uint8Array>);
+        return;
+      }
+
+      // Authorize the requestor. When signing is disabled, skip ACL/signature
+      // checks entirely -- any peer is treated as authorized.
+      let authorized = false;
+      if (!this._isSigningEnabled()) {
+        // Bypass: signing disabled, no signature verification needed.
+        authorized = true;
+      } else {
+        if (!message.signature) {
+          // Reject requests with missing/empty signatures (e.g. from peers
+          // that have signing disabled -- they cannot interoperate).
           console.warn(
-            `Detected an unauthorized snapshot load request for ${message.documentId}`,
+            `Rejected snapshot load request for ${message.documentId}: missing signature`,
           );
           await stream.sink([] as Iterable<Uint8Array>);
-          return [];
+          return;
         }
-
-        if (!this._latestSnapshot) {
-          // No snapshot available -- respond with empty payload so the peer
-          // can fall back to the normal doc-load protocol.
-          console.log(
-            `No snapshot available for ${this.documentPath}, sending empty response`,
-          );
-          await stream.sink([] as Iterable<Uint8Array>);
-          return [];
+        const readers = (
+          await Promise.all([this._readers.users(), this._writers.users()])
+        ).flat();
+        for (const reader of readers) {
+          if (
+            await this._authProvider.verify(
+              this._encoder.encode(message.documentId),
+              reader,
+              this._deserializeSignature(message.signature),
+            )
+          ) {
+            authorized = true;
+            break;
+          }
         }
+      }
 
-        // Build a complete sync message with the snapshot, post-snapshot
-        // changes, and keychain so the peer can fully catch up.
-        const snapshotMessage = this._createSyncMessage();
-        snapshotMessage.snapshot = this._latestSnapshot;
-        snapshotMessage.keychainChanges = await this._keychainChangesForVisibility();
-        snapshotMessage.signature = await this._signAsWriter(snapshotMessage);
-
-        const serialized =
-          this._syncMessageSerializer.serializeSyncMessage(snapshotMessage);
-
-        // Encrypt the response.
-        const [documentKeyID, documentKey] = await this._keychain.current();
-        if (!documentKey) {
-          throw new Error(`Document ${this.documentPath} has an empty keychain!`);
-        }
-        const { nonce, data } = await this._authProvider.encrypt(
-          serialized,
-          documentKey,
+      if (!authorized) {
+        console.warn(
+          `Detected an unauthorized snapshot load request for ${message.documentId}`,
         );
-        if (!nonce) {
-          throw new Error(`Failed to encrypt snapshot response! Nonce cannot be empty`);
-        }
-        const assembled = concatUint8Arrays(documentKeyID, nonce, data);
+        await stream.sink([] as Iterable<Uint8Array>);
+        return;
+      }
+
+      if (!this._latestSnapshot) {
+        // No snapshot available -- respond with empty payload so the peer
+        // can fall back to the normal doc-load protocol.
         console.log(
-          `sending ${this.protocolSnapshotLoadV1} response (encrypted)`,
+          `No snapshot available for ${this.documentPath}, sending empty response`,
         );
+        await stream.sink([] as Iterable<Uint8Array>);
+        return;
+      }
 
-        await stream.sink([assembled] as Iterable<Uint8Array>);
-        return [];
-      },
-    ).catch((err: unknown) => {
+      // Build a complete sync message with the snapshot, post-snapshot
+      // changes, and keychain so the peer can fully catch up.
+      const snapshotMessage = this._createSyncMessage();
+      snapshotMessage.snapshot = this._latestSnapshot;
+      snapshotMessage.keychainChanges = await this._keychainChangesForVisibility();
+      snapshotMessage.signature = await this._signAsWriter(snapshotMessage);
+
+      const serialized =
+        this._syncMessageSerializer.serializeSyncMessage(snapshotMessage);
+
+      // Encrypt the response.
+      const [documentKeyID, documentKey] = await this._keychain.current();
+      if (!documentKey) {
+        throw new Error(`Document ${this.documentPath} has an empty keychain!`);
+      }
+      const { nonce, data } = await this._authProvider.encrypt(
+        serialized,
+        documentKey,
+      );
+      if (!nonce) {
+        throw new Error(`Failed to encrypt snapshot response! Nonce cannot be empty`);
+      }
+      const assembled = concatUint8Arrays(documentKeyID, nonce, data);
+      console.log(
+        `sending ${snapshotLoadV1} response (encrypted)`,
+      );
+
+      await stream.sink([assembled] as Iterable<Uint8Array>);
+    } catch (err: unknown) {
       console.error(
-        `Error handling ${this.protocolSnapshotLoadV1} snapshot load request:`,
+        `Error handling ${snapshotLoadV1} snapshot load request:`,
         err,
       );
-    });
-  };
+    }
+  }
 
   /**
    * Build the deterministic binary payload used for snapshot signing/verification.
@@ -1448,7 +1440,7 @@ export class CollabswarmDocument<
       try {
         console.log('Trying snapshot-load from peer:', peer.toString());
         const snapshotStream = await this.libp2p.dialProtocol(peer, [
-          this.protocolSnapshotLoadV1,
+          snapshotLoadV1,
         ]);
         const loaded = await this._sendLoadRequestAndSync(snapshotStream, serializedRequest);
         if (loaded) return true;
@@ -1460,13 +1452,13 @@ export class CollabswarmDocument<
       try {
         console.log('Trying doc-load from peer:', peer.toString());
         const docStream = await this.libp2p.dialProtocol(peer, [
-          this.protocolLoadV1,
+          documentLoadV1,
         ]);
         const loaded = await this._sendLoadRequestAndSync(docStream, serializedRequest);
         if (loaded) return true;
       } catch (err) {
         console.warn(
-          `Failed to load document from (${this.protocolLoadV1}): `,
+          `Failed to load document from (${documentLoadV1}): `,
           peer.toString(),
           err,
         );
@@ -1590,14 +1582,11 @@ export class CollabswarmDocument<
     pubsub.addEventListener('message', this._pubsubHandler as EventListener);
     pubsub.subscribe(this._topic);
 
-    // For now we support multiple protocols, one per document path.
-    // TODO: Consider moving this to a single shared handler in Collabswarm and route messages to the
-    //       right document. This should be more efficient.
-    this.libp2p.handle(this.protocolLoadV1, this._handleLoadRequest.bind(this));
-    this.libp2p.handle(this.protocolKeyUpdateV1, this._handleKeyUpdateRequest.bind(this));
-    // Snapshot-load protocol: load() tries this first for faster initial sync,
-    // falling back to protocolLoadV1 if the peer doesn't support it or has no snapshot.
-    this.libp2p.handle(this.protocolSnapshotLoadV1, this._handleSnapshotLoadRequest.bind(this));
+    // Register this document with the swarm so incoming protocol requests
+    // are routed here by the shared protocol handlers registered during
+    // Collabswarm.initialize(). This replaces per-document libp2p.handle()
+    // calls, reducing protocol handler overhead.
+    this.swarm.registerDocument(this.documentPath, this);
 
     // Register GossipSub topic validator for authorization enforcement.
     // When enabled, messages from unauthorized peers are rejected at the
@@ -1710,10 +1699,8 @@ export class CollabswarmDocument<
       gossipsub.topicValidators.delete(topic);
     }
 
-    // Unregister protocol handlers.
-    await this.libp2p.unhandle(this.protocolLoadV1).catch(() => {});
-    await this.libp2p.unhandle(this.protocolKeyUpdateV1).catch(() => {});
-    await this.libp2p.unhandle(this.protocolSnapshotLoadV1).catch(() => {});
+    // Unregister this document from the shared protocol handler registry.
+    this.swarm.unregisterDocument(this.documentPath);
   }
 
   /**
@@ -2376,10 +2363,19 @@ export class CollabswarmDocument<
       throw new Error(`Failed to encrypt key update! Nonce cannot be empty`);
     }
 
-    // Send to all connected peers via the key-update protocol.
+    // Send to all connected peers via the shared key-update protocol.
+    // Prepend a 4-byte big-endian length + UTF-8 document path header
+    // so the shared handler in Collabswarm can route to the correct document.
     const peers = this.swarm.heliaNode.libp2p
       .getConnections()
       ?.map((x) => x.remoteAddr);
+
+    const pathBytes = new TextEncoder().encode(this.documentPath);
+    const pathHeader = new Uint8Array(4);
+    pathHeader[0] = (pathBytes.length >> 24) & 0xff;
+    pathHeader[1] = (pathBytes.length >> 16) & 0xff;
+    pathHeader[2] = (pathBytes.length >> 8) & 0xff;
+    pathHeader[3] = pathBytes.length & 0xff;
 
     // WARNING: If some peers fail to receive this update, they will be unable
     // to decrypt future messages encrypted with the new key. They will need to
@@ -2388,10 +2384,10 @@ export class CollabswarmDocument<
     for (const peer of peers) {
       try {
         const stream = await this.libp2p.dialProtocol(peer, [
-          this.protocolKeyUpdateV1,
+          documentKeyUpdateV1,
         ]);
         await pipe(
-          [concatUint8Arrays(previousKeyID, nonce, data)],
+          [concatUint8Arrays(pathHeader, pathBytes, previousKeyID, nonce, data)],
           stream.sink,
         );
       } catch (err) {
@@ -2418,92 +2414,96 @@ export class CollabswarmDocument<
    * Handle incoming key-update protocol messages.
    * Verifies the sender is an authorized writer, then merges the keychain changes.
    */
-  private _handleKeyUpdateRequest: StreamHandler = ({ stream }) => {
-    console.log(`received ${this.protocolKeyUpdateV1} dial`);
-    pipe(
-      stream.source,
-      async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
-        const assembled = await readUint8Iterable(source);
+  /**
+   * Handles a key-update request with pre-read payload data. Called by
+   * the shared protocol handler in Collabswarm after reading the document
+   * path header and routing.
+   *
+   * @param payload The encrypted key-update payload (without the document
+   *   path header that was already stripped by the shared handler).
+   */
+  public async handleKeyUpdateRequestData(
+    payload: Uint8Array,
+  ): Promise<void> {
+    try {
+      console.log(`received ${documentKeyUpdateV1} dial for ${this.documentPath}`);
 
-        // Decrypt the key update message.
-        const blockKeyID = assembled.slice(
-          0,
-          this._keychainProvider.keyIDLength,
-        );
-        const blockNonce = assembled.slice(
-          this._keychainProvider.keyIDLength,
-          this._keychainProvider.keyIDLength + this._authProvider.nonceBits,
-        );
-        const blockData = assembled.slice(
-          this._keychainProvider.keyIDLength + this._authProvider.nonceBits,
-        );
+      // Decrypt the key update message.
+      const blockKeyID = payload.slice(
+        0,
+        this._keychainProvider.keyIDLength,
+      );
+      const blockNonce = payload.slice(
+        this._keychainProvider.keyIDLength,
+        this._keychainProvider.keyIDLength + this._authProvider.nonceBits,
+      );
+      const blockData = payload.slice(
+        this._keychainProvider.keyIDLength + this._authProvider.nonceBits,
+      );
 
-        let rawContent: Uint8Array | undefined;
+      let rawContent: Uint8Array | undefined;
+      try {
+        rawContent = await this._decryptBlock(
+          blockKeyID,
+          blockNonce,
+          blockData,
+        );
+      } catch (e) {
+        console.warn('Failed to decrypt key update message:', e);
+      }
+
+      if (!rawContent) {
+        console.warn(
+          `Unable to decrypt key update for ${this.documentPath}`,
+        );
+        return;
+      }
+
+      const message =
+        this._syncMessageSerializer.deserializeSyncMessage(rawContent);
+
+      // Verify the sender is an authorized writer.
+      if (this._isSigningEnabled()) {
+        if (message.signature) {
+          const { signature, ...messageWithoutSignature } = message;
+          const raw =
+            this._syncMessageSerializer.serializeSyncMessage(
+              messageWithoutSignature,
+            );
+          if (!(await this._verifyWriterSignature(raw, signature))) {
+            console.warn(
+              `Received key update with invalid signature for ${this.documentPath}`,
+            );
+            return;
+          }
+        } else {
+          console.warn(
+            `Received unsigned key update for ${this.documentPath}`,
+          );
+          return;
+        }
+      }
+
+      // Merge keychain changes.
+      if (message.keychainChanges) {
         try {
-          rawContent = await this._decryptBlock(
-            blockKeyID,
-            blockNonce,
-            blockData,
+          this._keychain.merge(message.keychainChanges);
+          console.log(
+            `Updated keychain via key-update protocol in ${this.documentPath}`,
           );
         } catch (e) {
-          console.warn('Failed to decrypt key update message:', e);
-        }
-
-        if (!rawContent) {
-          console.warn(
-            `Unable to decrypt key update for ${this.documentPath}`,
+          console.error(
+            'Failed to merge keychain changes from key update:',
+            e,
           );
-          return [];
         }
-
-        const message =
-          this._syncMessageSerializer.deserializeSyncMessage(rawContent);
-
-        // Verify the sender is an authorized writer.
-        if (this._isSigningEnabled()) {
-          if (message.signature) {
-            const { signature, ...messageWithoutSignature } = message;
-            const raw =
-              this._syncMessageSerializer.serializeSyncMessage(
-                messageWithoutSignature,
-              );
-            if (!(await this._verifyWriterSignature(raw, signature))) {
-              console.warn(
-                `Received key update with invalid signature for ${this.documentPath}`,
-              );
-              return [];
-            }
-          } else {
-            console.warn(
-              `Received unsigned key update for ${this.documentPath}`,
-            );
-            return [];
-          }
-        }
-
-        // Merge keychain changes.
-        if (message.keychainChanges) {
-          try {
-            this._keychain.merge(message.keychainChanges);
-            console.log(
-              `Updated keychain via key-update protocol in ${this.documentPath}`,
-            );
-          } catch (e) {
-            console.error(
-              'Failed to merge keychain changes from key update:',
-              e,
-            );
-          }
-        }
-
-        return [];
-      },
-    ).catch((err: unknown) => {
+      }
+    } catch (err: unknown) {
       console.error(
-        `Error handling ${this.protocolKeyUpdateV1} request:`,
+        `Error handling ${documentKeyUpdateV1} request:`,
         err,
       );
-    });
-  };
+    }
+  }
 
 }

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -1146,12 +1146,12 @@ export class CollabswarmDocument<
       }
       const assembled = concatUint8Arrays(documentKeyID, nonce, data);
       console.log(
-        `sending ${documentLoadV1} response (encrypted)`,
+        `sending doc-load response (encrypted) for ${this.documentPath}`,
       );
 
       await stream.sink([assembled] as Iterable<Uint8Array>);
     } catch (err: unknown) {
-      console.error(`Error handling ${documentLoadV1} load request:`, err);
+      console.error(`Error handling doc-load request for ${this.documentPath}:`, err);
     }
   }
 
@@ -1259,13 +1259,13 @@ export class CollabswarmDocument<
       }
       const assembled = concatUint8Arrays(documentKeyID, nonce, data);
       console.log(
-        `sending ${snapshotLoadV1} response (encrypted)`,
+        `sending snapshot-load response (encrypted) for ${this.documentPath}`,
       );
 
       await stream.sink([assembled] as Iterable<Uint8Array>);
     } catch (err: unknown) {
       console.error(
-        `Error handling ${snapshotLoadV1} snapshot load request:`,
+        `Error handling snapshot-load request for ${this.documentPath}:`,
         err,
       );
     }
@@ -1682,6 +1682,11 @@ export class CollabswarmDocument<
     pubsub.addEventListener('message', this._pubsubHandler as EventListener);
     pubsub.subscribe(this._topic);
 
+    // The remaining setup steps register handlers and state that must be
+    // cleaned up if any step fails. Wrap in try/catch to call close() on
+    // failure, preventing leaked registry entries, protocol handlers, or
+    // pubsub subscriptions.
+    try {
     // Register this document with the swarm so incoming V2 protocol requests
     // are routed here by the shared protocol handlers registered during
     // Collabswarm.initialize().
@@ -1764,6 +1769,13 @@ export class CollabswarmDocument<
       // Add initial document key.
       console.log(`Adding a key to ${this.documentPath}`);
       await this._keychain.add();
+    }
+
+    } catch (err) {
+      // Clean up any partially-registered state to avoid leaked handlers,
+      // subscriptions, or registry entries.
+      await this.close().catch(() => {});
+      throw err;
     }
 
     return isExisting;
@@ -2480,7 +2492,7 @@ export class CollabswarmDocument<
       .getConnections()
       ?.map((x) => x.remoteAddr);
 
-    const pathBytes = new TextEncoder().encode(this.documentPath);
+    const pathBytes = this._encoder.encode(this.documentPath);
     const pathHeader = new Uint8Array(4);
     pathHeader[0] = (pathBytes.length >> 24) & 0xff;
     pathHeader[1] = (pathBytes.length >> 16) & 0xff;
@@ -2578,9 +2590,10 @@ export class CollabswarmDocument<
       const message =
         this._syncMessageSerializer.deserializeSyncMessage(rawContent);
 
-      // Validate that the deserialized message targets this document.
-      // This can happen when a V1-format payload is broadcast to all
-      // registered documents as a fallback (see shared key-update handler).
+      // The shared V2 key-update handler already routes by the
+      // length-prefixed document-path header and drops invalid headers;
+      // this check is kept as a defense-in-depth guard against malformed
+      // or misrouted messages.
       if (message.documentId && message.documentId !== this.documentPath) {
         console.warn(
           `Ignoring key-update for wrong document ` +

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -26,7 +26,6 @@ import { ACLProvider } from './acl-provider';
 import { KeychainProvider } from './keychain-provider';
 import { LoadMessageSerializer } from './load-request-serializer';
 import {
-  documentLoadV1, documentKeyUpdateV1, snapshotLoadV1,
   documentLoadV2, documentKeyUpdateV2, snapshotLoadV2,
 } from './wire-protocols';
 import { readUint8Iterable } from './utils';
@@ -205,6 +204,10 @@ export class Collabswarm<
 
     this._config = config;
 
+    // Reset shared handler flag so re-initialization registers handlers on
+    // the new libp2p node instance.
+    this._sharedHandlersRegistered = false;
+
     this._networkStats = config.enableNetworkStats ? new NetworkStats() : undefined;
 
     // Setup Helia node.
@@ -284,7 +287,7 @@ export class Collabswarm<
   }
 
   /**
-   * Registers a single set of protocol handlers on libp2p for all three
+   * Registers V2 shared protocol handlers on libp2p for all three
    * protocols (doc-load, snapshot-load, key-update). Each handler reads
    * the incoming stream, extracts the document path, and routes to the
    * matching CollabswarmDocument instance in the registry.
@@ -293,6 +296,9 @@ export class Collabswarm<
    * deserializing the CRDTLoadRequest from the stream data. For
    * key-update, a 4-byte length-prefixed document path header precedes
    * the encrypted payload.
+   *
+   * V1 backward compatibility is handled by per-document protocol handlers
+   * registered in CollabswarmDocument.open() and unregistered in close().
    */
   private _registerSharedProtocolHandlers(): void {
     if (this._sharedHandlersRegistered) {
@@ -390,18 +396,18 @@ export class Collabswarm<
       });
     };
 
-    // Register V2 (shared) protocol handlers.
+    // Register V2 (shared) protocol handlers. V2 protocol IDs use a single
+    // shared handler for all documents; the document path is extracted from
+    // the stream payload for routing.
+    //
+    // V1 backward compatibility is handled separately: per-document V1
+    // protocol handlers (with the document path suffixed to the protocol ID)
+    // are registered in CollabswarmDocument.open() and unregistered in
+    // CollabswarmDocument.close(). This preserves true interoperability with
+    // legacy peers that dial per-document protocol IDs.
     this.libp2p.handle(documentLoadV2, docLoadHandler);
     this.libp2p.handle(snapshotLoadV2, snapshotLoadHandler);
     this.libp2p.handle(documentKeyUpdateV2, keyUpdateHandler);
-
-    // Also register on V1 protocol IDs for backward compatibility with
-    // peers that have not yet upgraded. V1 peers dial the old per-document
-    // protocol IDs; the shared handler routes via the document path
-    // embedded in the request payload, so the same handler works for both.
-    this.libp2p.handle(documentLoadV1, docLoadHandler);
-    this.libp2p.handle(snapshotLoadV1, snapshotLoadHandler);
-    this.libp2p.handle(documentKeyUpdateV1, keyUpdateHandler);
   }
 
   /**

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -211,6 +211,15 @@ export class Collabswarm<
       );
     }
 
+    // Tear down the previous Helia/libp2p instance if reinitializing,
+    // preventing leaked background resources (connections, timers, etc.).
+    if (this._heliaNode) {
+      try { await this._heliaNode.stop(); } catch { /* best-effort */ }
+      this._heliaNode = undefined;
+      this._peerId = undefined;
+      this._peerIds = [];
+    }
+
     if (!config) {
       config = defaultConfig(defaultBootstrapConfig([]));
     }

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -305,10 +305,19 @@ export class Collabswarm<
   /**
    * Removes a document from the shared handler registry.
    *
+   * Instance-safe: only removes the entry if the registered document
+   * matches the provided reference. This prevents a stale close()
+   * from removing a live document that was re-opened at the same path.
+   *
    * Called by CollabswarmDocument.close().
    */
-  unregisterDocument(documentPath: string): void {
-    this._documentRegistry.delete(documentPath);
+  unregisterDocument(
+    documentPath: string,
+    document: CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>,
+  ): void {
+    if (this._documentRegistry.get(documentPath) === document) {
+      this._documentRegistry.delete(documentPath);
+    }
   }
 
   /**
@@ -360,7 +369,7 @@ export class Collabswarm<
             await stream.sink([] as Iterable<Uint8Array>);
             return [];
           }
-          await doc.handleLoadRequestData(assembled, stream);
+          await doc.handleLoadRequestData(request, stream);
           return [];
         },
       ).catch((err: unknown) => {
@@ -400,7 +409,7 @@ export class Collabswarm<
             await stream.sink([] as Iterable<Uint8Array>);
             return [];
           }
-          await doc.handleSnapshotLoadRequestData(assembled, stream);
+          await doc.handleSnapshotLoadRequestData(request, stream);
           return [];
         },
       ).catch((err: unknown) => {

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -39,7 +39,7 @@ import { PubSubBaseProtocol } from '@libp2p/pubsub';
 import type { Uint8ArrayList } from 'uint8arraylist';
 
 /** Maximum allowed document path length in key-update V2 wire format. */
-const MAX_DOCUMENT_PATH_LENGTH = 4096;
+export const MAX_DOCUMENT_PATH_LENGTH = 4096;
 
 /** Maximum allowed request size for shared protocol handlers (10 MB). */
 const MAX_REQUEST_SIZE = 10 * 1024 * 1024;

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -288,6 +288,8 @@ export class Collabswarm<
    * protocol requests can be routed to it.
    *
    * Called by CollabswarmDocument.open().
+   *
+   * @internal
    */
   registerDocument(
     documentPath: string,
@@ -310,6 +312,8 @@ export class Collabswarm<
    * from removing a live document that was re-opened at the same path.
    *
    * Called by CollabswarmDocument.close().
+   *
+   * @internal
    */
   unregisterDocument(
     documentPath: string,
@@ -425,53 +429,59 @@ export class Collabswarm<
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
-          let assembled: Uint8Array;
           try {
-            assembled = await readUint8Iterable(source, MAX_REQUEST_SIZE);
-          } catch (err) {
-            console.warn('Shared key-update handler: request too large, dropping');
-            return [];
-          }
-          if (assembled.length < 4) {
-            console.warn('Shared key-update handler: message too short');
-            return [];
-          }
-          // Use unsigned right shift (>>> 0) to ensure the path length
-          // is interpreted as an unsigned 32-bit integer.
-          const pathLength =
-            ((assembled[0] << 24) |
-            (assembled[1] << 16) |
-            (assembled[2] << 8) |
-            assembled[3]) >>> 0;
+            let assembled: Uint8Array;
+            try {
+              assembled = await readUint8Iterable(source, MAX_REQUEST_SIZE);
+            } catch (err) {
+              console.warn('Shared key-update handler: request too large, dropping');
+              return [];
+            }
+            if (assembled.length < 4) {
+              console.warn('Shared key-update handler: message too short');
+              return [];
+            }
+            // Use unsigned right shift (>>> 0) to ensure the path length
+            // is interpreted as an unsigned 32-bit integer.
+            const pathLength =
+              ((assembled[0] << 24) |
+              (assembled[1] << 16) |
+              (assembled[2] << 8) |
+              assembled[3]) >>> 0;
 
-          // Validate the path length header. If it looks invalid, treat the
-          // message as malformed, log a warning, and drop it rather than
-          // attempting to interpret it as a legacy (V1) payload.
-          if (
-            pathLength === 0 ||
-            pathLength > MAX_DOCUMENT_PATH_LENGTH ||
-            pathLength + 4 > assembled.length
-          ) {
-            console.warn(
-              'Shared key-update handler: invalid path header (pathLength=' +
-              pathLength + '), dropping message',
-            );
-            return [];
-          }
+            // Validate the path length header. If it looks invalid, treat the
+            // message as malformed, log a warning, and drop it rather than
+            // attempting to interpret it as a legacy (V1) payload.
+            if (
+              pathLength === 0 ||
+              pathLength > MAX_DOCUMENT_PATH_LENGTH ||
+              pathLength + 4 > assembled.length
+            ) {
+              console.warn(
+                'Shared key-update handler: invalid path header (pathLength=' +
+                pathLength + '), dropping message',
+              );
+              return [];
+            }
 
-          const documentPath = new TextDecoder().decode(
-            assembled.slice(4, 4 + pathLength),
-          );
-          const payload = assembled.slice(4 + pathLength);
-          const doc = this._documentRegistry.get(documentPath);
-          if (!doc) {
-            console.warn(
-              `Shared key-update handler: no document registered for "${documentPath}"`,
+            const documentPath = new TextDecoder().decode(
+              assembled.slice(4, 4 + pathLength),
             );
+            const payload = assembled.slice(4 + pathLength);
+            const doc = this._documentRegistry.get(documentPath);
+            if (!doc) {
+              console.warn(
+                `Shared key-update handler: no document registered for "${documentPath}"`,
+              );
+              return [];
+            }
+            await doc.handleKeyUpdateRequestData(payload);
             return [];
+          } finally {
+            // Key-update is fire-and-forget (no response via stream.sink),
+            // but the inbound stream must still be closed to release resources.
+            stream.close?.();
           }
-          await doc.handleKeyUpdateRequestData(payload);
-          return [];
         },
       ).catch((err: unknown) => {
         console.error('Error in shared key-update handler:', err);

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -10,6 +10,7 @@
  *   at least one address to join
  */
 
+import { pipe } from 'it-pipe';
 import { AuthProvider } from './auth-provider';
 import { CRDTProvider } from './crdt-provider';
 import {
@@ -24,6 +25,8 @@ import { ChangesSerializer } from './changes-serializer';
 import { ACLProvider } from './acl-provider';
 import { KeychainProvider } from './keychain-provider';
 import { LoadMessageSerializer } from './load-request-serializer';
+import { documentLoadV1, documentKeyUpdateV1, snapshotLoadV1 } from './wire-protocols';
+import { readUint8Iterable } from './utils';
 import { createHelia, DefaultLibp2pServices } from 'helia';
 import type { Helia } from '@helia/interface';
 import { Libp2p } from 'libp2p';
@@ -31,6 +34,7 @@ import { PeerId } from '@libp2p/interface';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { multiaddr } from '@multiformats/multiaddr';
 import { PubSubBaseProtocol } from '@libp2p/pubsub';
+import { Uint8ArrayList } from 'uint8arraylist';
 
 /**
  * Handler type for peer-connect and peer-disconnect events.
@@ -113,6 +117,14 @@ export class Collabswarm<
   private _peerDisconnectHandlers: Map<string, CollabswarmPeersHandler> =
     new Map<string, CollabswarmPeersHandler>();
   private _networkStats?: NetworkStats;
+
+  // Registry of open documents keyed by document path. Shared protocol
+  // handlers use this to route incoming stream requests to the correct
+  // CollabswarmDocument instance.
+  private _documentRegistry = new Map<
+    string,
+    CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>
+  >();
 
   /**
    * Network statistics tracker. Only available when `enableNetworkStats`
@@ -228,7 +240,135 @@ export class Collabswarm<
       }
     });
     this._peerId = this._heliaNode?.libp2p?.peerId;
+
+    // Register shared protocol handlers that route incoming requests to
+    // the appropriate document via the document registry. This replaces
+    // per-document protocol handler registration, reducing protocol
+    // handler overhead for multi-document applications.
+    this._registerSharedProtocolHandlers();
+
     console.log('Helia node initialized:', this._peerId);
+  }
+
+  /**
+   * Registers a document in the shared handler registry so incoming
+   * protocol requests can be routed to it.
+   *
+   * Called by CollabswarmDocument.open().
+   */
+  registerDocument(
+    documentPath: string,
+    document: CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>,
+  ): void {
+    this._documentRegistry.set(documentPath, document);
+  }
+
+  /**
+   * Removes a document from the shared handler registry.
+   *
+   * Called by CollabswarmDocument.close().
+   */
+  unregisterDocument(documentPath: string): void {
+    this._documentRegistry.delete(documentPath);
+  }
+
+  /**
+   * Registers a single set of protocol handlers on libp2p for all three
+   * protocols (doc-load, snapshot-load, key-update). Each handler reads
+   * the incoming stream, extracts the document path, and routes to the
+   * matching CollabswarmDocument instance in the registry.
+   *
+   * For doc-load and snapshot-load, the document path is extracted by
+   * deserializing the CRDTLoadRequest from the stream data. For
+   * key-update, a 4-byte length-prefixed document path header precedes
+   * the encrypted payload.
+   */
+  private _registerSharedProtocolHandlers(): void {
+    // Shared doc-load handler.
+    this.libp2p.handle(documentLoadV1, ({ stream }) => {
+      pipe(
+        stream.source,
+        async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
+          const assembled = await readUint8Iterable(source);
+          const request = this._loadMessageSerializer.deserializeLoadRequest(assembled);
+          const doc = this._documentRegistry.get(request.documentId);
+          if (!doc) {
+            console.warn(
+              `Shared doc-load handler: no document registered for "${request.documentId}"`,
+            );
+            await stream.sink([] as Iterable<Uint8Array>);
+            return [];
+          }
+          await doc.handleLoadRequestData(assembled, stream);
+          return [];
+        },
+      ).catch((err: unknown) => {
+        console.error('Error in shared doc-load handler:', err);
+      });
+    });
+
+    // Shared snapshot-load handler.
+    this.libp2p.handle(snapshotLoadV1, ({ stream }) => {
+      pipe(
+        stream.source,
+        async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
+          const assembled = await readUint8Iterable(source);
+          const request = this._loadMessageSerializer.deserializeLoadRequest(assembled);
+          const doc = this._documentRegistry.get(request.documentId);
+          if (!doc) {
+            console.warn(
+              `Shared snapshot-load handler: no document registered for "${request.documentId}"`,
+            );
+            await stream.sink([] as Iterable<Uint8Array>);
+            return [];
+          }
+          await doc.handleSnapshotLoadRequestData(assembled, stream);
+          return [];
+        },
+      ).catch((err: unknown) => {
+        console.error('Error in shared snapshot-load handler:', err);
+      });
+    });
+
+    // Shared key-update handler. The stream data is prefixed with a
+    // 4-byte big-endian length followed by the UTF-8 document path.
+    // The remaining bytes are the encrypted key-update payload.
+    this.libp2p.handle(documentKeyUpdateV1, ({ stream }) => {
+      pipe(
+        stream.source,
+        async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
+          const assembled = await readUint8Iterable(source);
+          if (assembled.length < 4) {
+            console.warn('Shared key-update handler: message too short');
+            return [];
+          }
+          const pathLength =
+            (assembled[0] << 24) |
+            (assembled[1] << 16) |
+            (assembled[2] << 8) |
+            assembled[3];
+          if (assembled.length < 4 + pathLength) {
+            console.warn('Shared key-update handler: message shorter than declared path length');
+            return [];
+          }
+          const documentPath = new TextDecoder().decode(
+            assembled.slice(4, 4 + pathLength),
+          );
+          const payload = assembled.slice(4 + pathLength);
+          const doc = this._documentRegistry.get(documentPath);
+          if (!doc) {
+            console.warn(
+              `Shared key-update handler: no document registered for "${documentPath}"`,
+            );
+            return [];
+          }
+          await doc.handleKeyUpdateRequestData(payload);
+          return [];
+        },
+      ).catch((err: unknown) => {
+        console.error('Error in shared key-update handler:', err);
+      });
+    });
   }
 
   /**

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -25,7 +25,10 @@ import { ChangesSerializer } from './changes-serializer';
 import { ACLProvider } from './acl-provider';
 import { KeychainProvider } from './keychain-provider';
 import { LoadMessageSerializer } from './load-request-serializer';
-import { documentLoadV1, documentKeyUpdateV1, snapshotLoadV1 } from './wire-protocols';
+import {
+  documentLoadV1, documentKeyUpdateV1, snapshotLoadV1,
+  documentLoadV2, documentKeyUpdateV2, snapshotLoadV2,
+} from './wire-protocols';
 import { readUint8Iterable } from './utils';
 import { createHelia, DefaultLibp2pServices } from 'helia';
 import type { Helia } from '@helia/interface';
@@ -34,7 +37,7 @@ import { PeerId } from '@libp2p/interface';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { multiaddr } from '@multiformats/multiaddr';
 import { PubSubBaseProtocol } from '@libp2p/pubsub';
-import { Uint8ArrayList } from 'uint8arraylist';
+import type { Uint8ArrayList } from 'uint8arraylist';
 
 /**
  * Handler type for peer-connect and peer-disconnect events.
@@ -117,6 +120,11 @@ export class Collabswarm<
   private _peerDisconnectHandlers: Map<string, CollabswarmPeersHandler> =
     new Map<string, CollabswarmPeersHandler>();
   private _networkStats?: NetworkStats;
+
+  // Whether shared protocol handlers have already been registered via
+  // _registerSharedProtocolHandlers(). Prevents duplicate registration
+  // if initialize() is called more than once.
+  private _sharedHandlersRegistered = false;
 
   // Registry of open documents keyed by document path. Shared protocol
   // handlers use this to route incoming stream requests to the correct
@@ -260,6 +268,9 @@ export class Collabswarm<
     documentPath: string,
     document: CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>,
   ): void {
+    if (this._documentRegistry.has(documentPath)) {
+      console.warn('Overwriting existing document registration:', documentPath);
+    }
     this._documentRegistry.set(documentPath, document);
   }
 
@@ -284,8 +295,14 @@ export class Collabswarm<
    * the encrypted payload.
    */
   private _registerSharedProtocolHandlers(): void {
-    // Shared doc-load handler.
-    this.libp2p.handle(documentLoadV1, ({ stream }) => {
+    if (this._sharedHandlersRegistered) {
+      return;
+    }
+    this._sharedHandlersRegistered = true;
+
+    // Handler implementation for doc-load requests. Used by both V2
+    // (shared) and V1 (per-document fallback) protocol registrations.
+    const docLoadHandler = ({ stream }: { stream: any }) => {
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
@@ -305,10 +322,10 @@ export class Collabswarm<
       ).catch((err: unknown) => {
         console.error('Error in shared doc-load handler:', err);
       });
-    });
+    };
 
-    // Shared snapshot-load handler.
-    this.libp2p.handle(snapshotLoadV1, ({ stream }) => {
+    // Handler implementation for snapshot-load requests.
+    const snapshotLoadHandler = ({ stream }: { stream: any }) => {
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
@@ -328,12 +345,13 @@ export class Collabswarm<
       ).catch((err: unknown) => {
         console.error('Error in shared snapshot-load handler:', err);
       });
-    });
+    };
 
-    // Shared key-update handler. The stream data is prefixed with a
-    // 4-byte big-endian length followed by the UTF-8 document path.
-    // The remaining bytes are the encrypted key-update payload.
-    this.libp2p.handle(documentKeyUpdateV1, ({ stream }) => {
+    // Handler implementation for key-update requests. The stream data
+    // is prefixed with a 4-byte big-endian length followed by the
+    // UTF-8 document path. The remaining bytes are the encrypted
+    // key-update payload.
+    const keyUpdateHandler = ({ stream }: { stream: any }) => {
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
@@ -342,11 +360,13 @@ export class Collabswarm<
             console.warn('Shared key-update handler: message too short');
             return [];
           }
+          // Use unsigned right shift (>>> 0) to ensure the path length
+          // is interpreted as an unsigned 32-bit integer.
           const pathLength =
-            (assembled[0] << 24) |
+            ((assembled[0] << 24) |
             (assembled[1] << 16) |
             (assembled[2] << 8) |
-            assembled[3];
+            assembled[3]) >>> 0;
           if (assembled.length < 4 + pathLength) {
             console.warn('Shared key-update handler: message shorter than declared path length');
             return [];
@@ -368,7 +388,20 @@ export class Collabswarm<
       ).catch((err: unknown) => {
         console.error('Error in shared key-update handler:', err);
       });
-    });
+    };
+
+    // Register V2 (shared) protocol handlers.
+    this.libp2p.handle(documentLoadV2, docLoadHandler);
+    this.libp2p.handle(snapshotLoadV2, snapshotLoadHandler);
+    this.libp2p.handle(documentKeyUpdateV2, keyUpdateHandler);
+
+    // Also register on V1 protocol IDs for backward compatibility with
+    // peers that have not yet upgraded. V1 peers dial the old per-document
+    // protocol IDs; the shared handler routes via the document path
+    // embedded in the request payload, so the same handler works for both.
+    this.libp2p.handle(documentLoadV1, docLoadHandler);
+    this.libp2p.handle(snapshotLoadV1, snapshotLoadHandler);
+    this.libp2p.handle(documentKeyUpdateV1, keyUpdateHandler);
   }
 
   /**

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -44,6 +44,13 @@ export const MAX_DOCUMENT_PATH_LENGTH = 4096;
 /** Maximum allowed request size for shared protocol handlers (10 MB). */
 const MAX_REQUEST_SIZE = 10 * 1024 * 1024;
 
+/** Minimal stream shape used by shared protocol handlers. */
+interface ProtocolStream {
+  source: AsyncIterable<Uint8ArrayList | Uint8Array>;
+  sink: (data: Iterable<Uint8Array>) => Promise<void>;
+  close?: () => void | Promise<void>;
+}
+
 /**
  * Handler type for peer-connect and peer-disconnect events.
  *
@@ -342,7 +349,7 @@ export class Collabswarm<
     this._sharedHandlersRegistered = true;
 
     // Handler implementation for doc-load requests.
-    const docLoadHandler = ({ stream }: { stream: any }) => {
+    const docLoadHandler = ({ stream }: { stream: ProtocolStream }) => {
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
@@ -350,7 +357,8 @@ export class Collabswarm<
           try {
             assembled = await readUint8Iterable(source, MAX_REQUEST_SIZE);
           } catch (err) {
-            console.warn('Shared doc-load handler: request too large, dropping');
+            const reason = err instanceof RangeError ? 'request too large' : 'failed to read request';
+            console.warn(`Shared doc-load handler: ${reason}, dropping`);
             await stream.sink([] as Iterable<Uint8Array>);
             return [];
           }
@@ -382,7 +390,7 @@ export class Collabswarm<
     };
 
     // Handler implementation for snapshot-load requests.
-    const snapshotLoadHandler = ({ stream }: { stream: any }) => {
+    const snapshotLoadHandler = ({ stream }: { stream: ProtocolStream }) => {
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
@@ -390,7 +398,8 @@ export class Collabswarm<
           try {
             assembled = await readUint8Iterable(source, MAX_REQUEST_SIZE);
           } catch (err) {
-            console.warn('Shared snapshot-load handler: request too large, dropping');
+            const reason = err instanceof RangeError ? 'request too large' : 'failed to read request';
+            console.warn(`Shared snapshot-load handler: ${reason}, dropping`);
             await stream.sink([] as Iterable<Uint8Array>);
             return [];
           }
@@ -425,7 +434,7 @@ export class Collabswarm<
     // is prefixed with a 4-byte big-endian length followed by the
     // UTF-8 document path. The remaining bytes are the encrypted
     // key-update payload.
-    const keyUpdateHandler = ({ stream }: { stream: any }) => {
+    const keyUpdateHandler = ({ stream }: { stream: ProtocolStream }) => {
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
@@ -434,7 +443,8 @@ export class Collabswarm<
             try {
               assembled = await readUint8Iterable(source, MAX_REQUEST_SIZE);
             } catch (err) {
-              console.warn('Shared key-update handler: request too large, dropping');
+              const reason = err instanceof RangeError ? 'request too large' : 'failed to read request';
+              console.warn(`Shared key-update handler: ${reason}, dropping`);
               return [];
             }
             if (assembled.length < 4) {

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -38,6 +38,12 @@ import { multiaddr } from '@multiformats/multiaddr';
 import { PubSubBaseProtocol } from '@libp2p/pubsub';
 import type { Uint8ArrayList } from 'uint8arraylist';
 
+/** Maximum allowed document path length in key-update V2 wire format. */
+const MAX_DOCUMENT_PATH_LENGTH = 4096;
+
+/** Maximum allowed request size for shared protocol handlers (10 MB). */
+const MAX_REQUEST_SIZE = 10 * 1024 * 1024;
+
 /**
  * Handler type for peer-connect and peer-disconnect events.
  *
@@ -297,7 +303,7 @@ export class Collabswarm<
   }
 
   /**
-   * Registers V2 shared protocol handlers on libp2p for all three
+   * Registers shared protocol handlers on libp2p for all three
    * protocols (doc-load, snapshot-load, key-update). Each handler reads
    * the incoming stream, extracts the document path, and routes to the
    * matching CollabswarmDocument instance in the registry.
@@ -306,9 +312,6 @@ export class Collabswarm<
    * deserializing the CRDTLoadRequest from the stream data. For
    * key-update, a 4-byte length-prefixed document path header precedes
    * the encrypted payload.
-   *
-   * V1 backward compatibility is handled by per-document protocol handlers
-   * registered in CollabswarmDocument.open() and unregistered in close().
    */
   private _registerSharedProtocolHandlers(): void {
     if (this._sharedHandlersRegistered) {
@@ -316,14 +319,18 @@ export class Collabswarm<
     }
     this._sharedHandlersRegistered = true;
 
-    // Handler implementation for doc-load requests used by the V2
-    // shared protocol registration. V1 per-document handlers are
-    // registered in CollabswarmDocument.open().
+    // Handler implementation for doc-load requests.
     const docLoadHandler = ({ stream }: { stream: any }) => {
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
           const assembled = await readUint8Iterable(source);
+          if (assembled.length > MAX_REQUEST_SIZE) {
+            console.warn(
+              `Shared doc-load handler: request too large (${assembled.length} bytes), dropping`,
+            );
+            return [];
+          }
           const request = this._loadMessageSerializer.deserializeLoadRequest(assembled);
           const doc = this._documentRegistry.get(request.documentId);
           if (!doc) {
@@ -347,6 +354,12 @@ export class Collabswarm<
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
           const assembled = await readUint8Iterable(source);
+          if (assembled.length > MAX_REQUEST_SIZE) {
+            console.warn(
+              `Shared snapshot-load handler: request too large (${assembled.length} bytes), dropping`,
+            );
+            return [];
+          }
           const request = this._loadMessageSerializer.deserializeLoadRequest(assembled);
           const doc = this._documentRegistry.get(request.documentId);
           if (!doc) {
@@ -373,6 +386,12 @@ export class Collabswarm<
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
           const assembled = await readUint8Iterable(source);
+          if (assembled.length > MAX_REQUEST_SIZE) {
+            console.warn(
+              `Shared key-update handler: request too large (${assembled.length} bytes), dropping`,
+            );
+            return [];
+          }
           if (assembled.length < 4) {
             console.warn('Shared key-update handler: message too short');
             return [];
@@ -385,12 +404,12 @@ export class Collabswarm<
             (assembled[2] << 8) |
             assembled[3]) >>> 0;
 
-          // Validate the path length header. If it looks invalid, this may
-          // be a V1-format payload (no path header). Fall back to
-          // deserializing the message to extract the documentId.
+          // Validate the path length header. If it looks invalid, treat the
+          // message as malformed, log a warning, and drop it rather than
+          // attempting to interpret it as a legacy (V1) payload.
           if (
             pathLength === 0 ||
-            pathLength >= 4096 ||
+            pathLength >= MAX_DOCUMENT_PATH_LENGTH ||
             pathLength + 4 > assembled.length
           ) {
             console.warn(
@@ -419,19 +438,9 @@ export class Collabswarm<
       });
     };
 
-    // Register V2 (shared) protocol handlers. V2 protocol IDs use a single
-    // shared handler for all documents; the document path is extracted from
-    // the stream payload for routing.
-    //
-    // Per-document V1 protocol handlers (with the document path appended to
-    // the protocol ID, e.g. "/collabswarm/doc-load/1.0.0/my-doc") are
-    // registered in CollabswarmDocument.open() and unregistered in close().
-    // These exist for peers that still dial the per-document V1 protocol
-    // strings, rather than the shared V2 protocol IDs defined in
-    // wire-protocols.ts. The shared key-update handler is intentionally not
-    // registered on the base V1 key-update protocol ID to avoid triggering
-    // fallback behavior across all open documents when peers dial
-    // an un-suffixed key-update protocol.
+    // Register shared protocol handlers. Each protocol ID uses a single
+    // handler for all documents; the document path is extracted from the
+    // stream payload for routing.
     this.libp2p.handle(documentLoadV2, docLoadHandler);
     this.libp2p.handle(snapshotLoadV2, snapshotLoadHandler);
     this.libp2p.handle(documentKeyUpdateV2, keyUpdateHandler);

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -316,8 +316,9 @@ export class Collabswarm<
     }
     this._sharedHandlersRegistered = true;
 
-    // Handler implementation for doc-load requests. Used by both V2
-    // (shared) and V1 (per-document fallback) protocol registrations.
+    // Handler implementation for doc-load requests used by the V2
+    // shared protocol registration. V1 per-document handlers are
+    // registered in CollabswarmDocument.open().
     const docLoadHandler = ({ stream }: { stream: any }) => {
       pipe(
         stream.source,

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -26,7 +26,6 @@ import { ACLProvider } from './acl-provider';
 import { KeychainProvider } from './keychain-provider';
 import { LoadMessageSerializer } from './load-request-serializer';
 import {
-  documentKeyUpdateV1,
   documentLoadV2, documentKeyUpdateV2, snapshotLoadV2,
 } from './wire-protocols';
 import { readUint8Iterable } from './utils';
@@ -395,14 +394,8 @@ export class Collabswarm<
           ) {
             console.warn(
               'Shared key-update handler: invalid path header (pathLength=' +
-              pathLength + '), treating as V1 format',
+              pathLength + '), dropping message',
             );
-            // V1 fallback: the entire payload is the encrypted key-update
-            // message. Try every registered document to see if one can
-            // decrypt and process it.
-            for (const [, doc] of this._documentRegistry) {
-              await doc.handleKeyUpdateRequestData(assembled);
-            }
             return [];
           }
 
@@ -433,16 +426,14 @@ export class Collabswarm<
     // the protocol ID, e.g. "/collabswarm/doc-load/1.0.0/my-doc") are
     // registered in CollabswarmDocument.open() and unregistered in close().
     // These exist for peers that still dial the per-document V1 protocol
-    // strings -- not the base V1 protocol IDs defined in wire-protocols.ts.
-    // The key-update shared handler also includes a V1-format fallback for
-    // payloads that lack a valid document-path header.
+    // strings, rather than the shared V2 protocol IDs defined in
+    // wire-protocols.ts. The shared key-update handler is intentionally not
+    // registered on the base V1 key-update protocol ID to avoid triggering
+    // fallback behavior across all open documents when peers dial
+    // an un-suffixed key-update protocol.
     this.libp2p.handle(documentLoadV2, docLoadHandler);
     this.libp2p.handle(snapshotLoadV2, snapshotLoadHandler);
     this.libp2p.handle(documentKeyUpdateV2, keyUpdateHandler);
-    // Also register on the base V1 key-update protocol ID so that peers
-    // dialing the un-suffixed V1 protocol are handled. The handler's
-    // V1-format fallback will process these payloads (no path header).
-    this.libp2p.handle(documentKeyUpdateV1, keyUpdateHandler);
   }
 
   /**

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -324,14 +324,25 @@ export class Collabswarm<
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
-          const assembled = await readUint8Iterable(source);
-          if (assembled.length > MAX_REQUEST_SIZE) {
-            console.warn(
-              `Shared doc-load handler: request too large (${assembled.length} bytes), dropping`,
-            );
+          let assembled: Uint8Array;
+          try {
+            assembled = await readUint8Iterable(source, MAX_REQUEST_SIZE);
+          } catch (err) {
+            console.warn('Shared doc-load handler: request too large, dropping');
+            await stream.sink([] as Iterable<Uint8Array>);
             return [];
           }
-          const request = this._loadMessageSerializer.deserializeLoadRequest(assembled);
+          let request;
+          try {
+            request = this._loadMessageSerializer.deserializeLoadRequest(assembled);
+          } catch (err) {
+            console.warn(
+              'Shared doc-load handler: failed to deserialize load request, dropping:',
+              err,
+            );
+            await stream.sink([] as Iterable<Uint8Array>);
+            return [];
+          }
           const doc = this._documentRegistry.get(request.documentId);
           if (!doc) {
             console.warn(
@@ -353,14 +364,25 @@ export class Collabswarm<
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
-          const assembled = await readUint8Iterable(source);
-          if (assembled.length > MAX_REQUEST_SIZE) {
-            console.warn(
-              `Shared snapshot-load handler: request too large (${assembled.length} bytes), dropping`,
-            );
+          let assembled: Uint8Array;
+          try {
+            assembled = await readUint8Iterable(source, MAX_REQUEST_SIZE);
+          } catch (err) {
+            console.warn('Shared snapshot-load handler: request too large, dropping');
+            await stream.sink([] as Iterable<Uint8Array>);
             return [];
           }
-          const request = this._loadMessageSerializer.deserializeLoadRequest(assembled);
+          let request;
+          try {
+            request = this._loadMessageSerializer.deserializeLoadRequest(assembled);
+          } catch (err) {
+            console.warn(
+              'Shared snapshot-load handler: failed to deserialize load request, dropping:',
+              err,
+            );
+            await stream.sink([] as Iterable<Uint8Array>);
+            return [];
+          }
           const doc = this._documentRegistry.get(request.documentId);
           if (!doc) {
             console.warn(
@@ -385,11 +407,11 @@ export class Collabswarm<
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
-          const assembled = await readUint8Iterable(source);
-          if (assembled.length > MAX_REQUEST_SIZE) {
-            console.warn(
-              `Shared key-update handler: request too large (${assembled.length} bytes), dropping`,
-            );
+          let assembled: Uint8Array;
+          try {
+            assembled = await readUint8Iterable(source, MAX_REQUEST_SIZE);
+          } catch (err) {
+            console.warn('Shared key-update handler: request too large, dropping');
             return [];
           }
           if (assembled.length < 4) {
@@ -409,7 +431,7 @@ export class Collabswarm<
           // attempting to interpret it as a legacy (V1) payload.
           if (
             pathLength === 0 ||
-            pathLength >= MAX_DOCUMENT_PATH_LENGTH ||
+            pathLength > MAX_DOCUMENT_PATH_LENGTH ||
             pathLength + 4 > assembled.length
           ) {
             console.warn(

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -26,6 +26,7 @@ import { ACLProvider } from './acl-provider';
 import { KeychainProvider } from './keychain-provider';
 import { LoadMessageSerializer } from './load-request-serializer';
 import {
+  documentKeyUpdateV1,
   documentLoadV2, documentKeyUpdateV2, snapshotLoadV2,
 } from './wire-protocols';
 import { readUint8Iterable } from './utils';
@@ -198,6 +199,13 @@ export class Collabswarm<
    * @param config General settings for collabswarm.
    */
   public async initialize(config?: CollabswarmConfig) {
+    if (this._documentRegistry.size > 0) {
+      throw new Error(
+        'Cannot reinitialize while documents are open. ' +
+        'Close all documents before calling initialize() again.',
+      );
+    }
+
     if (!config) {
       config = defaultConfig(defaultBootstrapConfig([]));
     }
@@ -272,7 +280,10 @@ export class Collabswarm<
     document: CollabswarmDocument<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>,
   ): void {
     if (this._documentRegistry.has(documentPath)) {
-      console.warn('Overwriting existing document registration:', documentPath);
+      throw new Error(
+        `A document is already registered for "${documentPath}". ` +
+        'Multiple instances per path are not supported. Close the existing document first.',
+      );
     }
     this._documentRegistry.set(documentPath, document);
   }
@@ -373,10 +384,28 @@ export class Collabswarm<
             (assembled[1] << 16) |
             (assembled[2] << 8) |
             assembled[3]) >>> 0;
-          if (assembled.length < 4 + pathLength) {
-            console.warn('Shared key-update handler: message shorter than declared path length');
+
+          // Validate the path length header. If it looks invalid, this may
+          // be a V1-format payload (no path header). Fall back to
+          // deserializing the message to extract the documentId.
+          if (
+            pathLength === 0 ||
+            pathLength >= 4096 ||
+            pathLength + 4 > assembled.length
+          ) {
+            console.warn(
+              'Shared key-update handler: invalid path header (pathLength=' +
+              pathLength + '), treating as V1 format',
+            );
+            // V1 fallback: the entire payload is the encrypted key-update
+            // message. Try every registered document to see if one can
+            // decrypt and process it.
+            for (const [, doc] of this._documentRegistry) {
+              await doc.handleKeyUpdateRequestData(assembled);
+            }
             return [];
           }
+
           const documentPath = new TextDecoder().decode(
             assembled.slice(4, 4 + pathLength),
           );
@@ -400,14 +429,20 @@ export class Collabswarm<
     // shared handler for all documents; the document path is extracted from
     // the stream payload for routing.
     //
-    // V1 backward compatibility is handled separately: per-document V1
-    // protocol handlers (with the document path suffixed to the protocol ID)
-    // are registered in CollabswarmDocument.open() and unregistered in
-    // CollabswarmDocument.close(). This preserves true interoperability with
-    // legacy peers that dial per-document protocol IDs.
+    // Per-document V1 protocol handlers (with the document path appended to
+    // the protocol ID, e.g. "/collabswarm/doc-load/1.0.0/my-doc") are
+    // registered in CollabswarmDocument.open() and unregistered in close().
+    // These exist for peers that still dial the per-document V1 protocol
+    // strings -- not the base V1 protocol IDs defined in wire-protocols.ts.
+    // The key-update shared handler also includes a V1-format fallback for
+    // payloads that lack a valid document-path header.
     this.libp2p.handle(documentLoadV2, docLoadHandler);
     this.libp2p.handle(snapshotLoadV2, snapshotLoadHandler);
     this.libp2p.handle(documentKeyUpdateV2, keyUpdateHandler);
+    // Also register on the base V1 key-update protocol ID so that peers
+    // dialing the un-suffixed V1 protocol are handled. The handler's
+    // V1-format fallback will process these payloads (no path header).
+    this.libp2p.handle(documentKeyUpdateV1, keyUpdateHandler);
   }
 
   /**

--- a/packages/collabswarm/src/utils.test.ts
+++ b/packages/collabswarm/src/utils.test.ts
@@ -183,6 +183,46 @@ describe('readUint8Iterable', () => {
     expect(result).toEqual(new Uint8Array([]));
     expect(result.length).toBe(0);
   });
+
+  describe('maxSize enforcement', () => {
+    test('throws RangeError when stream exceeds maxSize', async () => {
+      const chunks = [
+        new Uint8Array([1, 2, 3]),
+        new Uint8Array([4, 5, 6]),
+      ];
+      await expect(
+        readUint8Iterable(toAsyncIterable(chunks), 5),
+      ).rejects.toThrow(RangeError);
+    });
+
+    test('succeeds when stream is exactly at maxSize', async () => {
+      const chunks = [
+        new Uint8Array([1, 2, 3]),
+        new Uint8Array([4, 5]),
+      ];
+      const result = await readUint8Iterable(toAsyncIterable(chunks), 5);
+      expect(result).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
+    });
+
+    test('succeeds when stream is under maxSize', async () => {
+      const chunks = [new Uint8Array([1, 2])];
+      const result = await readUint8Iterable(toAsyncIterable(chunks), 100);
+      expect(result).toEqual(new Uint8Array([1, 2]));
+    });
+
+    test('throws on first chunk exceeding maxSize', async () => {
+      const chunks = [new Uint8Array(1000)];
+      await expect(
+        readUint8Iterable(toAsyncIterable(chunks), 10),
+      ).rejects.toThrow(/exceeded maximum allowed size/);
+    });
+
+    test('no limit when maxSize is undefined', async () => {
+      const chunks = [new Uint8Array(1000)];
+      const result = await readUint8Iterable(toAsyncIterable(chunks));
+      expect(result.length).toBe(1000);
+    });
+  });
 });
 
 describe('crypto key utilities', () => {

--- a/packages/collabswarm/src/utils.ts
+++ b/packages/collabswarm/src/utils.ts
@@ -36,6 +36,7 @@ export function isBufferList(input: Uint8Array | Uint8ArrayList | BufferList): i
 
 export async function readUint8Iterable(
   iterable: AsyncIterable<Uint8Array | Uint8ArrayList | BufferList>,
+  maxSize?: number,
 ): Promise<Uint8Array> {
   let length = 0;
   const chunks = [] as (Uint8Array | Uint8ArrayList | BufferList)[];
@@ -43,6 +44,11 @@ export async function readUint8Iterable(
     if (chunk) {
       chunks.push(chunk);
       length += chunk.length;
+      if (maxSize !== undefined && length > maxSize) {
+        throw new RangeError(
+          `Stream exceeded maximum allowed size of ${maxSize} bytes`,
+        );
+      }
     }
   }
 

--- a/packages/collabswarm/src/wire-protocols.ts
+++ b/packages/collabswarm/src/wire-protocols.ts
@@ -3,15 +3,12 @@ export const documentKeyUpdateV1 = '/collabswarm/key-update/1.0.0';
 export const bloomFilterUpdateV1 = '/collabswarm/bloom-index/1.0.0';
 export const snapshotLoadV1 = '/collabswarm/snapshot-load/1.0.0';
 
-// V2 protocol IDs use a shared handler model where the document path is
-// included in the stream payload. V1 protocol IDs register per-document
-// handlers (protocol ID is suffixed with the document path).
-//
-// For doc-load and snapshot-load, V1 and V2 share the same request wire
-// format; the version bump only signals that the handler is shared across
-// all documents. For key-update, V2 prepends a 4-byte big-endian length +
-// UTF-8 document-path header to the encrypted payload for shared routing;
-// V1 sends the encrypted payload without this header.
+// V2 protocol IDs use a shared handler model where a single handler serves
+// all documents; V1 protocol IDs register per-document handlers (protocol
+// ID is suffixed with the document path). For doc-load and snapshot-load,
+// V1 and V2 share the same request wire format; the version bump only
+// signals that the handler is shared across all documents. For key-update,
+// V2 prepends a length-prefixed document-path header for shared routing.
 export const documentLoadV2 = '/collabswarm/doc-load/2.0.0';
 export const documentKeyUpdateV2 = '/collabswarm/key-update/2.0.0';
 export const snapshotLoadV2 = '/collabswarm/snapshot-load/2.0.0';

--- a/packages/collabswarm/src/wire-protocols.ts
+++ b/packages/collabswarm/src/wire-protocols.ts
@@ -2,3 +2,11 @@ export const documentLoadV1 = '/collabswarm/doc-load/1.0.0';
 export const documentKeyUpdateV1 = '/collabswarm/key-update/1.0.0';
 export const bloomFilterUpdateV1 = '/collabswarm/bloom-index/1.0.0';
 export const snapshotLoadV1 = '/collabswarm/snapshot-load/1.0.0';
+
+// V2 protocol IDs use a shared handler model where the document path is
+// included in the stream payload. V1 protocol IDs registered per-document
+// handlers. Both versions use the same wire format; the version bump signals
+// that the handler is shared across all documents.
+export const documentLoadV2 = '/collabswarm/doc-load/2.0.0';
+export const documentKeyUpdateV2 = '/collabswarm/key-update/2.0.0';
+export const snapshotLoadV2 = '/collabswarm/snapshot-load/2.0.0';

--- a/packages/collabswarm/src/wire-protocols.ts
+++ b/packages/collabswarm/src/wire-protocols.ts
@@ -4,9 +4,14 @@ export const bloomFilterUpdateV1 = '/collabswarm/bloom-index/1.0.0';
 export const snapshotLoadV1 = '/collabswarm/snapshot-load/1.0.0';
 
 // V2 protocol IDs use a shared handler model where the document path is
-// included in the stream payload. V1 protocol IDs registered per-document
-// handlers. Both versions use the same wire format; the version bump signals
-// that the handler is shared across all documents.
+// included in the stream payload. V1 protocol IDs register per-document
+// handlers (protocol ID is suffixed with the document path).
+//
+// For doc-load and snapshot-load, V1 and V2 share the same request wire
+// format; the version bump only signals that the handler is shared across
+// all documents. For key-update, V2 prepends a 4-byte big-endian length +
+// UTF-8 document-path header to the encrypted payload for shared routing;
+// V1 sends the encrypted payload without this header.
 export const documentLoadV2 = '/collabswarm/doc-load/2.0.0';
 export const documentKeyUpdateV2 = '/collabswarm/key-update/2.0.0';
 export const snapshotLoadV2 = '/collabswarm/snapshot-load/2.0.0';


### PR DESCRIPTION
## Summary
- Move protocol handler registration from `CollabswarmDocument.open()` to `Collabswarm.initialize()`, replacing per-document `libp2p.handle()` calls with a single set of shared handlers
- Add document registry (`Map<string, CollabswarmDocument>`) in `Collabswarm` class with `registerDocument()`/`unregisterDocument()` methods for routing incoming requests
- For doc-load and snapshot-load protocols, route by deserializing the `CRDTLoadRequest` to extract `documentId`
- For key-update protocol, prepend a 4-byte length-prefixed document path header so the shared handler can route before decryption
- Refactor document handlers into public methods accepting pre-read data (`handleLoadRequestData`, `handleSnapshotLoadRequestData`, `handleKeyUpdateRequestData`)
- Update dialers to use base protocol IDs instead of per-document suffixed ones
- Reduces protocol handler overhead for multi-document applications (3 handlers total instead of 3 per document)

Fixes #181.

## Test plan
- [x] TypeScript compiles cleanly (`yarn workspace @collabswarm/collabswarm tsc`)
- [x] All 242 existing tests pass (`yarn workspace @collabswarm/collabswarm test`)
- [x] Dependent package `@collabswarm/collabswarm-yjs` compiles cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added V2 document, snapshot, and key-update protocols and centralized document registration/lookup.

* **Refactor**
  * Shared, routed request handlers with lifecycle guards and single-point protocol registration.

* **Bug Fixes**
  * Stronger request validation (IDs, path length, size limits), improved key-update validation/merge and optional signature checks, and better error logging/handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->