### PR TITLE
Remove unused V1 wire-protocol constants

### DIFF
--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -460,8 +460,7 @@ export class Collabswarm<
               assembled[3]) >>> 0;
 
             // Validate the path length header. If it looks invalid, treat the
-            // message as malformed, log a warning, and drop it rather than
-            // attempting to interpret it as a legacy (V1) payload.
+            // message as malformed, log a warning, and drop it.
             if (
               pathLength === 0 ||
               pathLength > MAX_DOCUMENT_PATH_LENGTH ||

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -77,7 +77,7 @@ import {
 } from './ucan-acl';
 import { NetworkStats } from './network-stats';
 import { LRUCache } from './lru-cache';
-import { bloomFilterUpdateV1, snapshotLoadV1 } from './wire-protocols';
+import { bloomFilterUpdateV1 } from './wire-protocols';
 import { documentTopic, DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 import type { CRDTSnapshotNode } from './snapshot-node';
 import type { CompactionConfig } from './compaction-config';
@@ -149,7 +149,6 @@ export {
   UCANACLProvider,
   // Wire protocols
   bloomFilterUpdateV1,
-  snapshotLoadV1,
   // Compaction
   defaultCompactionConfig,
   // Network statistics

--- a/packages/collabswarm/src/wire-protocols.ts
+++ b/packages/collabswarm/src/wire-protocols.ts
@@ -1,14 +1,9 @@
-export const documentLoadV1 = '/collabswarm/doc-load/1.0.0';
-export const documentKeyUpdateV1 = '/collabswarm/key-update/1.0.0';
 export const bloomFilterUpdateV1 = '/collabswarm/bloom-index/1.0.0';
-export const snapshotLoadV1 = '/collabswarm/snapshot-load/1.0.0';
 
-// V2 protocol IDs use a shared handler model where a single handler serves
-// all documents; V1 protocol IDs register per-document handlers (protocol
-// ID is suffixed with the document path). For doc-load and snapshot-load,
-// V1 and V2 share the same request wire format; the version bump only
-// signals that the handler is shared across all documents. For key-update,
-// V2 prepends a length-prefixed document-path header for shared routing.
+// V2 doc-load, key-update, and snapshot-load handlers use a shared handler
+// model where a single handler serves all documents. The key-update wire
+// format prepends a length-prefixed document-path header so the shared
+// handler can route requests to the correct document.
 export const documentLoadV2 = '/collabswarm/doc-load/2.0.0';
 export const documentKeyUpdateV2 = '/collabswarm/key-update/2.0.0';
 export const snapshotLoadV2 = '/collabswarm/snapshot-load/2.0.0';


### PR DESCRIPTION
## Summary

The V1 protocol IDs `documentLoadV1`, `documentKeyUpdateV1`, and `snapshotLoadV1` were never registered as libp2p stream handlers in `collabswarm.ts` — only their V2 counterparts (`documentLoadV2`, `documentKeyUpdateV2`, `snapshotLoadV2`) are wired up. They were effectively dead exports, so this PR removes them.

`bloomFilterUpdateV1` is intentionally preserved because `@collabswarm/collabswarm-index` still imports it for the bloom-filter gossip topic (see `packages/collabswarm-index/src/bloom-filter-gossip.ts`).

## Changes

- Delete `documentLoadV1`, `documentKeyUpdateV1`, and `snapshotLoadV1` from `packages/collabswarm/src/wire-protocols.ts`.
- Reduce the explanatory comment in `wire-protocols.ts` to describe only what remains: the V2 shared-handler model. The V1 vs. V2 contrast no longer maps to anything in the code.
- Drop the `snapshotLoadV1` import and re-export from `packages/collabswarm/src/index.ts`. The `bloomFilterUpdateV1` re-export stays.
- Reword the stale "legacy (V1) payload" comment in the shared key-update handler in `collabswarm.ts` — there is no V1 payload format to fall back to, so the comment now just describes the defensive validation.

## Test plan

- [x] `yarn workspace @collabswarm/collabswarm tsc` passes
- [x] `yarn workspace @collabswarm/collabswarm test` passes (298/298)
- [x] `yarn workspace @collabswarm/collabswarm-index tsc` passes (verifies `bloomFilterUpdateV1` still resolves)
- [x] `yarn workspace @collabswarm/collabswarm-index test` passes (173/173)
- [x] `grep -rn` across `packages/`, `e2e/`, `relay-server/`, `examples/` confirms no remaining references to the removed constants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed legacy V1 protocol version exports for document-load, key-update, and snapshot-load operations; only V2 protocol versions remain as the supported implementation.
  * Updated internal documentation to accurately describe V2 protocol behavior and routing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->