### PR TITLE
Audit and improve collabswarm-redux package

### DIFF
--- a/packages/collabswarm-redux/package.json
+++ b/packages/collabswarm-redux/package.json
@@ -25,9 +25,10 @@
     "ts-jest": "^29.2.5",
     "typescript": "^5.9.3"
   },
-  "dependencies": {
-    "@automerge/automerge": "^3.2.4",
-    "@collabswarm/collabswarm-automerge": "workspace:packages/collabswarm-automerge"
+  "peerDependencies": {
+    "@collabswarm/collabswarm": "workspace:*",
+    "redux": "^4.0.0 || ^5.0.0",
+    "redux-thunk": "^2.0.0 || ^3.0.0"
   },
   "gitHead": "5d48e475ac53ef5920423d3a22a4e19201e607a1",
   "publishConfig": {

--- a/packages/collabswarm-redux/src/actions.ts
+++ b/packages/collabswarm-redux/src/actions.ts
@@ -92,7 +92,6 @@ export function initializeAsync<
     });
     await node.initialize(config);
     dispatch(initialize(node, captureTrace()));
-    console.log('Node information:', node);
     return node;
   };
 }
@@ -191,8 +190,6 @@ export function connectAsync<
     }
     await node.connect(addresses);
     dispatch(connect(addresses, captureTrace()));
-    console.log('Node information:', node);
-    console.log('Connected to:', addresses);
   };
 }
 

--- a/packages/collabswarm-redux/src/index.ts
+++ b/packages/collabswarm-redux/src/index.ts
@@ -1,81 +1,46 @@
-import {
+export {
+  // Async action creators
   initializeAsync,
-  INITIALIZE,
-  InitializeAction,
-  initialize,
-
   connectAsync,
-  CONNECT,
-  ConnectAction,
-  connect,
-
   openDocumentAsync,
-  OPEN_DOCUMENT,
-  OpenDocumentAction,
-  openDocument,
-
   closeDocumentAsync,
-  CLOSE_DOCUMENT,
-  CloseDocumentAction,
-  closeDocument,
-
-  SYNC_DOCUMENT,
-  SyncDocumentAction,
-  syncDocument,
-  
   changeDocumentAsync,
-  CHANGE_DOCUMENT,
-  ChangeDocumentAction,
-  changeDocument,
 
-  CollabswarmActions
-} from "./actions";
-import {
-  CollabswarmState,
-  CollabswarmDocumentState,
-  initialState,
-  collabswarmReducer
-} from "./reducers";
+  // Action type constants
+  INITIALIZE,
+  CONNECT,
+  OPEN_DOCUMENT,
+  CLOSE_DOCUMENT,
+  SYNC_DOCUMENT,
+  CHANGE_DOCUMENT,
+  PEER_CONNECT,
+  PEER_DISCONNECT,
+
+  // Action interfaces
+  type InitializeAction,
+  type ConnectAction,
+  type OpenDocumentAction,
+  type CloseDocumentAction,
+  type SyncDocumentAction,
+  type ChangeDocumentAction,
+  type PeerConnectAction,
+  type PeerDisconnectAction,
+  type CollabswarmActions,
+
+  // Synchronous action creators
+  initialize,
+  connect,
+  openDocument,
+  closeDocument,
+  syncDocument,
+  changeDocument,
+  peerConnect,
+  peerDisconnect,
+} from './actions';
 
 export {
-  // Actions
-
-  initializeAsync,
-  INITIALIZE,
-  InitializeAction,
-  initialize,
-
-  connectAsync,
-  CONNECT,
-  ConnectAction,
-  connect,
-
-  openDocumentAsync,
-  OPEN_DOCUMENT,
-  OpenDocumentAction,
-  openDocument,
-
-  closeDocumentAsync,
-  CLOSE_DOCUMENT,
-  CloseDocumentAction,
-  closeDocument,
-
-  SYNC_DOCUMENT,
-  SyncDocumentAction,
-  syncDocument,
-  
-  changeDocumentAsync,
-  CHANGE_DOCUMENT,
-  ChangeDocumentAction,
-  changeDocument,
-
-  CollabswarmActions,
-
-
-  // Reducer
-
-  CollabswarmState,
-  CollabswarmDocumentState,
+  type CollabswarmState,
+  type CollabswarmDocumentState,
   initialState,
-  collabswarmReducer
-};
+  collabswarmReducer,
+} from './reducers';

