### PR TITLE
Add IPv6 dual-stack support to relay servers

### DIFF
--- a/examples/browser-test/src/relay.ts
+++ b/examples/browser-test/src/relay.ts
@@ -23,6 +23,8 @@ async function main() {
       listen: [
         '/ip4/0.0.0.0/tcp/9001/ws',
         '/ip4/0.0.0.0/tcp/9002',
+        '/ip6/::/tcp/9001/ws',
+        '/ip6/::/tcp/9002',
       ],
     },
     transports: [

--- a/examples/browser-test/src/relay.ts
+++ b/examples/browser-test/src/relay.ts
@@ -23,8 +23,9 @@ async function main() {
       listen: [
         '/ip4/0.0.0.0/tcp/9001/ws',
         '/ip4/0.0.0.0/tcp/9002',
-        '/ip6/::/tcp/9001/ws',
-        '/ip6/::/tcp/9002',
+        // IPv6 listeners omitted by default — on platforms where :: is
+        // dual-stack, binding both on the same port causes EADDRINUSE.
+        // Add '/ip6/::/tcp/9001/ws' and '/ip6/::/tcp/9002' if needed.
       ],
     },
     transports: [

--- a/relay-server/src/index.ts
+++ b/relay-server/src/index.ts
@@ -19,10 +19,17 @@ const PUBSUB_PEER_DISCOVERY_TOPIC = 'swarmdb._peer-discovery._p2p._pubsub'
 const DOCUMENT_PUBLISH_PATH = process.env.DOCUMENT_PUBLISH_PATH || '/documents'
 
 // Configurable listen addresses via environment variables.
+// Dual-stack (IPv4 + IPv6) by default to maximize reachability.
+// IPv6 uses [::] which accepts both IPv4 and IPv6 connections on
+// most operating systems (dual-stack socket). If the OS does not
+// support IPv6, the /ip6 listeners will fail to bind and libp2p
+// will fall back to the /ip4 listeners only.
 const WS_PORT = process.env.WS_PORT || '9001'
 const TCP_PORT = process.env.TCP_PORT || '9002'
 const WS_LISTEN = process.env.WS_LISTEN || `/ip4/0.0.0.0/tcp/${WS_PORT}/ws`
 const TCP_LISTEN = process.env.TCP_LISTEN || `/ip4/0.0.0.0/tcp/${TCP_PORT}`
+const WS_LISTEN_V6 = process.env.WS_LISTEN_V6 || `/ip6/::/tcp/${WS_PORT}/ws`
+const TCP_LISTEN_V6 = process.env.TCP_LISTEN_V6 || `/ip6/::/tcp/${TCP_PORT}`
 
 // Auto-subscribe configuration.
 // TOPIC_ALLOWLIST: comma-separated prefixes. If set, only topics matching
@@ -40,7 +47,7 @@ const MAX_AUTO_TOPICS = (() => {
 async function main() {
   const libp2p = await createLibp2p({
     addresses: {
-      listen: [WS_LISTEN, TCP_LISTEN],
+      listen: [WS_LISTEN, TCP_LISTEN, WS_LISTEN_V6, TCP_LISTEN_V6],
     },
     transports: [
       webSockets(),

--- a/relay-server/src/index.ts
+++ b/relay-server/src/index.ts
@@ -28,8 +28,8 @@ const TCP_PORT = process.env.TCP_PORT || '9002'
 const WS_LISTEN = process.env.WS_LISTEN || `/ip4/0.0.0.0/tcp/${WS_PORT}/ws`
 const TCP_LISTEN = process.env.TCP_LISTEN || `/ip4/0.0.0.0/tcp/${TCP_PORT}`
 const IPV6_ENABLED = process.env.ENABLE_IPV6 === '1'
-const WS_LISTEN_V6 = process.env.WS_LISTEN_V6 || `/ip6/::/tcp/${WS_PORT}/ws`
-const TCP_LISTEN_V6 = process.env.TCP_LISTEN_V6 || `/ip6/::/tcp/${TCP_PORT}`
+const WS_LISTEN_V6 = process.env.WS_LISTEN_V6 ?? `/ip6/::/tcp/${WS_PORT}/ws`
+const TCP_LISTEN_V6 = process.env.TCP_LISTEN_V6 ?? `/ip6/::/tcp/${TCP_PORT}`
 
 // Auto-subscribe configuration.
 // TOPIC_ALLOWLIST: comma-separated prefixes. If set, only topics matching

--- a/relay-server/src/index.ts
+++ b/relay-server/src/index.ts
@@ -19,15 +19,15 @@ const PUBSUB_PEER_DISCOVERY_TOPIC = 'swarmdb._peer-discovery._p2p._pubsub'
 const DOCUMENT_PUBLISH_PATH = process.env.DOCUMENT_PUBLISH_PATH || '/documents'
 
 // Configurable listen addresses via environment variables.
-// Dual-stack (IPv4 + IPv6) by default to maximize reachability.
-// IPv6 uses [::] which accepts both IPv4 and IPv6 connections on
-// most operating systems (dual-stack socket). If the OS does not
-// support IPv6, the /ip6 listeners will fail to bind and libp2p
-// will fall back to the /ip4 listeners only.
+// IPv4 listeners are always enabled. IPv6 dual-stack listeners are opt-in
+// because on platforms where :: is already dual-stack, binding both IPv4
+// and IPv6 on the same port causes EADDRINUSE.
+// Set ENABLE_IPV6=1 to add explicit IPv6 listeners.
 const WS_PORT = process.env.WS_PORT || '9001'
 const TCP_PORT = process.env.TCP_PORT || '9002'
 const WS_LISTEN = process.env.WS_LISTEN || `/ip4/0.0.0.0/tcp/${WS_PORT}/ws`
 const TCP_LISTEN = process.env.TCP_LISTEN || `/ip4/0.0.0.0/tcp/${TCP_PORT}`
+const IPV6_ENABLED = process.env.ENABLE_IPV6 === '1'
 const WS_LISTEN_V6 = process.env.WS_LISTEN_V6 || `/ip6/::/tcp/${WS_PORT}/ws`
 const TCP_LISTEN_V6 = process.env.TCP_LISTEN_V6 || `/ip6/::/tcp/${TCP_PORT}`
 
@@ -47,7 +47,11 @@ const MAX_AUTO_TOPICS = (() => {
 async function main() {
   const libp2p = await createLibp2p({
     addresses: {
-      listen: [WS_LISTEN, TCP_LISTEN, WS_LISTEN_V6, TCP_LISTEN_V6],
+      listen: [
+        WS_LISTEN,
+        TCP_LISTEN,
+        ...(IPV6_ENABLED ? [WS_LISTEN_V6, TCP_LISTEN_V6] : []),
+      ],
     },
     transports: [
       webSockets(),


### PR DESCRIPTION
## Summary

- Relay server adds opt-in IPv6 dual-stack support via `ENABLE_IPV6=1` environment variable
- When enabled, IPv6 listen addresses are configurable via `WS_LISTEN_V6` and `TCP_LISTEN_V6` environment variables
- IPv4 listeners remain always enabled; IPv6 is disabled by default to avoid `EADDRINUSE` on platforms where `::` is already dual-stack
- Browser-test relay (`examples/browser-test/src/relay.ts`) remains IPv4-only, with an explanatory comment noting that IPv6 listeners are omitted by default because binding both `0.0.0.0` and `::` on the same port causes `EADDRINUSE` on dual-stack platforms

### Why IPv6 doesn't replace NAT traversal

IPv6 eliminates address translation but **not firewalls**. Every home router ships with a default-deny inbound IPv6 firewall (RFC 6092), so unsolicited inbound connections are still blocked. Circuit Relay V2 + WebRTC remain essential for browser-to-browser connectivity regardless of IP version.

Adding dual-stack support simply adds IPv6 as an additional connectivity path alongside existing IPv4, maximizing reachability without changing the NAT traversal architecture.

Relates to #184

## Test plan
- [x] Core package builds and all 258 tests pass
- [x] Relay server typechecks cleanly
- [ ] Manual: verify relay binds to IPv6 when `ENABLE_IPV6=1` is set in Docker

Generated with [Claude Code](https://claude.com/claude-code)