### PR TITLE
Add /document/ prefix to pubsub topic paths

### DIFF
--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -87,10 +87,16 @@ export interface CollabswarmConfig {
   /**
    * Prefix to apply to document pubsub topics.
    *
-   * Defaults to `''` (empty string) so that topic strings are the bare
-   * document path -- backward-compatible with nodes that do not use this
-   * prefix. Set to `'/document/'` (or any other prefix) to namespace
-   * document traffic on the pubsub mesh.
+   * An empty string (`''`) means no prefix is applied and topic strings
+   * are the bare document path. This is the default for backward
+   * compatibility with existing deployments that were created before
+   * topic prefixing was introduced.
+   *
+   * For new deployments, `'/document/'` is the recommended prefix to
+   * clearly namespace document traffic on the pubsub mesh and avoid
+   * collisions with other topic types.
+   *
+   * @default ''
    */
   pubsubDocumentPrefix: string;
 

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -17,6 +17,7 @@ import { bitswap } from '@helia/block-brokers';
 import { IDBDatastore } from 'datastore-idb';
 import { IDBBlockstore } from 'blockstore-idb';
 import { CompactionConfig } from './compaction-config';
+import { DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 
 /**
  * Default collabswarm config to use if none is provided.
@@ -70,7 +71,7 @@ export const defaultConfig = (bootstrapConfig: BootstrapInit) =>
       },
     },
 
-    pubsubDocumentPrefix: '/document/',
+    pubsubDocumentPrefix: DEFAULT_DOCUMENT_TOPIC_PREFIX,
     pubsubDocumentPublishPath: '/documents',
   // Cast required: libp2p sub-dependency types have version mismatches that prevent structural compatibility
   } as unknown as CollabswarmConfig);
@@ -87,13 +88,13 @@ export interface CollabswarmConfig {
   /**
    * Prefix to apply to document pubsub topics.
    *
-   * Defaults to `'/document/'` to namespace document traffic on the
-   * pubsub mesh and avoid collisions with other topic types.
+   * Defaults to {@link DEFAULT_DOCUMENT_TOPIC_PREFIX} to namespace document
+   * traffic on the pubsub mesh and avoid collisions with other topic types.
    *
    * Set to an empty string (`''`) to disable prefixing; topic strings
    * will be the bare document path (legacy behavior).
    *
-   * @default '/document/'
+   * @default DEFAULT_DOCUMENT_TOPIC_PREFIX
    */
   pubsubDocumentPrefix: string;
 

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -70,7 +70,7 @@ export const defaultConfig = (bootstrapConfig: BootstrapInit) =>
       },
     },
 
-    pubsubDocumentPrefix: '/document/',
+    pubsubDocumentPrefix: '',
     pubsubDocumentPublishPath: '/documents',
   // Cast required: libp2p sub-dependency types have version mismatches that prevent structural compatibility
   } as unknown as CollabswarmConfig);
@@ -85,7 +85,12 @@ export interface CollabswarmConfig {
   helia?: HeliaInit;
 
   /**
-   * Prefix to apply to newly created documents.
+   * Prefix to apply to document pubsub topics.
+   *
+   * Defaults to `''` (empty string) so that topic strings are the bare
+   * document path -- backward-compatible with nodes that do not use this
+   * prefix. Set to `'/document/'` (or any other prefix) to namespace
+   * document traffic on the pubsub mesh.
    */
   pubsubDocumentPrefix: string;
 

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -70,7 +70,7 @@ export const defaultConfig = (bootstrapConfig: BootstrapInit) =>
       },
     },
 
-    pubsubDocumentPrefix: '',
+    pubsubDocumentPrefix: '/document/',
     pubsubDocumentPublishPath: '/documents',
   // Cast required: libp2p sub-dependency types have version mismatches that prevent structural compatibility
   } as unknown as CollabswarmConfig);
