### PR TITLE
Add mDNS peer discovery for LAN connectivity

### DIFF
--- a/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
+++ b/packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
 import {
-  CollabswarmNode,
   defaultBootstrapConfig,
-  defaultNodeConfig,
   SubtleCrypto,
 } from '@collabswarm/collabswarm';
+import {
+  CollabswarmNode,
+  defaultNodeConfig,
+} from '@collabswarm/collabswarm/src/collabswarm-node';
 import { AutomergeJSONSerializer, AutomergeProvider } from '../src';
 import {
   AutomergeACLProvider,

--- a/packages/collabswarm-index/package.json
+++ b/packages/collabswarm-index/package.json
@@ -96,6 +96,7 @@
       "^@libp2p/kad-dht$": "<rootDir>/src/__mocks__/empty-module.cjs",
       "^@libp2p/interface$": "<rootDir>/src/__mocks__/empty-module.cjs",
       "^@libp2p/pubsub$": "<rootDir>/src/__mocks__/empty-module.cjs",
+      "^@libp2p/mdns$": "<rootDir>/src/__mocks__/empty-module.cjs",
       "^@libp2p/peer-id$": "<rootDir>/src/__mocks__/empty-module.cjs",
       "^ipns/selector$": "<rootDir>/src/__mocks__/empty-module.cjs",
       "^ipns/validator$": "<rootDir>/src/__mocks__/empty-module.cjs",

--- a/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
+++ b/packages/collabswarm-yjs/bin/collabswarm-yjs-d.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
 import {
-  CollabswarmNode,
   defaultBootstrapConfig,
-  defaultNodeConfig,
   SubtleCrypto,
 } from '@collabswarm/collabswarm';
+import {
+  CollabswarmNode,
+  defaultNodeConfig,
+} from '@collabswarm/collabswarm/src/collabswarm-node';
 import {
   YjsACLProvider,
   YjsJSONSerializer,

--- a/packages/collabswarm-yjs/package.json
+++ b/packages/collabswarm-yjs/package.json
@@ -80,6 +80,7 @@
       "^@libp2p/kad-dht$": "<rootDir>/src/__mocks__/empty-module.js",
       "^@libp2p/interface$": "<rootDir>/src/__mocks__/empty-module.js",
       "^@libp2p/pubsub$": "<rootDir>/src/__mocks__/empty-module.js",
+      "^@libp2p/mdns$": "<rootDir>/src/__mocks__/empty-module.js",
       "^@libp2p/peer-id$": "<rootDir>/src/__mocks__/empty-module.js",
       "^ipns/selector$": "<rootDir>/src/__mocks__/empty-module.js",
       "^ipns/validator$": "<rootDir>/src/__mocks__/empty-module.js",

--- a/packages/collabswarm/package.json
+++ b/packages/collabswarm/package.json
@@ -45,6 +45,7 @@
     "@libp2p/identify": "^3.0.39",
     "@libp2p/interface": "^2.11.0",
     "@libp2p/kad-dht": "^15.0.2",
+    "@libp2p/mdns": "^11.0.47",
     "@libp2p/peer-id": "^5.1.9",
     "@libp2p/pubsub-peer-discovery": "^11.0.2",
     "@libp2p/topology": "^4.0.3",

--- a/packages/collabswarm/package.json
+++ b/packages/collabswarm/package.json
@@ -12,6 +12,21 @@
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    },
+    "./node": {
+      "types": "./dist/src/collabswarm-node.d.ts",
+      "default": "./dist/src/collabswarm-node.js"
+    },
+    "./src/*": {
+      "types": "./dist/src/*.d.ts",
+      "default": "./dist/src/*.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -1,6 +1,7 @@
 import { HeliaInit } from 'helia';
 import { yamux } from '@chainsafe/libp2p-yamux';
 import { bootstrap, BootstrapInit } from '@libp2p/bootstrap';
+import { mdns } from '@libp2p/mdns';
 import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery';
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2';
 import { webRTC, webRTCDirect } from '@libp2p/webrtc';
@@ -47,7 +48,7 @@ export const defaultConfig = (bootstrapConfig: BootstrapInit) =>
           webTransport(),
         ],
         streamMuxers: [yamux()],
-        peerDiscovery: [bootstrap(bootstrapConfig), pubsubPeerDiscovery()],
+        peerDiscovery: [bootstrap(bootstrapConfig), pubsubPeerDiscovery(), mdns()],
         services: {
           identify: identify(),
           autoNAT: autoNAT(),

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -1,7 +1,6 @@
 import { HeliaInit } from 'helia';
 import { yamux } from '@chainsafe/libp2p-yamux';
 import { bootstrap, BootstrapInit } from '@libp2p/bootstrap';
-import { mdns } from '@libp2p/mdns';
 import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery';
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2';
 import { webRTC, webRTCDirect } from '@libp2p/webrtc';
@@ -23,8 +22,10 @@ import { DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 /**
  * Default collabswarm config to use if none is provided.
  *
- * Note: This default configuration does not contain any other bootstrap nodes
- *       so upon startup this node will be in a swarm of one.
+ * Note: This is a browser-compatible default. It does not include mDNS
+ *       (which requires the Node-only `dgram` module). Without bootstrap
+ *       nodes this node will be in a swarm of one; use
+ *       `collabswarm.connect()` or pass bootstrap addresses to join peers.
  */
 export const defaultConfig = (bootstrapConfig: BootstrapInit) =>
   ({
@@ -48,7 +49,7 @@ export const defaultConfig = (bootstrapConfig: BootstrapInit) =>
           webTransport(),
         ],
         streamMuxers: [yamux()],
-        peerDiscovery: [bootstrap(bootstrapConfig), pubsubPeerDiscovery(), mdns()],
+        peerDiscovery: [bootstrap(bootstrapConfig), pubsubPeerDiscovery()],
         services: {
           identify: identify(),
           autoNAT: autoNAT(),

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -21,6 +21,7 @@ import { autoNAT } from '@libp2p/autonat';
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2';
 import { identify } from '@libp2p/identify';
 import { kadDHT } from '@libp2p/kad-dht';
+import { mdns } from '@libp2p/mdns';
 import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery';
 import { webRTC, webRTCDirect } from '@libp2p/webrtc';
 import { webSockets } from '@libp2p/websockets';
@@ -55,7 +56,7 @@ export const defaultNodeConfig = (bootstrapConfig: BootstrapInit) =>
           webTransport(),
         ],
         streamMuxers: [yamux()],
-        peerDiscovery: [bootstrap(bootstrapConfig), pubsubPeerDiscovery()],
+        peerDiscovery: [bootstrap(bootstrapConfig), pubsubPeerDiscovery(), mdns()],
         services: {
           identify: identify(),
           autoNAT: autoNAT(),

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -7,8 +7,8 @@
  * that are unavailable in browsers. It is intentionally excluded from the
  * barrel export in `index.ts` to keep the main entry point browser-compatible.
  *
- * Import directly when running in Node.js:
- *   import { CollabswarmNode, defaultNodeConfig } from '@collabswarm/collabswarm/src/collabswarm-node';
+ * Import from the dedicated `/node` subpath export when running in Node.js:
+ *   import { CollabswarmNode, defaultNodeConfig } from '@collabswarm/collabswarm/node';
  */
 import * as fs from 'fs';
 import {
@@ -53,9 +53,13 @@ import { bootstrap, BootstrapInit } from '@libp2p/bootstrap';
 /**
  * Default config for Node.js environments.
  *
- * Includes mDNS peer discovery, which advertises and discovers peers on the
- * local LAN via UDP multicast. This allows same-network nodes to find each
- * other without relay servers or bootstrap peers.
+ * **Note on mDNS (LAN broadcast):** This default includes mDNS peer discovery,
+ * which advertises and discovers peers on the local LAN via UDP multicast.
+ * This allows same-network nodes to find each other without relay servers or
+ * bootstrap peers. Because this actively broadcasts the node's presence on the
+ * local network, privacy-sensitive deployments should disable it by building a
+ * custom config (copy this one and omit `mdns()` from `peerDiscovery`) rather
+ * than using `defaultNodeConfig` directly.
  */
 export const defaultNodeConfig = (bootstrapConfig: BootstrapInit) =>
   ({

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -1,3 +1,15 @@
+/**
+ * @module collabswarm-node
+ *
+ * **Node-only module.** Do not import in browser environments.
+ *
+ * This module depends on Node.js built-ins (`fs`, `dgram` via `@libp2p/mdns`)
+ * that are unavailable in browsers. It is intentionally excluded from the
+ * barrel export in `index.ts` to keep the main entry point browser-compatible.
+ *
+ * Import directly when running in Node.js:
+ *   import { CollabswarmNode, defaultNodeConfig } from '@collabswarm/collabswarm/src/collabswarm-node';
+ */
 import * as fs from 'fs';
 import {
   CollabswarmConfig,

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -21,6 +21,9 @@ import { autoNAT } from '@libp2p/autonat';
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2';
 import { identify } from '@libp2p/identify';
 import { kadDHT } from '@libp2p/kad-dht';
+// mDNS is Node-only: it depends on the `dgram` built-in for UDP multicast,
+// which is unavailable in browsers. The browser-compatible default config in
+// collabswarm-config.ts intentionally omits it.
 import { mdns } from '@libp2p/mdns';
 import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery';
 import { webRTC, webRTCDirect } from '@libp2p/webrtc';
@@ -35,6 +38,13 @@ import { bitswap } from '@helia/block-brokers';
 import { yamux } from '@chainsafe/libp2p-yamux';
 import { bootstrap, BootstrapInit } from '@libp2p/bootstrap';
 
+/**
+ * Default config for Node.js environments.
+ *
+ * Includes mDNS peer discovery, which advertises and discovers peers on the
+ * local LAN via UDP multicast. This allows same-network nodes to find each
+ * other without relay servers or bootstrap peers.
+ */
 export const defaultNodeConfig = (bootstrapConfig: BootstrapInit) =>
   ({
     helia: {

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -13,8 +13,9 @@ import {
 import { CRDTSyncMessage } from './crdt-sync-message';
 // CollabswarmNode is intentionally excluded from this barrel export.
 // It is a Node-only module (imports `fs`, `@libp2p/mdns` which depends on
-// `dgram`) and must not be bundled by browser consumers. Import it directly:
-//   import { CollabswarmNode, defaultNodeConfig } from '@collabswarm/collabswarm/src/collabswarm-node';
+// `dgram`) and must not be bundled by browser consumers. Import it from the
+// dedicated Node subpath export:
+//   import { CollabswarmNode, defaultNodeConfig } from '@collabswarm/collabswarm/node';
 import { CRDTProvider } from './crdt-provider';
 import { SyncMessageSerializer } from './sync-message-serializer';
 import { ChangesSerializer } from './changes-serializer';

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -11,7 +11,10 @@ import {
   HistoryVisibility,
 } from './collabswarm-document';
 import { CRDTSyncMessage } from './crdt-sync-message';
-import { CollabswarmNode, defaultNodeConfig } from './collabswarm-node';
+// CollabswarmNode is intentionally excluded from this barrel export.
+// It is a Node-only module (imports `fs`, `@libp2p/mdns` which depends on
+// `dgram`) and must not be bundled by browser consumers. Import it directly:
+//   import { CollabswarmNode, defaultNodeConfig } from '@collabswarm/collabswarm/src/collabswarm-node';
 import { CRDTProvider } from './crdt-provider';
 import { SyncMessageSerializer } from './sync-message-serializer';
 import { ChangesSerializer } from './changes-serializer';
@@ -93,7 +96,6 @@ export {
   CollabswarmDocument,
   CollabswarmDocumentChangeHandler,
   HistoryVisibility,
-  CollabswarmNode,
   CRDTChangeBlock,
   CRDTChangeNodeKind,
   CRDTChangeNodeDeferred,
@@ -127,7 +129,6 @@ export {
   defaultConfig,
   defaultBootstrapConfig,
   getDefaultConfig,
-  defaultNodeConfig,
   // Capabilities
   CAP_DOC_ADMIN,
   CAP_DOC_WRITE,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2010,6 +2010,7 @@ __metadata:
     "@libp2p/identify": "npm:^3.0.39"
     "@libp2p/interface": "npm:^2.11.0"
     "@libp2p/kad-dht": "npm:^15.0.2"
+    "@libp2p/mdns": "npm:^11.0.47"
     "@libp2p/peer-id": "npm:^5.1.9"
     "@libp2p/pubsub-peer-discovery": "npm:^11.0.2"
     "@libp2p/topology": "npm:^4.0.3"
@@ -3849,7 +3850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@libp2p/mdns@npm:^11.0.20":
+"@libp2p/mdns@npm:^11.0.20, @libp2p/mdns@npm:^11.0.47":
   version: 11.0.47
   resolution: "@libp2p/mdns@npm:11.0.47"
   dependencies:


### PR DESCRIPTION
## Summary
- Add `@libp2p/mdns@^11.0.47` as a dependency (compatible with existing libp2p v2.x stack)
- Add `mdns()` to the `peerDiscovery` array in `collabswarm-node.ts` (Node-only config)
- Same-LAN peers can now discover each other directly via multicast DNS without needing a relay

**mDNS is Node-only.** `@libp2p/mdns` depends on Node's `dgram` built-in for UDP multicast, which is unavailable in browsers. To keep the main barrel export (`index.ts`) browser-compatible:
- `CollabswarmNode` and `defaultNodeConfig` are **not** re-exported from `index.ts`
- The browser-compatible default config in `collabswarm-config.ts` does **not** include mDNS
- Node-only consumers (e.g. the CLI daemons in `collabswarm-yjs` and `collabswarm-automerge`) import `CollabswarmNode` directly from `collabswarm-node.ts`

Partially addresses #236.

## Test plan
- [x] All 274 existing unit tests pass (`yarn workspace @collabswarm/collabswarm test`)
- [ ] Manual: verify two Node.js peers on the same LAN discover each other without a relay server
- [ ] Manual: verify relay-based discovery still works as before
- [ ] Manual: verify browser bundle does not pull in `dgram` or `@libp2p/mdns`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled mDNS-based peer discovery to automatically find/connect peers on the local network (Node.js only).

* **Chores**
  * Added explicit package entrypoints to improve module resolution.

* **Documentation**
  * Clarified default config is browser-compatible (mDNS not included) and swarm behavior when no bootstrap peers are provided.

* **Tests**
  * Added test mocks so mDNS imports are ignored during browser/unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->