--- a/packages/collabswarm-redux/src/reducers.test.ts
+++ b/packages/collabswarm-redux/src/reducers.test.ts
@@ -106,6 +106,28 @@ describe('action creators', () => {
       peerAddress: '/ip4/192.168.1.1/tcp/4001',
     });
   });
+
+  test('action creators include _trace when provided', () => {
+    const trace = 'Error\n    at test';
+    expect(initialize({} as any, trace)).toHaveProperty('_trace', trace);
+    expect(connect([], trace)).toHaveProperty('_trace', trace);
+    expect(openDocument('doc', {} as any, trace)).toHaveProperty('_trace', trace);
+    expect(closeDocument('doc', trace)).toHaveProperty('_trace', trace);
+    expect(syncDocument('doc', {}, trace)).toHaveProperty('_trace', trace);
+    expect(changeDocument('doc', {}, trace)).toHaveProperty('_trace', trace);
+    expect(peerConnect('addr', trace)).toHaveProperty('_trace', trace);
+    expect(peerDisconnect('addr', trace)).toHaveProperty('_trace', trace);
+  });
+
+  test('action creators omit _trace when not provided', () => {
+    expect(initialize({} as any)).not.toHaveProperty('_trace');
+    expect(connect([])).not.toHaveProperty('_trace');
+    expect(closeDocument('doc')).not.toHaveProperty('_trace');
+    expect(syncDocument('doc', {})).not.toHaveProperty('_trace');
+    expect(changeDocument('doc', {})).not.toHaveProperty('_trace');
+    expect(peerConnect('addr')).not.toHaveProperty('_trace');
+    expect(peerDisconnect('addr')).not.toHaveProperty('_trace');
+  });
 });
 
 describe('collabswarmReducer', () => {
@@ -274,9 +296,77 @@ describe('collabswarmReducer', () => {
     expect(newState).toBe(state);
   });
 
-  test('unknown action returns same state', () => {
+  test('unknown action returns same state without warning', () => {
     const state = createMockState();
     const newState = reducer(state, { type: 'UNKNOWN_ACTION' } as any);
     expect(newState).toBe(state);
+    // Redux reducers should silently ignore unknown actions
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  test('OPEN_DOCUMENT overwrites already-open document with warning', () => {
+    const docRef1 = { document: { text: 'first' } } as any;
+    const docRef2 = { document: { text: 'second' } } as any;
+    const state: CollabswarmState<any, any, any, any, any, any> = {
+      ...createMockState(),
+      documents: {
+        'doc-1': { documentRef: docRef1, document: docRef1.document, peers: [] },
+      },
+    };
+    const newState = reducer(state, openDocument('doc-1', docRef2));
+    expect(newState.documents['doc-1'].document).toEqual({ text: 'second' });
+    expect(newState.documents['doc-1'].documentRef).toBe(docRef2);
+    expect(console.warn).toHaveBeenCalledWith(
+      'Overwriting already open document:',
+      'doc-1',
+    );
+  });
+
+  test('multiple documents can be open simultaneously', () => {
+    const state = createMockState();
+    const docRef1 = { document: { text: 'doc1' } } as any;
+    const docRef2 = { document: { text: 'doc2' } } as any;
+    const state1 = reducer(state, openDocument('doc-1', docRef1));
+    const state2 = reducer(state1, openDocument('doc-2', docRef2));
+    expect(Object.keys(state2.documents)).toEqual(['doc-1', 'doc-2']);
+    expect(state2.documents['doc-1'].document).toEqual({ text: 'doc1' });
+    expect(state2.documents['doc-2'].document).toEqual({ text: 'doc2' });
+  });
+
+  test('CLOSE_DOCUMENT does not affect other open documents', () => {
+    const docRef1 = { document: { text: 'doc1' } } as any;
+    const docRef2 = { document: { text: 'doc2' } } as any;
+    const state: CollabswarmState<any, any, any, any, any, any> = {
+      ...createMockState(),
+      documents: {
+        'doc-1': { documentRef: docRef1, document: docRef1.document, peers: [] },
+        'doc-2': { documentRef: docRef2, document: docRef2.document, peers: [] },
+      },
+    };
+    const newState = reducer(state, closeDocument('doc-1'));
+    expect(newState.documents['doc-1']).toBeUndefined();
+    expect(newState.documents['doc-2'].document).toEqual({ text: 'doc2' });
+  });
+
+  test('multiple PEER_CONNECT actions accumulate peers', () => {
+    const state = createMockState();
+    const state1 = reducer(state, peerConnect('peer-1'));
+    const state2 = reducer(state1, peerConnect('peer-2'));
+    const state3 = reducer(state2, peerConnect('peer-3'));
+    expect(state3.peers).toEqual(['peer-1', 'peer-2', 'peer-3']);
+  });
+
+  test('CHANGE_DOCUMENT preserves documentRef', () => {
+    const docRef = { document: { text: 'old' } } as any;
+    const state: CollabswarmState<any, any, any, any, any, any> = {
+      ...createMockState(),
+      documents: {
+        'doc-1': { documentRef: docRef, document: docRef.document, peers: ['peer-a'] },
+      },
+    };
+    const updatedDoc = { text: 'changed' };
+    const newState = reducer(state, changeDocument('doc-1', updatedDoc));
+    expect(newState.documents['doc-1'].documentRef).toBe(docRef);
+    expect(newState.documents['doc-1'].peers).toEqual(['peer-a']);
   });
 });

--- a/packages/collabswarm-redux/src/reducers.ts
+++ b/packages/collabswarm-redux/src/reducers.ts
@@ -21,8 +21,6 @@ import {
   SyncMessageSerializer,
 } from '@collabswarm/collabswarm';
 
-// user id should be the same as peer id.
-
 export interface CollabswarmDocumentState<
   DocType,
   ChangesType,
@@ -131,7 +129,10 @@ export function collabswarmReducer<
   authProvider: AuthProvider<PrivateKey, PublicKey, DocumentKey>,
   aclProvider: ACLProvider<ChangesType, PublicKey>,
   keychainProvider: KeychainProvider<ChangesType, DocumentKey>,
-) {
+): (
+  state: CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> | undefined,
+  action: CollabswarmActions<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>,
+) => CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey> {
   return (
     state: CollabswarmState<
       DocType,
@@ -182,7 +183,6 @@ export function collabswarmReducer<
           ...state,
         };
       }
-      // Open Document (two options: 1. Overwrite the "current" document, 2. ???)
       case OPEN_DOCUMENT: {
         if (state.documents[action.documentId]) {
           console.warn('Overwriting already open document:', action.documentId);
@@ -264,8 +264,6 @@ export function collabswarmReducer<
         };
       }
       default: {
-        console.warn('Unrecognized action:', action);
-        console.warn('Unrecognized action (state):', state);
         return state;
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1962,8 +1962,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@collabswarm/collabswarm-redux@workspace:packages/collabswarm-redux"
   dependencies:
-    "@automerge/automerge": "npm:^3.2.4"
-    "@collabswarm/collabswarm-automerge": "workspace:packages/collabswarm-automerge"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^10.0.2"
     jest: "npm:^29.2.5"
@@ -1971,6 +1969,10 @@ __metadata:
     redux-thunk: "npm:^3.1.0"
     ts-jest: "npm:^29.2.5"
     typescript: "npm:^5.9.3"
+  peerDependencies:
+    "@collabswarm/collabswarm": "workspace:*"
+    redux: ^4.0.0 || ^5.0.0
+    redux-thunk: ^2.0.0 || ^3.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- **Remove debug logging**: Stripped `console.log('Node information:', node)` and `console.log('Connected to:', ...)` from async action creators that leaked to production
- **Fix Redux anti-pattern**: Default reducer case no longer warns on unknown actions -- other reducers in a combined store legitimately dispatch actions this reducer doesn't handle
- **Export missing peer actions**: `PEER_CONNECT`, `PEER_DISCONNECT`, `PeerConnectAction`, `PeerDisconnectAction`, `peerConnect`, `peerDisconnect` were defined but not exported from the package entry point
- **Fix incorrect dependencies**: Replaced hard dependencies on `@automerge/automerge` and `@collabswarm/collabswarm-automerge` (CRDT-provider-specific) with proper `peerDependencies` on `@collabswarm/collabswarm`, `redux`, and `redux-thunk`
- **Add return type annotation** to `collabswarmReducer` for better type inference at call sites
- **Clean up index.ts**: Use direct re-exports and `type` keyword for type-only exports; remove import-then-export indirection
- **Remove stale comments**: Orphaned "user id should be the same as peer id" note and incomplete "two options" TODO
- **Expand test coverage** from 22 to 30 tests: `_trace` parameter behavior, document overwrite warning, multi-document state, document isolation on close, peer accumulation, and ref/peers preservation on change

## Test plan

- [x] `yarn workspace @collabswarm/collabswarm-redux test` -- 30/30 passing
- [ ] Verify no downstream breakage in packages that import from `@collabswarm/collabswarm-redux`