### PR TITLE
Add public STUN servers to WebRTC ICE config (#236 phase 3)

### DIFF
--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -48,6 +48,26 @@ export const DEFAULT_WEBRTC_ICE_SERVERS: ReadonlyArray<Readonly<RTCIceServer>> =
   ]);
 
 /**
+ * Returns a deep-enough copy of an `RTCIceServer` so callers can hand the
+ * result to libp2p (which expects a mutable `RTCIceServer`) without sharing
+ * any inner references with the source object.
+ *
+ * In particular:
+ * - the top-level object is a fresh `{ ...server }` so mutating fields like
+ *   `username`/`credential` on the copy cannot affect the source;
+ * - if `urls` is an array, it is copied to a fresh array so `push()`/`splice()`
+ *   on the copy cannot affect the source's URL list (a single `string` value
+ *   is immutable, so it is forwarded as-is).
+ *
+ * Exported so {@link defaultNodeConfig} (and any future config helpers) can
+ * share the same defensive-copy behavior.
+ */
+export const cloneIceServer = (server: RTCIceServer): RTCIceServer => ({
+  ...server,
+  urls: Array.isArray(server.urls) ? [...server.urls] : server.urls,
+});
+
+/**
  * Default collabswarm config to use if none is provided.
  *
  * Note: This is a browser-compatible default. It does not include mDNS
@@ -63,17 +83,19 @@ export const DEFAULT_WEBRTC_ICE_SERVERS: ReadonlyArray<Readonly<RTCIceServer>> =
  */
 export const defaultConfig = (
   bootstrapConfig: BootstrapInit,
-  webrtcIceServers?: ReadonlyArray<RTCIceServer>,
+  webrtcIceServers?: ReadonlyArray<Readonly<RTCIceServer>>,
 ) => {
   // Resolve once from the (possibly readonly) input or the frozen defaults.
-  // Each consumer below gets its own independent copy so mutating any one of
+  // Each consumer below gets its own independent copy (including a deep-enough
+  // clone of every server object via `cloneIceServer`) so mutating any one of
   // them (e.g., the array exposed on the returned config, or the array
-  // libp2p's webRTC transport stores internally) cannot leak into the others.
+  // libp2p's webRTC transport stores internally, or any individual server's
+  // fields) cannot leak into the others.
   const sourceIceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
   // Defensive copy for the exposed config: freeze so consumers cannot mutate
   // it in place and inadvertently shift state shared with anything else.
   const exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>> = Object.freeze(
-    sourceIceServers.map((server) => Object.freeze({ ...server })),
+    sourceIceServers.map((server) => Object.freeze(cloneIceServer(server))),
   );
   return ({
     // Helia configuration (ref: https://gist.github.com/bellbind/23ad8d6e3a1509335253ff074fcd3cb6)
@@ -93,10 +115,11 @@ export const defaultConfig = (
           webSockets({ filter: all }),
           // Pass STUN servers so RTCPeerConnection can gather server-reflexive
           // candidates and attempt direct connections without relay forwarding.
-          // Each transport gets its own fresh mutable copy to avoid aliasing
-          // with the array exposed on `config.webrtcIceServers` below.
-          webRTC({ rtcConfiguration: { iceServers: [...sourceIceServers] } }),
-          webRTCDirect({ rtcConfiguration: { iceServers: [...sourceIceServers] } }),
+          // Each transport gets its own fresh mutable copy (with each server
+          // object also deep-enough-cloned via `cloneIceServer`) to avoid
+          // aliasing with the array exposed on `config.webrtcIceServers` below.
+          webRTC({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) } }),
+          webRTCDirect({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) } }),
           webTransport(),
         ],
         streamMuxers: [yamux()],