@@ -87,16 +87,13 @@ export interface CollabswarmConfig {
   /**
    * Prefix to apply to document pubsub topics.
    *
-   * An empty string (`''`) means no prefix is applied and topic strings
-   * are the bare document path. This is the default for backward
-   * compatibility with existing deployments that were created before
-   * topic prefixing was introduced.
+   * Defaults to `'/document/'` to namespace document traffic on the
+   * pubsub mesh and avoid collisions with other topic types.
    *
-   * For new deployments, `'/document/'` is the recommended prefix to
-   * clearly namespace document traffic on the pubsub mesh and avoid
-   * collisions with other topic types.
+   * Set to an empty string (`''`) to disable prefixing; topic strings
+   * will be the bare document path (legacy behavior).
    *
-   * @default ''
+   * @default '/document/'
    */
   pubsubDocumentPrefix: string;
 

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -710,12 +710,6 @@ export class CollabswarmDocument<
     changes: ChangesType,
     kind: CRDTChangeNodeKind = crdtDocumentChangeNode,
   ) {
-    // Ensure we have a valid topic. Normally set in open(), but guard
-    // against callers that reach this path before open() completes.
-    if (!this._topic) {
-      this._topic = this._computeTopic();
-    }
-
     // Store changes in blockstore.
     const hash = await this._putBlock(changes);
     this._hashes.add(hash);
@@ -1546,9 +1540,14 @@ export class CollabswarmDocument<
 
     // For backward compatibility during rollout, also subscribe to the legacy
     // (unprefixed) topic so we receive messages from peers that haven't upgraded.
+    // However, when topic validators are enabled, we avoid subscribing to the
+    // legacy topic so that all messages must pass through the validated,
+    // prefixed topic.
     if (this._topic !== this.documentPath) {
       this._legacyTopic = this.documentPath;
-      pubsub.subscribe(this._legacyTopic);
+      if (!this.swarm.config?.enableTopicValidators) {
+        pubsub.subscribe(this._legacyTopic);
+      }
     }
 
     // For now we support multiple protocols, one per document path.

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -30,6 +30,7 @@ import { SyncMessageSerializer } from './sync-message-serializer';
 import { documentKeyUpdateV1, documentLoadV1, snapshotLoadV1 } from './wire-protocols';
 import { CRDTSnapshotNode } from './snapshot-node';
 import { CompactionConfig, defaultCompactionConfig } from './compaction-config';
+import { documentTopic } from './document-topic';
 import { ACLProvider } from './acl-provider';
 import { KeychainProvider } from './keychain-provider';
 import { LoadMessageSerializer } from './load-request-serializer';
@@ -318,6 +319,15 @@ export class CollabswarmDocument<
   }
 
   // Helpers ------------------------------------------------------------------
+
+  /**
+   * Returns the pubsub topic for this document by applying the configured
+   * prefix (defaults to `/document/`) to the document path.
+   */
+  private get _topic(): string {
+    const prefix = this.swarm.config?.pubsubDocumentPrefix ?? '/document/';
+    return documentTopic(this.documentPath, prefix);
+  }
 
   private async _shuffledPeers() {
     const peers = this.swarm.heliaNode.libp2p
@@ -717,7 +727,7 @@ export class CollabswarmDocument<
       throw new Error(`Failed to encrypt sync message! Nonce cannot be empty`);
     }
     await this.swarm.heliaNode.libp2p.services.pubsub.publish(
-      this.documentPath,
+      this._topic,
       concatUint8Arrays(documentKeyID, nonce, data),
     );
 
@@ -1504,7 +1514,7 @@ export class CollabswarmDocument<
     // Cast required: EventHandler<CustomEvent<Message>> is incompatible with PubSubBaseProtocol's
     // addEventListener due to duplicate @libp2p/interface versions in the dependency tree
     pubsub.addEventListener('message', this._pubsubHandler as EventListener);
-    pubsub.subscribe(this.documentPath);
+    pubsub.subscribe(this._topic);
 
     // For now we support multiple protocols, one per document path.
     // TODO: Consider moving this to a single shared handler in Collabswarm and route messages to the
