### PR TITLE
Remove stale TODO and dead code from core package

### DIFF
--- a/packages/collabswarm/src/auth-subtlecrypto.ts
+++ b/packages/collabswarm/src/auth-subtlecrypto.ts
@@ -105,11 +105,8 @@ export class SubtleCrypto
       }
       case 'AES-CTR':
       case 'AES-CBC':
-        // NOTE: Only AES-GCM is currently supported. AES-CTR and AES-CBC throw -- see PR description.
-        // TODO: AES-CTR and AES-CBC support is planned but not yet implemented.
-        // They require different nonce sizes (16 bytes) and key import
-        // parameters than AES-GCM. Implementation is deferred until the
-        // key derivation paths and wire format header parsing are updated.
+        // Only AES-GCM is supported. AES-CTR and AES-CBC require different
+        // nonce sizes (16 bytes) and key import parameters.
         throw new Error(`${this._encryptionAlgorithmName} is not yet supported. Use AES-GCM.`);
       default:
         throw new Error(`Unknown encryption algorithm: ${this._encryptionAlgorithmName}`);


### PR DESCRIPTION
## Summary

- Removed the stale TODO comment in `auth-subtlecrypto.ts` about planned AES-CTR/AES-CBC support (no implementation plan exists; the informational comment about why they're unsupported is retained)

The remaining items from the cleanup audit were already addressed by prior commits on `feat/shared-stream-handler`:
- Commented-out IPFS configuration block in `collabswarm-node.ts` -- already removed
- Commented-out `circuitRelayTransport({ discoverRelays: 3 })` -- already removed
- Commented-out `mplex()` stream muxer -- already removed
- Compaction GC TODOs in `compaction-config.ts` -- already removed
- `documentLoadV1` / `documentKeyUpdateV1` re-exports -- not present in `index.ts`

## Test plan

- [x] `yarn workspace @collabswarm/collabswarm test` passes (269/269 tests)
- [x] No files modified that are touched by open PRs (`collabswarm.ts`, `collabswarm-document.ts`, `wire-protocols.ts`, `e2e/`, `.github/workflows/ci.yml`)