@@ -224,7 +247,7 @@ export interface CollabswarmConfig {
    *
    * @default DEFAULT_WEBRTC_ICE_SERVERS
    */
-  webrtcIceServers?: ReadonlyArray<RTCIceServer>;
+  webrtcIceServers?: ReadonlyArray<Readonly<RTCIceServer>>;
 
   /**
    * Optional callback to validate document paths before creation.
@@ -282,7 +305,7 @@ export const defaultBootstrapConfig = (clientAddresses: string[]) =>
  *   When undefined, {@link DEFAULT_WEBRTC_ICE_SERVERS} is used.
  */
 export function getDefaultConfig(
-  webrtcIceServers?: ReadonlyArray<RTCIceServer>,
+  webrtcIceServers?: ReadonlyArray<Readonly<RTCIceServer>>,
 ): CollabswarmConfig {
   return defaultConfig(defaultBootstrapConfig([]), webrtcIceServers);
 }

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -92,7 +92,7 @@ export const DEFAULT_WEBRTC_ICE_SERVERS: ReadonlyArray<Readonly<IceServer>> =
  * Exported so {@link defaultNodeConfig} (and any future config helpers) can
  * share the same defensive-copy behavior.
  */
-export const cloneIceServer = (server: IceServer): IceServer => {
+export const cloneIceServer = (server: Readonly<IceServer>): IceServer => {
   const clone: IceServer = { ...server };
   if (Array.isArray(server.urls)) {
     clone.urls = [...server.urls];

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -21,15 +21,51 @@ import { CompactionConfig } from './compaction-config';
 import { DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 
 /**
+ * Default list of free public STUN servers used to populate the WebRTC
+ * `iceServers` configuration when none is provided by the consumer.
+ *
+ * STUN lets peers discover their public IP/port mapping so they can attempt
+ * direct browser-to-browser WebRTC connections without depending on a
+ * Circuit Relay for data forwarding (issue #236, layered NAT-traversal phase 3).
+ *
+ * The list is intentionally kept small (3-4 servers across multiple operators)
+ * so we get redundancy without flooding ICE gathering with redundant probes.
+ *
+ * Sources:
+ * - Google: `stun.l.google.com:19302` -- the de-facto reference public STUN
+ *   server, widely used in WebRTC examples and production apps.
+ * - Cloudflare: `stun.cloudflare.com:3478` -- operated by Cloudflare's
+ *   public WebRTC infra; geographically diverse from Google's anycast.
+ * - Twilio (Mozilla-style fallback): `global.stun.twilio.com:3478` --
+ *   commonly recommended free public STUN endpoint.
+ */
+export const DEFAULT_WEBRTC_ICE_SERVERS: RTCIceServer[] = [
+  { urls: 'stun:stun.l.google.com:19302' },
+  { urls: 'stun:stun1.l.google.com:19302' },
+  { urls: 'stun:stun.cloudflare.com:3478' },
+  { urls: 'stun:global.stun.twilio.com:3478' },
+];
+
+/**
  * Default collabswarm config to use if none is provided.
  *
  * Note: This is a browser-compatible default. It does not include mDNS
  *       (which requires the Node-only `dgram` module). Without bootstrap
  *       nodes this node will be in a swarm of one; use
  *       `collabswarm.connect()` or pass bootstrap addresses to join peers.
+ *
+ * @param bootstrapConfig Bootstrap peer list to seed peer discovery.
+ * @param webrtcIceServers Optional override for the WebRTC ICE server list.
+ *   When undefined, {@link DEFAULT_WEBRTC_ICE_SERVERS} is used so peers can
+ *   discover their public address mappings via STUN without relying on relay
+ *   infrastructure for data plane forwarding.
  */
-export const defaultConfig = (bootstrapConfig: BootstrapInit) =>
-  ({
+export const defaultConfig = (
+  bootstrapConfig: BootstrapInit,
+  webrtcIceServers?: RTCIceServer[],
+) => {
+  const iceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
+  return ({
     // Helia configuration (ref: https://gist.github.com/bellbind/23ad8d6e3a1509335253ff074fcd3cb6)
     helia: {
       blockstore: new IDBBlockstore('/collabswarm-blocks'),
@@ -45,8 +81,10 @@ export const defaultConfig = (bootstrapConfig: BootstrapInit) =>
             reservationConcurrency: 1,
           }),
           webSockets({ filter: all }),
-          webRTC(),
-          webRTCDirect(),
+          // Pass STUN servers so RTCPeerConnection can gather server-reflexive
+          // candidates and attempt direct connections without relay forwarding.
+          webRTC({ rtcConfiguration: { iceServers } }),
+          webRTCDirect({ rtcConfiguration: { iceServers } }),
           webTransport(),
         ],
         streamMuxers: [yamux()],
@@ -74,8 +112,10 @@ export const defaultConfig = (bootstrapConfig: BootstrapInit) =>
 
     pubsubDocumentPrefix: DEFAULT_DOCUMENT_TOPIC_PREFIX,
     pubsubDocumentPublishPath: '/documents',
+    webrtcIceServers: iceServers,
   // Cast required: libp2p sub-dependency types have version mismatches that prevent structural compatibility
   } as unknown as CollabswarmConfig);
+};
 
 /**
  * CollabswarmConfig is a settings object for collabswarm.
@@ -154,6 +194,27 @@ export interface CollabswarmConfig {
   enableNetworkStats?: boolean;
 
   /**
+   * Optional override for the WebRTC ICE server list used by the `webRTC()`
+   * and `webRTCDirect()` transports. When undefined, the built-in
+   * {@link DEFAULT_WEBRTC_ICE_SERVERS} list (Google + Cloudflare + Twilio
+   * public STUN endpoints) is used so peers can discover their public
+   * address mappings without depending on Circuit Relay for the data plane.
+   *
+   * Pass an empty array (`[]`) to disable STUN entirely (e.g. for
+   * fully-internal LAN deployments where mDNS is sufficient), or supply
+   * custom STUN/TURN servers for self-hosted infrastructure.
+   *
+   * Note: this field is informational once the libp2p config has already
+   * been built by {@link defaultConfig}; to actually change the ICE
+   * configuration, pass the override into `defaultConfig(bootstrap, ice)`
+   * (or `getDefaultConfig(ice)`) so it is wired into the transports at
+   * construction time.
+   *
+   * @default DEFAULT_WEBRTC_ICE_SERVERS
+   */
+  webrtcIceServers?: RTCIceServer[];
+
+  /**
    * Optional callback to validate document paths before creation.
    *
    * Called when `open()` determines the document is new (i.e., `load()` returned
@@ -204,7 +265,12 @@ export const defaultBootstrapConfig = (clientAddresses: string[]) =>
  *
  * **Note:** Lazily instantiated -- safe to import in Node.js test environments
  * that lack IndexedDB as long as the function is not called.
+ *
+ * @param webrtcIceServers Optional override for the WebRTC ICE server list.
+ *   When undefined, {@link DEFAULT_WEBRTC_ICE_SERVERS} is used.
  */
-export function getDefaultConfig(): CollabswarmConfig {
-  return defaultConfig(defaultBootstrapConfig([]));
+export function getDefaultConfig(
+  webrtcIceServers?: RTCIceServer[],
+): CollabswarmConfig {
+  return defaultConfig(defaultBootstrapConfig([]), webrtcIceServers);
 }

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -21,6 +21,27 @@ import { CompactionConfig } from './compaction-config';
 import { DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 
 /**
+ * Project-local ICE-server interface used in place of the DOM lib's
+ * `RTCIceServer` so consumers don't need `lib: ["DOM"]` in their tsconfig
+ * (especially Node-only consumers of `collabswarm-node.ts`). The shape
+ * mirrors the subset of WebIDL `RTCIceServer` collabswarm actually reads
+ * and forwards into libp2p's webRTC transport configuration.
+ *
+ * Structurally compatible with `RTCIceServer` in browser environments, so
+ * values typed as `IceServer` can be cast to `RTCIceServer[]` at the
+ * libp2p call site without runtime conversion.
+ */
+export interface IceServer {
+  /** A single STUN/TURN URL or a list of URLs for this server entry. */
+  urls: string | string[];
+  /** Username for TURN authentication. Optional. */
+  username?: string;
+  /** Credential (typically a shared secret / password) for TURN
+   *  authentication. Optional. */
+  credential?: string;
+}
+
+/**
  * Default list of free public STUN servers used to populate the WebRTC
  * `iceServers` configuration when none is provided by the consumer.
  *
@@ -45,27 +66,6 @@ import { DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
  * - Twilio (Mozilla-style fallback): `global.stun.twilio.com:3478` --
  *   commonly recommended free public STUN endpoint.
  */
-/**
- * Project-local ICE-server interface used in place of the DOM lib's
- * `RTCIceServer` so consumers don't need `lib: ["DOM"]` in their tsconfig
- * (especially Node-only consumers of `collabswarm-node.ts`). The shape
- * mirrors the subset of WebIDL `RTCIceServer` collabswarm actually reads
- * and forwards into libp2p's webRTC transport configuration.
- *
- * Structurally compatible with `RTCIceServer` in browser environments, so
- * values typed as `IceServer` can be cast to `RTCIceServer[]` at the
- * libp2p call site without runtime conversion.
- */
-export interface IceServer {
-  /** A single STUN/TURN URL or a list of URLs for this server entry. */
-  urls: string | string[];
-  /** Username for TURN authentication. Optional. */
-  username?: string;
-  /** Credential (typically a shared secret / password) for TURN
-   *  authentication. Optional. */
-  credential?: string;
-}
-
 export const DEFAULT_WEBRTC_ICE_SERVERS: ReadonlyArray<Readonly<IceServer>> =
   Object.freeze([
     Object.freeze({ urls: 'stun:stun.l.google.com:19302' }),

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -39,12 +39,13 @@ import { DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
  * - Twilio (Mozilla-style fallback): `global.stun.twilio.com:3478` --
  *   commonly recommended free public STUN endpoint.
  */
-export const DEFAULT_WEBRTC_ICE_SERVERS: RTCIceServer[] = [
-  { urls: 'stun:stun.l.google.com:19302' },
-  { urls: 'stun:stun1.l.google.com:19302' },
-  { urls: 'stun:stun.cloudflare.com:3478' },
-  { urls: 'stun:global.stun.twilio.com:3478' },
-];
+export const DEFAULT_WEBRTC_ICE_SERVERS: ReadonlyArray<Readonly<RTCIceServer>> =
+  Object.freeze([
+    Object.freeze({ urls: 'stun:stun.l.google.com:19302' }),
+    Object.freeze({ urls: 'stun:stun1.l.google.com:19302' }),
+    Object.freeze({ urls: 'stun:stun.cloudflare.com:3478' }),
+    Object.freeze({ urls: 'stun:global.stun.twilio.com:3478' }),
+  ]);
 
 /**
  * Default collabswarm config to use if none is provided.
@@ -62,9 +63,12 @@ export const DEFAULT_WEBRTC_ICE_SERVERS: RTCIceServer[] = [
  */
 export const defaultConfig = (
   bootstrapConfig: BootstrapInit,
-  webrtcIceServers?: RTCIceServer[],
+  webrtcIceServers?: ReadonlyArray<RTCIceServer>,
 ) => {
-  const iceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
+  // Copy into a fresh mutable array so libp2p's `RTCConfiguration.iceServers`
+  // type (mutable `RTCIceServer[]`) is satisfied without exposing the frozen
+  // `DEFAULT_WEBRTC_ICE_SERVERS` to mutation.
+  const iceServers: RTCIceServer[] = [...(webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS)];
   return ({
     // Helia configuration (ref: https://gist.github.com/bellbind/23ad8d6e3a1509335253ff074fcd3cb6)
     helia: {
@@ -212,7 +216,7 @@ export interface CollabswarmConfig {
    *
    * @default DEFAULT_WEBRTC_ICE_SERVERS
    */
-  webrtcIceServers?: RTCIceServer[];
+  webrtcIceServers?: ReadonlyArray<RTCIceServer>;
 
   /**
    * Optional callback to validate document paths before creation.
@@ -270,7 +274,7 @@ export const defaultBootstrapConfig = (clientAddresses: string[]) =>
  *   When undefined, {@link DEFAULT_WEBRTC_ICE_SERVERS} is used.
  */
 export function getDefaultConfig(
-  webrtcIceServers?: RTCIceServer[],
+  webrtcIceServers?: ReadonlyArray<RTCIceServer>,
 ): CollabswarmConfig {
   return defaultConfig(defaultBootstrapConfig([]), webrtcIceServers);
 }

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -65,10 +65,16 @@ export const defaultConfig = (
   bootstrapConfig: BootstrapInit,
   webrtcIceServers?: ReadonlyArray<RTCIceServer>,
 ) => {
-  // Copy into a fresh mutable array so libp2p's `RTCConfiguration.iceServers`
-  // type (mutable `RTCIceServer[]`) is satisfied without exposing the frozen
-  // `DEFAULT_WEBRTC_ICE_SERVERS` to mutation.
-  const iceServers: RTCIceServer[] = [...(webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS)];
+  // Resolve once from the (possibly readonly) input or the frozen defaults.
+  // Each consumer below gets its own independent copy so mutating any one of
+  // them (e.g., the array exposed on the returned config, or the array
+  // libp2p's webRTC transport stores internally) cannot leak into the others.
+  const sourceIceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
+  // Defensive copy for the exposed config: freeze so consumers cannot mutate
+  // it in place and inadvertently shift state shared with anything else.
+  const exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>> = Object.freeze(
+    sourceIceServers.map((server) => Object.freeze({ ...server })),
+  );
   return ({
     // Helia configuration (ref: https://gist.github.com/bellbind/23ad8d6e3a1509335253ff074fcd3cb6)
     helia: {
@@ -87,8 +93,10 @@ export const defaultConfig = (
           webSockets({ filter: all }),
           // Pass STUN servers so RTCPeerConnection can gather server-reflexive
           // candidates and attempt direct connections without relay forwarding.
-          webRTC({ rtcConfiguration: { iceServers } }),
-          webRTCDirect({ rtcConfiguration: { iceServers } }),
+          // Each transport gets its own fresh mutable copy to avoid aliasing
+          // with the array exposed on `config.webrtcIceServers` below.
+          webRTC({ rtcConfiguration: { iceServers: [...sourceIceServers] } }),
+          webRTCDirect({ rtcConfiguration: { iceServers: [...sourceIceServers] } }),
           webTransport(),
         ],
         streamMuxers: [yamux()],
@@ -116,7 +124,7 @@ export const defaultConfig = (
 
     pubsubDocumentPrefix: DEFAULT_DOCUMENT_TOPIC_PREFIX,
     pubsubDocumentPublishPath: '/documents',
-    webrtcIceServers: iceServers,
+    webrtcIceServers: exposedIceServers,
   // Cast required: libp2p sub-dependency types have version mismatches that prevent structural compatibility
   } as unknown as CollabswarmConfig);
 };

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -31,6 +31,12 @@ import { DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
  * The list is intentionally kept small (3-4 servers across multiple operators)
  * so we get redundancy without flooding ICE gathering with redundant probes.
  *
+ * **Privacy note:** Using these defaults discloses each peer's public
+ * IP/port mapping (and approximate location/ISP) to the listed third-party
+ * STUN operators. Privacy-sensitive deployments should pass `[]` to disable
+ * STUN entirely, or supply their own self-hosted STUN/TURN endpoints via
+ * the `webrtcIceServers` parameter.
+ *
  * Sources:
  * - Google: `stun.l.google.com:19302` -- the de-facto reference public STUN
  *   server, widely used in WebRTC examples and production apps.
@@ -110,6 +116,31 @@ export const freezeIceServer = (server: RTCIceServer): Readonly<RTCIceServer> =>
 };
 
 /**
+ * Internal helper: resolve the source ICE-server list (override or frozen
+ * defaults) and produce a deeply-frozen, defensively-cloned `exposed` view
+ * suitable for assigning to `config.webrtcIceServers`.
+ *
+ * Returning both halves lets the caller hand out fresh per-transport copies
+ * of `sourceIceServers` (via `cloneIceServer`) without re-deriving the
+ * source, while sharing the deep-freeze/clone setup between the browser
+ * (`defaultConfig`) and Node (`defaultNodeConfig`) defaults so they cannot
+ * drift over time.
+ *
+ * Not exported from the package barrel: this is an implementation detail of
+ * the default config builders.
+ */
+export function resolveIceServers(override?: ReadonlyArray<Readonly<RTCIceServer>>): {
+  sourceIceServers: ReadonlyArray<Readonly<RTCIceServer>>;
+  exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>>;
+} {
+  const sourceIceServers = override ?? DEFAULT_WEBRTC_ICE_SERVERS;
+  const exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>> = Object.freeze(
+    sourceIceServers.map((server) => freezeIceServer(cloneIceServer(server))),
+  );
+  return { sourceIceServers, exposedIceServers };
+}
+
+/**
  * Default collabswarm config to use if none is provided.
  *
  * Note: This is a browser-compatible default. It does not include mDNS
@@ -127,19 +158,11 @@ export const defaultConfig = (
   bootstrapConfig: BootstrapInit,
   webrtcIceServers?: ReadonlyArray<Readonly<RTCIceServer>>,
 ) => {
-  // Resolve once from the (possibly readonly) input or the frozen defaults.
-  // Each consumer below gets its own independent copy (including a deep-enough
-  // clone of every server object via `cloneIceServer`) so mutating any one of
-  // them (e.g., the array exposed on the returned config, or the array
-  // libp2p's webRTC transport stores internally, or any individual server's
-  // fields) cannot leak into the others.
-  const sourceIceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
-  // Defensive copy for the exposed config: deep-freeze so consumers cannot
-  // mutate it (or any nested `urls` array / object `credential`) in place and
-  // inadvertently shift state shared with anything else.
-  const exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>> = Object.freeze(
-    sourceIceServers.map((server) => freezeIceServer(cloneIceServer(server))),
-  );
+  // Resolve the source list and a deeply-frozen exposed view in one place so
+  // the browser and Node defaults stay in sync. Each transport below still
+  // gets its own fresh `cloneIceServer`-deep-cloned copy of `sourceIceServers`
+  // so mutations never leak between transport state and `config.webrtcIceServers`.
+  const { sourceIceServers, exposedIceServers } = resolveIceServers(webrtcIceServers);
   return ({
     // Helia configuration (ref: https://gist.github.com/bellbind/23ad8d6e3a1509335253ff074fcd3cb6)
     helia: {
@@ -278,9 +301,11 @@ export interface CollabswarmConfig {
    * public STUN endpoints) is used so peers can discover their public
    * address mappings without depending on Circuit Relay for the data plane.
    *
-   * Pass an empty array (`[]`) to disable STUN entirely (e.g. for
-   * fully-internal LAN deployments where mDNS is sufficient), or supply
-   * custom STUN/TURN servers for self-hosted infrastructure.
+   * **Privacy note:** Using the public STUN defaults discloses each peer's
+   * public IP/port mapping to the third-party STUN operators. For
+   * privacy-sensitive deployments, pass `[]` to disable STUN entirely (e.g.
+   * for fully-internal LAN deployments where mDNS is sufficient), or supply
+   * self-hosted STUN/TURN servers.
    *
    * Note: this field is informational once the libp2p config has already
    * been built by {@link defaultConfig}; to actually change the ICE

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -45,7 +45,28 @@ import { DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
  * - Twilio (Mozilla-style fallback): `global.stun.twilio.com:3478` --
  *   commonly recommended free public STUN endpoint.
  */
-export const DEFAULT_WEBRTC_ICE_SERVERS: ReadonlyArray<Readonly<RTCIceServer>> =
+/**
+ * Project-local ICE-server interface used in place of the DOM lib's
+ * `RTCIceServer` so consumers don't need `lib: ["DOM"]` in their tsconfig
+ * (especially Node-only consumers of `collabswarm-node.ts`). The shape
+ * mirrors the subset of WebIDL `RTCIceServer` collabswarm actually reads
+ * and forwards into libp2p's webRTC transport configuration.
+ *
+ * Structurally compatible with `RTCIceServer` in browser environments, so
+ * values typed as `IceServer` can be cast to `RTCIceServer[]` at the
+ * libp2p call site without runtime conversion.
+ */
+export interface IceServer {
+  /** A single STUN/TURN URL or a list of URLs for this server entry. */
+  urls: string | string[];
+  /** Username for TURN authentication. Optional. */
+  username?: string;
+  /** Credential (typically a shared secret / password) for TURN
+   *  authentication. Optional. */
+  credential?: string;
+}
+
+export const DEFAULT_WEBRTC_ICE_SERVERS: ReadonlyArray<Readonly<IceServer>> =
   Object.freeze([
     Object.freeze({ urls: 'stun:stun.l.google.com:19302' }),
     Object.freeze({ urls: 'stun:stun1.l.google.com:19302' }),
@@ -54,63 +75,51 @@ export const DEFAULT_WEBRTC_ICE_SERVERS: ReadonlyArray<Readonly<RTCIceServer>> =
   ]);
 
 /**
- * Returns a deep-enough copy of an `RTCIceServer` so callers can hand the
+ * Returns a deep-enough copy of an {@link IceServer} so callers can hand the
  * result to libp2p (which expects a mutable `RTCIceServer`) without sharing
  * any inner references with the source object.
  *
  * In particular:
  * - the top-level object is a fresh `{ ...server }` so mutating fields like
- *   `username` on the copy cannot affect the source;
+ *   `username`/`credential` on the copy cannot affect the source;
  * - if `urls` is an array, it is copied to a fresh array so `push()`/`splice()`
  *   on the copy cannot affect the source's URL list (a single `string` value
- *   is immutable, so it is forwarded as-is);
- * - if `credential` is an object (e.g. the historical `RTCOAuthCredential`
- *   shape, which is no longer in the current TS lib.dom but can still appear
- *   at runtime), it is shallow-copied so mutating its fields on the copy
- *   cannot affect the source. A `string` credential is immutable and is
- *   forwarded as-is.
+ *   is immutable, so it is forwarded as-is).
+ *
+ * `credential` is a `string` in the project-local {@link IceServer} shape
+ * (and strings are immutable), so no nested copy is needed there.
  *
  * Exported so {@link defaultNodeConfig} (and any future config helpers) can
  * share the same defensive-copy behavior.
  */
-export const cloneIceServer = (server: RTCIceServer): RTCIceServer => {
-  const clone: RTCIceServer = { ...server };
+export const cloneIceServer = (server: IceServer): IceServer => {
+  const clone: IceServer = { ...server };
   if (Array.isArray(server.urls)) {
     clone.urls = [...server.urls];
-  }
-  // `credential` is typed as `string | undefined` in current TS lib.dom, but
-  // older WebIDL allowed an `RTCOAuthCredential` object and some runtimes
-  // still accept one. Guard with a runtime check (cast to `unknown` first to
-  // bypass the narrowed type) so we copy object credentials defensively.
-  const credential = server.credential as unknown;
-  if (typeof credential === 'object' && credential !== null) {
-    (clone as { credential?: unknown }).credential = { ...(credential as object) };
   }
   return clone;
 };
 
 /**
- * Freezes an `RTCIceServer` and any nested mutable structures it owns so the
- * returned value is safe to expose to consumers as deeply-immutable.
+ * Freezes an {@link IceServer} and any nested mutable structures it owns so
+ * the returned value is safe to expose to consumers as deeply-immutable.
  *
- * `Object.freeze` is shallow, so without freezing nested arrays/objects a
- * caller could still mutate `server.urls` (when it's an array) or an object
- * `credential` through the exposed reference. This helper closes that gap.
+ * `Object.freeze` is shallow, so without also freezing the nested `urls`
+ * array (when present) a caller could still mutate it through the exposed
+ * reference. This helper closes that gap. `urls` as a plain `string` and
+ * the `string` `credential`/`username` fields are already immutable and
+ * need no extra handling.
  *
- * Mutates the input in place (then returns it) -- callers should pair it with
- * {@link cloneIceServer} when they need to freeze a copy without affecting
- * the source.
+ * Mutates the input in place (then returns it) -- callers should pair it
+ * with {@link cloneIceServer} when they need to freeze a copy without
+ * affecting the source.
  *
  * Exported so {@link defaultNodeConfig} (and any future config helpers) can
  * share the same deep-freeze behavior.
  */
-export const freezeIceServer = (server: RTCIceServer): Readonly<RTCIceServer> => {
+export const freezeIceServer = (server: IceServer): Readonly<IceServer> => {
   if (Array.isArray(server.urls)) {
     Object.freeze(server.urls);
-  }
-  const credential = server.credential as unknown;
-  if (typeof credential === 'object' && credential !== null) {
-    Object.freeze(credential);
   }
   return Object.freeze(server);
 };
@@ -129,12 +138,12 @@ export const freezeIceServer = (server: RTCIceServer): Readonly<RTCIceServer> =>
  * Not exported from the package barrel: this is an implementation detail of
  * the default config builders.
  */
-export function resolveIceServers(override?: ReadonlyArray<Readonly<RTCIceServer>>): {
-  sourceIceServers: ReadonlyArray<Readonly<RTCIceServer>>;
-  exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>>;
+export function resolveIceServers(override?: ReadonlyArray<Readonly<IceServer>>): {
+  sourceIceServers: ReadonlyArray<Readonly<IceServer>>;
+  exposedIceServers: ReadonlyArray<Readonly<IceServer>>;
 } {
   const sourceIceServers = override ?? DEFAULT_WEBRTC_ICE_SERVERS;
-  const exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>> = Object.freeze(
+  const exposedIceServers: ReadonlyArray<Readonly<IceServer>> = Object.freeze(
     sourceIceServers.map((server) => freezeIceServer(cloneIceServer(server))),
   );
   return { sourceIceServers, exposedIceServers };
@@ -156,7 +165,7 @@ export function resolveIceServers(override?: ReadonlyArray<Readonly<RTCIceServer
  */
 export const defaultConfig = (
   bootstrapConfig: BootstrapInit,
-  webrtcIceServers?: ReadonlyArray<Readonly<RTCIceServer>>,
+  webrtcIceServers?: ReadonlyArray<Readonly<IceServer>>,
 ) => {
   // Resolve the source list and a deeply-frozen exposed view in one place so
   // the browser and Node defaults stay in sync. Each transport below still
@@ -184,8 +193,10 @@ export const defaultConfig = (
           // Each transport gets its own fresh mutable copy (with each server
           // object also deep-enough-cloned via `cloneIceServer`) to avoid
           // aliasing with the array exposed on `config.webrtcIceServers` below.
-          webRTC({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) } }),
-          webRTCDirect({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) } }),
+          // Cast to `RTCIceServer[]` only at the libp2p call site so the
+          // public collabswarm API stays free of DOM lib types.
+          webRTC({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) as RTCIceServer[] } }),
+          webRTCDirect({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) as RTCIceServer[] } }),
           webTransport(),
         ],
         streamMuxers: [yamux()],
@@ -315,7 +326,7 @@ export interface CollabswarmConfig {
    *
    * @default DEFAULT_WEBRTC_ICE_SERVERS
    */
-  webrtcIceServers?: ReadonlyArray<Readonly<RTCIceServer>>;
+  webrtcIceServers?: ReadonlyArray<Readonly<IceServer>>;
 
   /**
    * Optional callback to validate document paths before creation.
@@ -373,7 +384,7 @@ export const defaultBootstrapConfig = (clientAddresses: string[]) =>
  *   When undefined, {@link DEFAULT_WEBRTC_ICE_SERVERS} is used.
  */
 export function getDefaultConfig(
-  webrtcIceServers?: ReadonlyArray<Readonly<RTCIceServer>>,
+  webrtcIceServers?: ReadonlyArray<Readonly<IceServer>>,
 ): CollabswarmConfig {
   return defaultConfig(defaultBootstrapConfig([]), webrtcIceServers);
 }

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -54,18 +54,60 @@ export const DEFAULT_WEBRTC_ICE_SERVERS: ReadonlyArray<Readonly<RTCIceServer>> =
  *
  * In particular:
  * - the top-level object is a fresh `{ ...server }` so mutating fields like
- *   `username`/`credential` on the copy cannot affect the source;
+ *   `username` on the copy cannot affect the source;
  * - if `urls` is an array, it is copied to a fresh array so `push()`/`splice()`
  *   on the copy cannot affect the source's URL list (a single `string` value
- *   is immutable, so it is forwarded as-is).
+ *   is immutable, so it is forwarded as-is);
+ * - if `credential` is an object (e.g. the historical `RTCOAuthCredential`
+ *   shape, which is no longer in the current TS lib.dom but can still appear
+ *   at runtime), it is shallow-copied so mutating its fields on the copy
+ *   cannot affect the source. A `string` credential is immutable and is
+ *   forwarded as-is.
  *
  * Exported so {@link defaultNodeConfig} (and any future config helpers) can
  * share the same defensive-copy behavior.
  */
-export const cloneIceServer = (server: RTCIceServer): RTCIceServer => ({
-  ...server,
-  urls: Array.isArray(server.urls) ? [...server.urls] : server.urls,
-});
+export const cloneIceServer = (server: RTCIceServer): RTCIceServer => {
+  const clone: RTCIceServer = { ...server };
+  if (Array.isArray(server.urls)) {
+    clone.urls = [...server.urls];
+  }
+  // `credential` is typed as `string | undefined` in current TS lib.dom, but
+  // older WebIDL allowed an `RTCOAuthCredential` object and some runtimes
+  // still accept one. Guard with a runtime check (cast to `unknown` first to
+  // bypass the narrowed type) so we copy object credentials defensively.
+  const credential = server.credential as unknown;
+  if (typeof credential === 'object' && credential !== null) {
+    (clone as { credential?: unknown }).credential = { ...(credential as object) };
+  }
+  return clone;
+};
+
+/**
+ * Freezes an `RTCIceServer` and any nested mutable structures it owns so the
+ * returned value is safe to expose to consumers as deeply-immutable.
+ *
+ * `Object.freeze` is shallow, so without freezing nested arrays/objects a
+ * caller could still mutate `server.urls` (when it's an array) or an object
+ * `credential` through the exposed reference. This helper closes that gap.
+ *
+ * Mutates the input in place (then returns it) -- callers should pair it with
+ * {@link cloneIceServer} when they need to freeze a copy without affecting
+ * the source.
+ *
+ * Exported so {@link defaultNodeConfig} (and any future config helpers) can
+ * share the same deep-freeze behavior.
+ */
+export const freezeIceServer = (server: RTCIceServer): Readonly<RTCIceServer> => {
+  if (Array.isArray(server.urls)) {
+    Object.freeze(server.urls);
+  }
+  const credential = server.credential as unknown;
+  if (typeof credential === 'object' && credential !== null) {
+    Object.freeze(credential);
+  }
+  return Object.freeze(server);
+};
 
 /**
  * Default collabswarm config to use if none is provided.
@@ -92,10 +134,11 @@ export const defaultConfig = (
   // libp2p's webRTC transport stores internally, or any individual server's
   // fields) cannot leak into the others.
   const sourceIceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
-  // Defensive copy for the exposed config: freeze so consumers cannot mutate
-  // it in place and inadvertently shift state shared with anything else.
+  // Defensive copy for the exposed config: deep-freeze so consumers cannot
+  // mutate it (or any nested `urls` array / object `credential`) in place and
+  // inadvertently shift state shared with anything else.
   const exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>> = Object.freeze(
-    sourceIceServers.map((server) => Object.freeze(cloneIceServer(server))),
+    sourceIceServers.map((server) => freezeIceServer(cloneIceServer(server))),
   );
   return ({
     // Helia configuration (ref: https://gist.github.com/bellbind/23ad8d6e3a1509335253ff074fcd3cb6)

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -73,10 +73,16 @@ export const defaultNodeConfig = (
   bootstrapConfig: BootstrapInit,
   webrtcIceServers?: ReadonlyArray<RTCIceServer>,
 ) => {
-  // Copy into a fresh mutable array so libp2p's `RTCConfiguration.iceServers`
-  // type (mutable `RTCIceServer[]`) is satisfied without exposing the frozen
-  // `DEFAULT_WEBRTC_ICE_SERVERS` to mutation.
-  const iceServers: RTCIceServer[] = [...(webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS)];
+  // Resolve once from the (possibly readonly) input or the frozen defaults.
+  // Each consumer below gets its own independent copy so mutating any one of
+  // them (e.g., the array exposed on the returned config, or the array
+  // libp2p's webRTC transport stores internally) cannot leak into the others.
+  const sourceIceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
+  // Defensive copy for the exposed config: freeze so consumers cannot mutate
+  // it in place and inadvertently shift state shared with anything else.
+  const exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>> = Object.freeze(
+    sourceIceServers.map((server) => Object.freeze({ ...server })),
+  );
   return ({
     helia: {
       blockstore: new IDBBlockstore('/collabswarm-blocks'),
@@ -94,8 +100,10 @@ export const defaultNodeConfig = (
           webSockets({ filter: all }),
           // Pass STUN servers so RTCPeerConnection can gather server-reflexive
           // candidates and attempt direct connections without relay forwarding.
-          webRTC({ rtcConfiguration: { iceServers } }),
-          webRTCDirect({ rtcConfiguration: { iceServers } }),
+          // Each transport gets its own fresh mutable copy to avoid aliasing
+          // with the array exposed on `config.webrtcIceServers` below.
+          webRTC({ rtcConfiguration: { iceServers: [...sourceIceServers] } }),
+          webRTCDirect({ rtcConfiguration: { iceServers: [...sourceIceServers] } }),
           webTransport(),
         ],
         streamMuxers: [yamux()],
@@ -122,7 +130,7 @@ export const defaultNodeConfig = (
     },
     pubsubDocumentPrefix: '/document/',
     pubsubDocumentPublishPath: '/documents',
-    webrtcIceServers: iceServers,
+    webrtcIceServers: exposedIceServers,
   // Cast required: libp2p sub-dependency types have version mismatches that prevent structural compatibility
   } as unknown as CollabswarmConfig);
 };

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -13,6 +13,7 @@
 import * as fs from 'fs';
 import {
   CollabswarmConfig,
+  DEFAULT_WEBRTC_ICE_SERVERS,
   defaultBootstrapConfig,
   defaultConfig,
 } from './collabswarm-config';
@@ -61,9 +62,19 @@ import { bootstrap, BootstrapInit } from '@libp2p/bootstrap';
  * local network, privacy-sensitive deployments should disable it by building a
  * custom config (copy this one and omit `mdns()` from `peerDiscovery`) rather
  * than using `defaultNodeConfig` directly.
+ *
+ * @param bootstrapConfig Bootstrap peer list to seed peer discovery.
+ * @param webrtcIceServers Optional override for the WebRTC ICE server list.
+ *   When undefined, {@link DEFAULT_WEBRTC_ICE_SERVERS} is used so peers can
+ *   discover their public address mappings via STUN without relying on relay
+ *   infrastructure for data plane forwarding (issue #236 phase 3).
  */
-export const defaultNodeConfig = (bootstrapConfig: BootstrapInit) =>
-  ({
+export const defaultNodeConfig = (
+  bootstrapConfig: BootstrapInit,
+  webrtcIceServers?: RTCIceServer[],
+) => {
+  const iceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
+  return ({
     helia: {
       blockstore: new IDBBlockstore('/collabswarm-blocks'),
       datastore: new IDBDatastore('/collabswarm-data'),
@@ -78,8 +89,10 @@ export const defaultNodeConfig = (bootstrapConfig: BootstrapInit) =>
             reservationConcurrency: 1,
           }),
           webSockets({ filter: all }),
-          webRTC(),
-          webRTCDirect(),
+          // Pass STUN servers so RTCPeerConnection can gather server-reflexive
+          // candidates and attempt direct connections without relay forwarding.
+          webRTC({ rtcConfiguration: { iceServers } }),
+          webRTCDirect({ rtcConfiguration: { iceServers } }),
           webTransport(),
         ],
         streamMuxers: [yamux()],
@@ -106,8 +119,10 @@ export const defaultNodeConfig = (bootstrapConfig: BootstrapInit) =>
     },
     pubsubDocumentPrefix: '/document/',
     pubsubDocumentPublishPath: '/documents',
+    webrtcIceServers: iceServers,
   // Cast required: libp2p sub-dependency types have version mismatches that prevent structural compatibility
   } as unknown as CollabswarmConfig);
+};
 
 export class CollabswarmNode<
   DocType,

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -71,9 +71,12 @@ import { bootstrap, BootstrapInit } from '@libp2p/bootstrap';
  */
 export const defaultNodeConfig = (
   bootstrapConfig: BootstrapInit,
-  webrtcIceServers?: RTCIceServer[],
+  webrtcIceServers?: ReadonlyArray<RTCIceServer>,
 ) => {
-  const iceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
+  // Copy into a fresh mutable array so libp2p's `RTCConfiguration.iceServers`
+  // type (mutable `RTCIceServer[]`) is satisfied without exposing the frozen
+  // `DEFAULT_WEBRTC_ICE_SERVERS` to mutation.
+  const iceServers: RTCIceServer[] = [...(webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS)];
   return ({
     helia: {
       blockstore: new IDBBlockstore('/collabswarm-blocks'),

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -301,9 +301,33 @@ export class CollabswarmNode<
     // is written to a file that can be bundled into browser builds. Browsers
     // that need authenticated TURN should obtain ephemeral credentials at
     // runtime instead of receiving long-lived secrets via this file.
+    //
+    // Warn loudly when stripping a non-empty credential: a TURN entry without
+    // its credential will not authenticate, so the browser silently degrades
+    // to STUN-only / host candidates and may fail to connect through
+    // symmetric NATs. Operators should either provide STUN-only entries or
+    // wire up an ephemeral-TURN-credential flow in their app code.
+    const strippedTurnEntries: string[] = [];
     const browserSafeIceServers = this.config.webrtcIceServers?.map(
-      ({ username: _username, credential: _credential, ...rest }) => rest,
+      ({ username, credential, ...rest }) => {
+        if (username !== undefined || credential !== undefined) {
+          const urlsLabel = Array.isArray(rest.urls)
+            ? rest.urls.join(',')
+            : rest.urls;
+          strippedTurnEntries.push(urlsLabel);
+        }
+        return rest;
+      },
     );
+    if (strippedTurnEntries.length > 0) {
+      console.warn(
+        `[collabswarm] Stripped TURN credentials from clientConfig for: ${strippedTurnEntries.join(
+          '; ',
+        )}. Browsers will not authenticate against these TURN servers; ` +
+          'supply ephemeral credentials at runtime instead of long-lived ' +
+          'secrets in clientConfig.',
+      );
+    }
     const clientConfig = defaultConfig(
       defaultBootstrapConfig(bootstrapAddresses ?? []),
       browserSafeIceServers,

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -307,23 +307,23 @@ export class CollabswarmNode<
     // to STUN-only / host candidates and may fail to connect through
     // symmetric NATs. Operators should either provide STUN-only entries or
     // wire up an ephemeral-TURN-credential flow in their app code.
-    const strippedTurnEntries: string[] = [];
+    const strippedTurnEntries = new Set<string>();
     const browserSafeIceServers = this.config.webrtcIceServers?.map(
       ({ username, credential, ...rest }) => {
         if (username !== undefined || credential !== undefined) {
           const urlsLabel = Array.isArray(rest.urls)
             ? rest.urls.join(',')
             : rest.urls;
-          strippedTurnEntries.push(urlsLabel);
+          strippedTurnEntries.add(urlsLabel);
         }
         return rest;
       },
     );
-    if (strippedTurnEntries.length > 0) {
+    if (strippedTurnEntries.size > 0) {
       console.warn(
-        `[collabswarm] Stripped TURN credentials from clientConfig for: ${strippedTurnEntries.join(
-          '; ',
-        )}. Browsers will not authenticate against these TURN servers; ` +
+        `[collabswarm] Stripped TURN credentials from clientConfig for: ${Array.from(
+          strippedTurnEntries,
+        ).join('; ')}. Browsers will not authenticate against these TURN servers; ` +
           'supply ephemeral credentials at runtime instead of long-lived ' +
           'secrets in clientConfig.',
       );

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -17,6 +17,7 @@ import {
   cloneIceServer,
   defaultBootstrapConfig,
   defaultConfig,
+  freezeIceServer,
 } from './collabswarm-config';
 import { Collabswarm } from './collabswarm';
 import { CollabswarmDocument } from './collabswarm-document';
@@ -81,10 +82,11 @@ export const defaultNodeConfig = (
   // libp2p's webRTC transport stores internally, or any individual server's
   // fields) cannot leak into the others.
   const sourceIceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
-  // Defensive copy for the exposed config: freeze so consumers cannot mutate
-  // it in place and inadvertently shift state shared with anything else.
+  // Defensive copy for the exposed config: deep-freeze so consumers cannot
+  // mutate it (or any nested `urls` array / object `credential`) in place and
+  // inadvertently shift state shared with anything else.
   const exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>> = Object.freeze(
-    sourceIceServers.map((server) => Object.freeze(cloneIceServer(server))),
+    sourceIceServers.map((server) => freezeIceServer(cloneIceServer(server))),
   );
   return ({
     helia: {

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -281,8 +281,14 @@ export class CollabswarmNode<
   // Start
   public async start(boostrapAddresses?: string[]) {
     await this.swarm.initialize(this.config);
+    // Thread the Node-side ICE override (already resolved and exposed on
+    // `this.config.webrtcIceServers` by `defaultNodeConfig`) into the
+    // browser-side client config so a deployment that customizes STUN/TURN
+    // (or disables it via `[]`) ends up with the same list on both sides
+    // rather than silently falling back to `DEFAULT_WEBRTC_ICE_SERVERS`.
     const clientConfig = defaultConfig(
       defaultBootstrapConfig(boostrapAddresses ?? []),
+      this.config.webrtcIceServers,
     );
     const clientConfigFile =
       process.env.REACT_APP_CLIENT_CONFIG_FILE || 'client-config.env';

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -67,9 +67,10 @@ import { bootstrap, BootstrapInit } from '@libp2p/bootstrap';
  *
  * @param bootstrapConfig Bootstrap peer list to seed peer discovery.
  * @param webrtcIceServers Optional override for the WebRTC ICE server list.
- *   When undefined, {@link DEFAULT_WEBRTC_ICE_SERVERS} is used so peers can
- *   discover their public address mappings via STUN without relying on relay
- *   infrastructure for data plane forwarding (issue #236 phase 3).
+ *   When undefined, the package-level `DEFAULT_WEBRTC_ICE_SERVERS` list is
+ *   used (see `./collabswarm-config`) so peers can discover their public
+ *   address mappings via STUN without relying on relay infrastructure for
+ *   data plane forwarding (issue #236 phase 3).
  */
 export const defaultNodeConfig = (
   bootstrapConfig: BootstrapInit,
@@ -284,11 +285,16 @@ export class CollabswarmNode<
   // Start
   public async start(bootstrapAddresses?: string[]) {
     await this.swarm.initialize(this.config);
-    // Thread the Node-side ICE override (already resolved and exposed on
+    // Thread the Node-side ICE override (resolved and exposed on
     // `this.config.webrtcIceServers` by `defaultNodeConfig`) into the
     // browser-side client config so a deployment that customizes STUN/TURN
-    // (or disables it via `[]`) ends up with the same list on both sides
-    // rather than silently falling back to `DEFAULT_WEBRTC_ICE_SERVERS`.
+    // (or disables it via `[]`) ends up with the same list on both sides.
+    //
+    // Edge case: if a hand-rolled config skips `defaultNodeConfig` and
+    // leaves `webrtcIceServers` unset, `browserSafeIceServers` is left
+    // undefined and `defaultConfig` falls back to its own
+    // `DEFAULT_WEBRTC_ICE_SERVERS`. Configs built via `defaultNodeConfig`
+    // never hit that path.
     //
     // Strip `username`/`credential` before passing the list across: TURN
     // credentials are server-side secrets and the resulting `clientConfig`

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -282,16 +282,25 @@ export class CollabswarmNode<
   }
 
   // Start
-  public async start(boostrapAddresses?: string[]) {
+  public async start(bootstrapAddresses?: string[]) {
     await this.swarm.initialize(this.config);
     // Thread the Node-side ICE override (already resolved and exposed on
     // `this.config.webrtcIceServers` by `defaultNodeConfig`) into the
     // browser-side client config so a deployment that customizes STUN/TURN
     // (or disables it via `[]`) ends up with the same list on both sides
     // rather than silently falling back to `DEFAULT_WEBRTC_ICE_SERVERS`.
+    //
+    // Strip `username`/`credential` before passing the list across: TURN
+    // credentials are server-side secrets and the resulting `clientConfig`
+    // is written to a file that can be bundled into browser builds. Browsers
+    // that need authenticated TURN should obtain ephemeral credentials at
+    // runtime instead of receiving long-lived secrets via this file.
+    const browserSafeIceServers = this.config.webrtcIceServers?.map(
+      ({ username: _username, credential: _credential, ...rest }) => rest,
+    );
     const clientConfig = defaultConfig(
-      defaultBootstrapConfig(boostrapAddresses ?? []),
-      this.config.webrtcIceServers,
+      defaultBootstrapConfig(bootstrapAddresses ?? []),
+      browserSafeIceServers,
     );
     const clientConfigFile =
       process.env.REACT_APP_CLIENT_CONFIG_FILE || 'client-config.env';

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -14,6 +14,7 @@ import * as fs from 'fs';
 import {
   CollabswarmConfig,
   DEFAULT_WEBRTC_ICE_SERVERS,
+  cloneIceServer,
   defaultBootstrapConfig,
   defaultConfig,
 } from './collabswarm-config';
@@ -71,17 +72,19 @@ import { bootstrap, BootstrapInit } from '@libp2p/bootstrap';
  */
 export const defaultNodeConfig = (
   bootstrapConfig: BootstrapInit,
-  webrtcIceServers?: ReadonlyArray<RTCIceServer>,
+  webrtcIceServers?: ReadonlyArray<Readonly<RTCIceServer>>,
 ) => {
   // Resolve once from the (possibly readonly) input or the frozen defaults.
-  // Each consumer below gets its own independent copy so mutating any one of
+  // Each consumer below gets its own independent copy (including a deep-enough
+  // clone of every server object via `cloneIceServer`) so mutating any one of
   // them (e.g., the array exposed on the returned config, or the array
-  // libp2p's webRTC transport stores internally) cannot leak into the others.
+  // libp2p's webRTC transport stores internally, or any individual server's
+  // fields) cannot leak into the others.
   const sourceIceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
   // Defensive copy for the exposed config: freeze so consumers cannot mutate
   // it in place and inadvertently shift state shared with anything else.
   const exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>> = Object.freeze(
-    sourceIceServers.map((server) => Object.freeze({ ...server })),
+    sourceIceServers.map((server) => Object.freeze(cloneIceServer(server))),
   );
   return ({
     helia: {
@@ -100,10 +103,11 @@ export const defaultNodeConfig = (
           webSockets({ filter: all }),
           // Pass STUN servers so RTCPeerConnection can gather server-reflexive
           // candidates and attempt direct connections without relay forwarding.
-          // Each transport gets its own fresh mutable copy to avoid aliasing
-          // with the array exposed on `config.webrtcIceServers` below.
-          webRTC({ rtcConfiguration: { iceServers: [...sourceIceServers] } }),
-          webRTCDirect({ rtcConfiguration: { iceServers: [...sourceIceServers] } }),
+          // Each transport gets its own fresh mutable copy (with each server
+          // object also deep-enough-cloned via `cloneIceServer`) to avoid
+          // aliasing with the array exposed on `config.webrtcIceServers` below.
+          webRTC({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) } }),
+          webRTCDirect({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) } }),
           webTransport(),
         ],
         streamMuxers: [yamux()],

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -13,6 +13,7 @@
 import * as fs from 'fs';
 import {
   CollabswarmConfig,
+  IceServer,
   cloneIceServer,
   defaultBootstrapConfig,
   defaultConfig,
@@ -72,7 +73,7 @@ import { bootstrap, BootstrapInit } from '@libp2p/bootstrap';
  */
 export const defaultNodeConfig = (
   bootstrapConfig: BootstrapInit,
-  webrtcIceServers?: ReadonlyArray<Readonly<RTCIceServer>>,
+  webrtcIceServers?: ReadonlyArray<Readonly<IceServer>>,
 ) => {
   // Resolve the source list and a deeply-frozen exposed view in one place so
   // the browser and Node defaults stay in sync. Each transport below still
@@ -99,8 +100,10 @@ export const defaultNodeConfig = (
           // Each transport gets its own fresh mutable copy (with each server
           // object also deep-enough-cloned via `cloneIceServer`) to avoid
           // aliasing with the array exposed on `config.webrtcIceServers` below.
-          webRTC({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) } }),
-          webRTCDirect({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) } }),
+          // Cast to `RTCIceServer[]` only at the libp2p call site so the
+          // public collabswarm API stays free of DOM lib types.
+          webRTC({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) as RTCIceServer[] } }),
+          webRTCDirect({ rtcConfiguration: { iceServers: sourceIceServers.map(cloneIceServer) as RTCIceServer[] } }),
           webTransport(),
         ],
         streamMuxers: [yamux()],

--- a/packages/collabswarm/src/collabswarm-node.ts
+++ b/packages/collabswarm/src/collabswarm-node.ts
@@ -13,11 +13,10 @@
 import * as fs from 'fs';
 import {
   CollabswarmConfig,
-  DEFAULT_WEBRTC_ICE_SERVERS,
   cloneIceServer,
   defaultBootstrapConfig,
   defaultConfig,
-  freezeIceServer,
+  resolveIceServers,
 } from './collabswarm-config';
 import { Collabswarm } from './collabswarm';
 import { CollabswarmDocument } from './collabswarm-document';
@@ -75,19 +74,11 @@ export const defaultNodeConfig = (
   bootstrapConfig: BootstrapInit,
   webrtcIceServers?: ReadonlyArray<Readonly<RTCIceServer>>,
 ) => {
-  // Resolve once from the (possibly readonly) input or the frozen defaults.
-  // Each consumer below gets its own independent copy (including a deep-enough
-  // clone of every server object via `cloneIceServer`) so mutating any one of
-  // them (e.g., the array exposed on the returned config, or the array
-  // libp2p's webRTC transport stores internally, or any individual server's
-  // fields) cannot leak into the others.
-  const sourceIceServers = webrtcIceServers ?? DEFAULT_WEBRTC_ICE_SERVERS;
-  // Defensive copy for the exposed config: deep-freeze so consumers cannot
-  // mutate it (or any nested `urls` array / object `credential`) in place and
-  // inadvertently shift state shared with anything else.
-  const exposedIceServers: ReadonlyArray<Readonly<RTCIceServer>> = Object.freeze(
-    sourceIceServers.map((server) => freezeIceServer(cloneIceServer(server))),
-  );
+  // Resolve the source list and a deeply-frozen exposed view in one place so
+  // the browser and Node defaults stay in sync. Each transport below still
+  // gets its own fresh `cloneIceServer`-deep-cloned copy of `sourceIceServers`
+  // so mutations never leak between transport state and `config.webrtcIceServers`.
+  const { sourceIceServers, exposedIceServers } = resolveIceServers(webrtcIceServers);
   return ({
     helia: {
       blockstore: new IDBBlockstore('/collabswarm-blocks'),

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -1,6 +1,7 @@
 import { Collabswarm, CollabswarmPeersHandler } from './collabswarm';
 import {
   CollabswarmConfig,
+  DEFAULT_WEBRTC_ICE_SERVERS,
   defaultConfig,
   defaultBootstrapConfig,
   getDefaultConfig,
@@ -128,6 +129,7 @@ export {
   defaultConfig,
   defaultBootstrapConfig,
   getDefaultConfig,
+  DEFAULT_WEBRTC_ICE_SERVERS,
   // Capabilities
   CAP_DOC_ADMIN,
   CAP_DOC_WRITE,

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -2,10 +2,8 @@ import { Collabswarm, CollabswarmPeersHandler } from './collabswarm';
 import {
   CollabswarmConfig,
   DEFAULT_WEBRTC_ICE_SERVERS,
-  cloneIceServer,
   defaultConfig,
   defaultBootstrapConfig,
-  freezeIceServer,
   getDefaultConfig,
 } from './collabswarm-config';
 import {
@@ -132,8 +130,6 @@ export {
   defaultBootstrapConfig,
   getDefaultConfig,
   DEFAULT_WEBRTC_ICE_SERVERS,
-  cloneIceServer,
-  freezeIceServer,
   // Capabilities
   CAP_DOC_ADMIN,
   CAP_DOC_WRITE,

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -2,6 +2,7 @@ import { Collabswarm, CollabswarmPeersHandler } from './collabswarm';
 import {
   CollabswarmConfig,
   DEFAULT_WEBRTC_ICE_SERVERS,
+  cloneIceServer,
   defaultConfig,
   defaultBootstrapConfig,
   getDefaultConfig,
@@ -130,6 +131,7 @@ export {
   defaultBootstrapConfig,
   getDefaultConfig,
   DEFAULT_WEBRTC_ICE_SERVERS,
+  cloneIceServer,
   // Capabilities
   CAP_DOC_ADMIN,
   CAP_DOC_WRITE,

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -5,6 +5,7 @@ import {
   cloneIceServer,
   defaultConfig,
   defaultBootstrapConfig,
+  freezeIceServer,
   getDefaultConfig,
 } from './collabswarm-config';
 import {
@@ -132,6 +133,7 @@ export {
   getDefaultConfig,
   DEFAULT_WEBRTC_ICE_SERVERS,
   cloneIceServer,
+  freezeIceServer,
   // Capabilities
   CAP_DOC_ADMIN,
   CAP_DOC_WRITE,

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -2,6 +2,7 @@ import { Collabswarm, CollabswarmPeersHandler } from './collabswarm';
 import {
   CollabswarmConfig,
   DEFAULT_WEBRTC_ICE_SERVERS,
+  IceServer,
   defaultConfig,
   defaultBootstrapConfig,
   getDefaultConfig,
@@ -130,6 +131,7 @@ export {
   defaultBootstrapConfig,
   getDefaultConfig,
   DEFAULT_WEBRTC_ICE_SERVERS,
+  IceServer,
   // Capabilities
   CAP_DOC_ADMIN,
   CAP_DOC_WRITE,


### PR DESCRIPTION
## Summary

Implements **phase 3** of the layered NAT-traversal strategy from issue #236: adds free public STUN servers to the `webRTC()` and `webRTCDirect()` transport configurations so peers can gather server-reflexive ICE candidates and discover their public IP/port mappings without depending on Circuit Relay V2 for data plane forwarding.

Phase 1 (mDNS for same-LAN peers, #238) is already merged. This PR ships phase 3 alone; phase 2 (DCUtR hole-punching) is intentionally out of scope and will be a separate change since it requires adding a new `@libp2p/dcutr` package.

## Changes

- New exported constant `DEFAULT_WEBRTC_ICE_SERVERS` containing four reputable free public STUN endpoints, kept intentionally small to avoid flooding ICE gathering:
  - `stun:stun.l.google.com:19302` (Google primary)
  - `stun:stun1.l.google.com:19302` (Google secondary, different anycast pool)
  - `stun:stun.cloudflare.com:3478` (Cloudflare's public WebRTC infra)
  - `stun:global.stun.twilio.com:3478` (Twilio public STUN, commonly recommended fallback)
- `webRTC()` and `webRTCDirect()` invocations in both `defaultConfig` (browser) and `defaultNodeConfig` (Node) now pass `rtcConfiguration: { iceServers }` so the STUN servers are wired into every `RTCPeerConnection`.
- New optional `webrtcIceServers?: ReadonlyArray<Readonly<IceServer>>` field on `CollabswarmConfig` (typed against a project-local `IceServer` interface rather than the DOM `RTCIceServer` lib type so Node-only consumers don't need the `DOM` lib). Pass an empty array to disable STUN entirely (e.g. LAN-only deployments where mDNS is sufficient), or supply custom STUN/TURN servers for self-hosted infrastructure.
- `defaultConfig`, `defaultNodeConfig`, and `getDefaultConfig` accept an optional override parameter that gets plumbed through to the transport options and copied onto the merged config for introspection.

## Why STUN matters here

Issue #236 notes that Circuit Relay V2 is currently required for all browser-to-browser connections. STUN alone won't punch through symmetric NATs (that's what phase 2 / DCUtR is for), but it does let peers discover their public address mappings, which is a prerequisite for direct connections on roughly cone-NAT-style endpoints and lays the groundwork for DCUtR to operate on top.

Closes part of #236.

## Test plan

- [x] `yarn workspace @collabswarm/collabswarm tsc` (clean, 0 errors)
- [x] `yarn workspace @collabswarm/collabswarm test` (15 suites, 298 tests passing)
- [ ] Manual smoke: open two browsers behind home NATs, confirm WebRTC connection establishes after relay reservation but does not require relay forwarding for sustained data
- [ ] Verify default ICE servers show up in `RTCPeerConnection.getConfiguration()` in browser devtools when running an app built against the default config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebRTC ICE servers can be provided per deployment and override defaults.
  * A public default ICE server list is exposed for reference and reuse.
  * Node and client configs share a resolved ICE server set for consistent connection behavior.
  * Client/browser configs automatically omit sensitive ICE credential fields for safe distribution.
  * Startup now logs a warning when ICE credentials are stripped from entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