@@ -1523,7 +1533,7 @@ export class CollabswarmDocument<
       const gossipsubService = pubsub as any;
       if (typeof gossipsubService.topicValidators?.set === 'function') {
         gossipsubService.topicValidators.set(
-          this.documentPath,
+          this._topic,
           async (
             _peerIdStr: string,
             message: { data: Uint8Array },
@@ -1604,7 +1614,7 @@ export class CollabswarmDocument<
     if (this._pubsubHandler) {
       const pubsub = this.swarm.heliaNode.libp2p.services
         .pubsub as PubSubBaseProtocol;
-      pubsub.unsubscribe(this.documentPath);
+      pubsub.unsubscribe(this._topic);
       // Cast required: see addEventListener comment above
       pubsub.removeEventListener('message', this._pubsubHandler as EventListener);
 
@@ -1613,13 +1623,13 @@ export class CollabswarmDocument<
       // and ensures cleanup regardless of config changes between open() and close().
       const gossipsubService = pubsub as any;
       if (typeof gossipsubService.topicValidators?.delete === 'function') {
-        gossipsubService.topicValidators.delete(this.documentPath);
+        gossipsubService.topicValidators.delete(this._topic);
       }
     }
     // Remove topicValidators entry if one was registered during open().
     const gossipsub = this.swarm.libp2p?.services?.pubsub as any;
     if (gossipsub?.topicValidators) {
-      gossipsub.topicValidators.delete(this.documentPath);
+      gossipsub.topicValidators.delete(this._topic);
     }
 
     // Unregister protocol handlers.

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -194,9 +194,10 @@ export class CollabswarmDocument<
   // the document is `.open()`-ed.
   private _pubsubHandler: EventHandler<CustomEvent<Message>> | undefined;
 
-  // Cached pubsub topic string, set once in open() to ensure consistency
-  // between subscribe and unsubscribe even if config changes at runtime.
-  private _topic: string = '';
+  // Cached pubsub topic string. Initialized to the bare documentPath so that
+  // callers that invoke _makeChange() before open() (e.g. via load()) publish
+  // to a valid topic. open() recomputes this with the configured prefix.
+  private _topic: string;
 
   // Transaction state for batching multiple changes atomically.
   private _pendingChangeFns: ChangeFnType[] = [];
@@ -320,6 +321,11 @@ export class CollabswarmDocument<
       ...defaultCompactionConfig,
       ...(this.swarm.config?.compaction ?? {}),
     };
+
+    // Provide a valid default topic so that _makeChange() works even before
+    // open() is called (e.g. when load() triggers a change). open() will
+    // recompute this with the configured prefix.
+    this._topic = this._computeTopic();
   }
 
   // Helpers ------------------------------------------------------------------

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -1540,12 +1540,12 @@ export class CollabswarmDocument<
 
     // For backward compatibility during rollout, also subscribe to the legacy
     // (unprefixed) topic so we receive messages from peers that haven't upgraded.
-    // However, when topic validators are enabled, we avoid subscribing to the
-    // legacy topic so that all messages must pass through the validated,
-    // prefixed topic.
+    // However, when topic validators are active (enabled in config AND signing
+    // is enabled), skip the legacy topic so all messages pass through the
+    // validated prefixed topic.
     if (this._topic !== this.documentPath) {
       this._legacyTopic = this.documentPath;
-      if (!this.swarm.config?.enableTopicValidators) {
+      if (!(this.swarm.config?.enableTopicValidators && this._isSigningEnabled())) {
         pubsub.subscribe(this._legacyTopic);
       }
     }

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -194,10 +194,15 @@ export class CollabswarmDocument<
   // the document is `.open()`-ed.
   private _pubsubHandler: EventHandler<CustomEvent<Message>> | undefined;
 
-  // Cached pubsub topic string. Initialized to the bare documentPath so that
-  // callers that invoke _makeChange() before open() (e.g. via load()) publish
-  // to a valid topic. open() recomputes this with the configured prefix.
+  // Cached pubsub topic string. Initialized in constructor via _computeTopic()
+  // so that callers that invoke _makeChange() before open() (e.g. via load())
+  // publish to a valid topic. open() recomputes this with the configured prefix.
   private _topic: string;
+
+  // When the prefixed topic differs from the bare documentPath, we also
+  // subscribe to the legacy (unprefixed) topic for backward compatibility
+  // during rollout. This field is set in open() and used in close().
+  private _legacyTopic: string | undefined;
 
   // Transaction state for batching multiple changes atomically.
   private _pendingChangeFns: ChangeFnType[] = [];
@@ -337,7 +342,9 @@ export class CollabswarmDocument<
    */
   private _computeTopic(): string {
     const prefix = this.swarm.config?.pubsubDocumentPrefix;
-    return documentTopic(this.documentPath, prefix);
+    return prefix !== undefined
+      ? documentTopic(this.documentPath, prefix)
+      : documentTopic(this.documentPath);
   }
 
   private async _shuffledPeers() {
@@ -703,6 +710,12 @@ export class CollabswarmDocument<
     changes: ChangesType,
     kind: CRDTChangeNodeKind = crdtDocumentChangeNode,
   ) {
+    // Ensure we have a valid topic. Normally set in open(), but guard
+    // against callers that reach this path before open() completes.
+    if (!this._topic) {
+      this._topic = this._computeTopic();
+    }
+
     // Store changes in blockstore.
     const hash = await this._putBlock(changes);
     this._hashes.add(hash);
@@ -1531,6 +1544,13 @@ export class CollabswarmDocument<
     pubsub.addEventListener('message', this._pubsubHandler as EventListener);
     pubsub.subscribe(this._topic);
 
+    // For backward compatibility during rollout, also subscribe to the legacy
+    // (unprefixed) topic so we receive messages from peers that haven't upgraded.
+    if (this._topic !== this.documentPath) {
+      this._legacyTopic = this.documentPath;
+      pubsub.subscribe(this._legacyTopic);
+    }
+
     // For now we support multiple protocols, one per document path.
     // TODO: Consider moving this to a single shared handler in Collabswarm and route messages to the
     //       right document. This should be more efficient.
@@ -1626,10 +1646,20 @@ export class CollabswarmDocument<
    * breaking any other instance using the same path.
    */
   public async close() {
+    // Compute the topic to clean up. Prefer the cached value, but fall back
+    // to computing it so cleanup works even if _topic was never set.
+    const topic = this._topic || this._computeTopic();
+
     if (this._pubsubHandler) {
       const pubsub = this.swarm.heliaNode.libp2p.services
         .pubsub as PubSubBaseProtocol;
-      pubsub.unsubscribe(this._topic);
+      pubsub.unsubscribe(topic);
+
+      // Unsubscribe from the legacy (unprefixed) topic if we subscribed to it.
+      if (this._legacyTopic) {
+        pubsub.unsubscribe(this._legacyTopic);
+      }
+
       // Cast required: see addEventListener comment above
       pubsub.removeEventListener('message', this._pubsubHandler as EventListener);
 
@@ -1638,14 +1668,16 @@ export class CollabswarmDocument<
       // and ensures cleanup regardless of config changes between open() and close().
       const gossipsubService = pubsub as any;
       if (typeof gossipsubService.topicValidators?.delete === 'function') {
-        gossipsubService.topicValidators.delete(this._topic);
+        gossipsubService.topicValidators.delete(topic);
       }
     }
     // Remove topicValidators entry if one was registered during open().
     const gossipsub = this.swarm.libp2p?.services?.pubsub as any;
     if (gossipsub?.topicValidators) {
-      gossipsub.topicValidators.delete(this._topic);
+      gossipsub.topicValidators.delete(topic);
     }
+
+    this._legacyTopic = undefined;
 
     // Unregister protocol handlers.
     await this.libp2p.unhandle(this.protocolLoadV1).catch(() => {});

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -194,6 +194,10 @@ export class CollabswarmDocument<
   // the document is `.open()`-ed.
   private _pubsubHandler: EventHandler<CustomEvent<Message>> | undefined;
 
+  // Cached pubsub topic string, set once in open() to ensure consistency
+  // between subscribe and unsubscribe even if config changes at runtime.
+  private _topic: string = '';
+
   // Transaction state for batching multiple changes atomically.
   private _pendingChangeFns: ChangeFnType[] = [];
   private _inTransaction = false;
@@ -321,11 +325,12 @@ export class CollabswarmDocument<
   // Helpers ------------------------------------------------------------------
 
   /**
-   * Returns the pubsub topic for this document by applying the configured
-   * prefix (defaults to `/document/`) to the document path.
+   * Computes the pubsub topic for this document by applying the configured
+   * prefix to the document path. Called once in open() to populate the
+   * cached _topic field.
    */
-  private get _topic(): string {
-    const prefix = this.swarm.config?.pubsubDocumentPrefix ?? '/document/';
+  private _computeTopic(): string {
+    const prefix = this.swarm.config?.pubsubDocumentPrefix;
     return documentTopic(this.documentPath, prefix);
   }
 
@@ -1448,6 +1453,10 @@ export class CollabswarmDocument<
    *   registering protocol handlers, so no cleanup is needed on rejection.
    */
   public async open(): Promise<boolean> {
+    // Cache the topic once so that subscribe and unsubscribe always target
+    // the same string, even if config.pubsubDocumentPrefix changes later.
+    this._topic = this._computeTopic();
+
     // Load initial document from peers via direct dial (no subscription needed).
     const isExisting = await this.load();
 

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -199,11 +199,6 @@ export class CollabswarmDocument<
   // publish to a valid topic. open() recomputes this with the configured prefix.
   private _topic: string;
 
-  // When the prefixed topic differs from the bare documentPath, we also
-  // subscribe to the legacy (unprefixed) topic for backward compatibility
-  // during rollout. This field is set in open() and used in close().
-  private _legacyTopic: string | undefined;
-
   // Transaction state for batching multiple changes atomically.
   private _pendingChangeFns: ChangeFnType[] = [];
   private _inTransaction = false;
@@ -1538,18 +1533,6 @@ export class CollabswarmDocument<
     pubsub.addEventListener('message', this._pubsubHandler as EventListener);
     pubsub.subscribe(this._topic);
 
-    // For backward compatibility during rollout, also subscribe to the legacy
-    // (unprefixed) topic so we receive messages from peers that haven't upgraded.
-    // However, when topic validators are active (enabled in config AND signing
-    // is enabled), skip the legacy topic so all messages pass through the
-    // validated prefixed topic.
-    if (this._topic !== this.documentPath) {
-      this._legacyTopic = this.documentPath;
-      if (!(this.swarm.config?.enableTopicValidators && this._isSigningEnabled())) {
-        pubsub.subscribe(this._legacyTopic);
-      }
-    }
-
     // For now we support multiple protocols, one per document path.
     // TODO: Consider moving this to a single shared handler in Collabswarm and route messages to the
     //       right document. This should be more efficient.
@@ -1647,17 +1630,12 @@ export class CollabswarmDocument<
   public async close() {
     // Compute the topic to clean up. Prefer the cached value, but fall back
     // to computing it so cleanup works even if _topic was never set.
-    const topic = this._topic || this._computeTopic();
+    const topic = this._topic ?? this._computeTopic();
 
     if (this._pubsubHandler) {
       const pubsub = this.swarm.heliaNode.libp2p.services
         .pubsub as PubSubBaseProtocol;
       pubsub.unsubscribe(topic);
-
-      // Unsubscribe from the legacy (unprefixed) topic if we subscribed to it.
-      if (this._legacyTopic) {
-        pubsub.unsubscribe(this._legacyTopic);
-      }
 
       // Cast required: see addEventListener comment above
       pubsub.removeEventListener('message', this._pubsubHandler as EventListener);
@@ -1675,8 +1653,6 @@ export class CollabswarmDocument<
     if (gossipsub?.topicValidators) {
       gossipsub.topicValidators.delete(topic);
     }
-
-    this._legacyTopic = undefined;
 
     // Unregister protocol handlers.
     await this.libp2p.unhandle(this.protocolLoadV1).catch(() => {});

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -1628,9 +1628,8 @@ export class CollabswarmDocument<
    * breaking any other instance using the same path.
    */
   public async close() {
-    // Compute the topic to clean up. Prefer the cached value, but fall back
-    // to computing it so cleanup works even if _topic was never set.
-    const topic = this._topic ?? this._computeTopic();
+    // Use the cached topic for cleanup; it is initialized in the constructor.
+    const topic = this._topic;
 
     if (this._pubsubHandler) {
       const pubsub = this.swarm.heliaNode.libp2p.services

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -274,7 +274,6 @@ export class CollabswarmNode<
     );
 
     // Open a pubsub channel (set by some config) for controlling this swarm of listeners.
-    // TODO: Add a '/document/<id>' prefix to all "normal" document paths.
     this._docPublishHandler = (rawMessage) => {
       try {
         const thisNodeId = this.swarm.peerId.toString();

--- a/packages/collabswarm/src/document-topic.test.ts
+++ b/packages/collabswarm/src/document-topic.test.ts
@@ -2,20 +2,24 @@ import { describe, expect, test } from '@jest/globals';
 import { documentTopic } from './document-topic';
 
 describe('documentTopic', () => {
-  test('prepends default /document/ prefix to a path without leading slash', () => {
-    expect(documentTopic('my-doc')).toBe('/document/my-doc');
+  test('returns bare path when using default empty prefix', () => {
+    expect(documentTopic('my-doc')).toBe('my-doc');
   });
 
-  test('avoids double slash when path starts with /', () => {
-    expect(documentTopic('/my-doc')).toBe('/document/my-doc');
+  test('preserves leading slash with default empty prefix', () => {
+    expect(documentTopic('/my-doc')).toBe('/my-doc');
   });
 
-  test('handles nested paths', () => {
-    expect(documentTopic('/org/team/doc')).toBe('/document/org/team/doc');
+  test('preserves nested paths with default empty prefix', () => {
+    expect(documentTopic('/org/team/doc')).toBe('/org/team/doc');
   });
 
-  test('handles nested paths without leading slash', () => {
-    expect(documentTopic('org/team/doc')).toBe('/document/org/team/doc');
+  test('preserves nested paths without leading slash with default empty prefix', () => {
+    expect(documentTopic('org/team/doc')).toBe('org/team/doc');
+  });
+
+  test('returns empty string for empty path with default empty prefix', () => {
+    expect(documentTopic('')).toBe('');
   });
 
   test('uses a custom prefix', () => {
@@ -34,7 +38,11 @@ describe('documentTopic', () => {
     expect(documentTopic('/my-doc', '/docs')).toBe('/docs/my-doc');
   });
 
-  test('handles empty document path with default prefix', () => {
-    expect(documentTopic('')).toBe('/document/');
+  test('applies /document/ prefix when explicitly provided', () => {
+    expect(documentTopic('my-doc', '/document/')).toBe('/document/my-doc');
+  });
+
+  test('applies /document/ prefix and avoids double slash', () => {
+    expect(documentTopic('/my-doc', '/document/')).toBe('/document/my-doc');
   });
 });

--- a/packages/collabswarm/src/document-topic.test.ts
+++ b/packages/collabswarm/src/document-topic.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from '@jest/globals';
+import { documentTopic } from './document-topic';
+
+describe('documentTopic', () => {
+  test('prepends default /document/ prefix to a path without leading slash', () => {
+    expect(documentTopic('my-doc')).toBe('/document/my-doc');
+  });
+
+  test('avoids double slash when path starts with /', () => {
+    expect(documentTopic('/my-doc')).toBe('/document/my-doc');
+  });
+
+  test('handles nested paths', () => {
+    expect(documentTopic('/org/team/doc')).toBe('/document/org/team/doc');
+  });
+
+  test('handles nested paths without leading slash', () => {
+    expect(documentTopic('org/team/doc')).toBe('/document/org/team/doc');
+  });
+
+  test('uses a custom prefix', () => {
+    expect(documentTopic('my-doc', '/docs/')).toBe('/docs/my-doc');
+  });
+
+  test('avoids double slash with custom prefix ending in / and path starting with /', () => {
+    expect(documentTopic('/my-doc', '/docs/')).toBe('/docs/my-doc');
+  });
+
+  test('inserts slash when prefix does not end with / and path does not start with /', () => {
+    expect(documentTopic('my-doc', '/docs')).toBe('/docs/my-doc');
+  });
+
+  test('works when prefix does not end with / but path starts with /', () => {
+    expect(documentTopic('/my-doc', '/docs')).toBe('/docs/my-doc');
+  });
+
+  test('handles empty document path with default prefix', () => {
+    expect(documentTopic('')).toBe('/document/');
+  });
+});

--- a/packages/collabswarm/src/document-topic.test.ts
+++ b/packages/collabswarm/src/document-topic.test.ts
@@ -1,25 +1,37 @@
 import { describe, expect, test } from '@jest/globals';
-import { documentTopic } from './document-topic';
+import { documentTopic, DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 
 describe('documentTopic', () => {
-  test('returns bare path when using default empty prefix', () => {
-    expect(documentTopic('my-doc')).toBe('my-doc');
+  test('uses /document/ prefix by default', () => {
+    expect(documentTopic('my-doc')).toBe('/document/my-doc');
   });
 
-  test('preserves leading slash with default empty prefix', () => {
-    expect(documentTopic('/my-doc')).toBe('/my-doc');
+  test('default prefix matches DEFAULT_DOCUMENT_TOPIC_PREFIX', () => {
+    expect(DEFAULT_DOCUMENT_TOPIC_PREFIX).toBe('/document/');
   });
 
-  test('preserves nested paths with default empty prefix', () => {
-    expect(documentTopic('/org/team/doc')).toBe('/org/team/doc');
+  test('avoids double slash with default prefix and leading-slash path', () => {
+    expect(documentTopic('/my-doc')).toBe('/document/my-doc');
   });
 
-  test('preserves nested paths without leading slash with default empty prefix', () => {
-    expect(documentTopic('org/team/doc')).toBe('org/team/doc');
+  test('returns bare path when using explicit empty prefix', () => {
+    expect(documentTopic('my-doc', '')).toBe('my-doc');
   });
 
-  test('returns empty string for empty path with default empty prefix', () => {
-    expect(documentTopic('')).toBe('');
+  test('preserves leading slash with explicit empty prefix', () => {
+    expect(documentTopic('/my-doc', '')).toBe('/my-doc');
+  });
+
+  test('preserves nested paths with explicit empty prefix', () => {
+    expect(documentTopic('/org/team/doc', '')).toBe('/org/team/doc');
+  });
+
+  test('preserves nested paths without leading slash with explicit empty prefix', () => {
+    expect(documentTopic('org/team/doc', '')).toBe('org/team/doc');
+  });
+
+  test('returns empty string for empty path with explicit empty prefix', () => {
+    expect(documentTopic('', '')).toBe('');
   });
 
   test('uses a custom prefix', () => {
@@ -44,5 +56,14 @@ describe('documentTopic', () => {
 
   test('applies /document/ prefix and avoids double slash', () => {
     expect(documentTopic('/my-doc', '/document/')).toBe('/document/my-doc');
+  });
+
+  // Edge case: '/' prefix produces '/path'
+  test('applies bare / prefix correctly', () => {
+    expect(documentTopic('my-doc', '/')).toBe('/my-doc');
+  });
+
+  test('applies bare / prefix and avoids double slash with leading-slash path', () => {
+    expect(documentTopic('/my-doc', '/')).toBe('/my-doc');
   });
 });

--- a/packages/collabswarm/src/document-topic.ts
+++ b/packages/collabswarm/src/document-topic.ts
@@ -1,0 +1,23 @@
+/**
+ * Builds a pubsub topic string for a given document path by prepending
+ * the configured topic prefix. This separates document pubsub traffic
+ * from other topics on the same network.
+ *
+ * @param documentPath - The path identifying the document.
+ * @param topicPrefix - Prefix to prepend (defaults to `/document/`).
+ * @returns The full pubsub topic string.
+ */
+export function documentTopic(
+  documentPath: string,
+  topicPrefix: string = '/document/',
+): string {
+  // Avoid double slashes when both prefix ends with '/' and path starts with '/'.
+  if (topicPrefix.endsWith('/') && documentPath.startsWith('/')) {
+    return `${topicPrefix}${documentPath.slice(1)}`;
+  }
+  // Insert a separator when neither side provides one.
+  if (!topicPrefix.endsWith('/') && !documentPath.startsWith('/')) {
+    return `${topicPrefix}/${documentPath}`;
+  }
+  return `${topicPrefix}${documentPath}`;
+}

--- a/packages/collabswarm/src/document-topic.ts
+++ b/packages/collabswarm/src/document-topic.ts
@@ -3,14 +3,24 @@
  * the configured topic prefix. This separates document pubsub traffic
  * from other topics on the same network.
  *
+ * The default prefix is an empty string, which means the topic is the
+ * bare document path -- identical to the behavior before this helper
+ * was introduced. To namespace document topics, pass a prefix such as
+ * `'/document/'` via `CollabswarmConfig.pubsubDocumentPrefix`.
+ *
  * @param documentPath - The path identifying the document.
- * @param topicPrefix - Prefix to prepend (defaults to `/document/`).
+ * @param topicPrefix - Prefix to prepend (defaults to `''`).
  * @returns The full pubsub topic string.
  */
 export function documentTopic(
   documentPath: string,
-  topicPrefix: string = '/document/',
+  topicPrefix: string = '',
 ): string {
+  // When the prefix is empty, return the path unchanged to preserve
+  // backward-compatible topic strings.
+  if (topicPrefix === '') {
+    return documentPath;
+  }
   // Avoid double slashes when both prefix ends with '/' and path starts with '/'.
   if (topicPrefix.endsWith('/') && documentPath.startsWith('/')) {
     return `${topicPrefix}${documentPath.slice(1)}`;

--- a/packages/collabswarm/src/document-topic.ts
+++ b/packages/collabswarm/src/document-topic.ts
@@ -1,20 +1,25 @@
+/** Default topic prefix for document pubsub topics. */
+export const DEFAULT_DOCUMENT_TOPIC_PREFIX = '/document/';
+
 /**
  * Builds a pubsub topic string for a given document path by prepending
  * the configured topic prefix. This separates document pubsub traffic
  * from other topics on the same network.
  *
- * The default prefix is an empty string, which means the topic is the
- * bare document path -- identical to the behavior before this helper
- * was introduced. To namespace document topics, pass a prefix such as
- * `'/document/'` via `CollabswarmConfig.pubsubDocumentPrefix`.
+ * The default prefix is `'/document/'`, which namespaces document traffic
+ * on the pubsub mesh. Pass an empty string to disable prefixing (the topic
+ * will be the bare document path, matching legacy behavior).
+ *
+ * **Edge case:** An empty string (`''`) prefix returns `documentPath`
+ * unchanged. This is intentional for backward compatibility.
  *
  * @param documentPath - The path identifying the document.
- * @param topicPrefix - Prefix to prepend (defaults to `''`).
+ * @param topicPrefix - Prefix to prepend (defaults to `'/document/'`).
  * @returns The full pubsub topic string.
  */
 export function documentTopic(
   documentPath: string,
-  topicPrefix: string = '',
+  topicPrefix: string = DEFAULT_DOCUMENT_TOPIC_PREFIX,
 ): string {
   // When the prefix is empty, return the path unchanged to preserve
   // backward-compatible topic strings.

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -75,7 +75,7 @@ import {
 import { NetworkStats } from './network-stats';
 import { LRUCache } from './lru-cache';
 import { bloomFilterUpdateV1, snapshotLoadV1 } from './wire-protocols';
-import { documentTopic } from './document-topic';
+import { documentTopic, DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 import type { CRDTSnapshotNode } from './snapshot-node';
 import type { CompactionConfig } from './compaction-config';
 import { defaultCompactionConfig } from './compaction-config';
@@ -156,6 +156,7 @@ export {
   NetworkStats,
   // Utilities
   documentTopic,
+  DEFAULT_DOCUMENT_TOPIC_PREFIX,
   LRUCache,
 };
 

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -75,6 +75,7 @@ import {
 import { NetworkStats } from './network-stats';
 import { LRUCache } from './lru-cache';
 import { bloomFilterUpdateV1, snapshotLoadV1 } from './wire-protocols';
+import { documentTopic } from './document-topic';
 import type { CRDTSnapshotNode } from './snapshot-node';
 import type { CompactionConfig } from './compaction-config';
 import { defaultCompactionConfig } from './compaction-config';
@@ -154,6 +155,7 @@ export {
   // Network statistics
   NetworkStats,
   // Utilities
+  documentTopic,
   LRUCache,
 };
 


### PR DESCRIPTION
## Summary
- Add `documentTopic()` helper and `DEFAULT_DOCUMENT_TOPIC_PREFIX` constant to prefix document paths with a configurable prefix (defaults to `/document/`)
- Update all pubsub subscribe/publish/unsubscribe and topicValidators calls in `CollabswarmDocument` to use prefixed topics
- Remove TODO comment from `collabswarm-node.ts`
- Export `documentTopic` and `DEFAULT_DOCUMENT_TOPIC_PREFIX` from the package index
- Use `DEFAULT_DOCUMENT_TOPIC_PREFIX` in `defaultConfig` to keep defaults in sync

Fixes #182.

**Note:** This is a wire-breaking change — upgraded peers publish/subscribe on the prefixed topic (`/document/<path>`) while older peers use the bare document path. All peers should be upgraded together.

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 258 tests pass
- [x] New unit tests for `documentTopic()` helper covering slash normalization, custom prefixes, empty prefix, and edge cases