### PR TITLE
Cache writer key list to avoid redundant ACL traversals

### DIFF
--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -144,10 +144,16 @@ export class CollabswarmDocument<
 
   // Cached snapshot of `_writers.users()` for hot-path signature verification.
   // Document-scoped (not per-DAG-node): every signature check needs the current
-  // trusted writer set, so a single lazy cache is sufficient. Invalidated to
-  // `null` whenever `_writers` is mutated via `_mergeWriters` / `_addWriter` /
-  // `_removeWriter`. All ACL mutations must go through those helpers.
+  // trusted writer set, so a single lazy cache is sufficient. Invalidated by
+  // bumping `_writerKeysVersion` whenever `_writers` is mutated via
+  // `_mergeWriters` / `_addWriter` / `_removeWriter`. All ACL mutations must
+  // go through those helpers. The version counter is what makes invalidation
+  // race-safe: `_getWriterKeys` captures the version before awaiting and only
+  // commits the result if the version is still current, so an in-flight fetch
+  // that races with an invalidation cannot overwrite the new null state with
+  // a stale list (which could otherwise admit signatures from a revoked writer).
   private _cachedWriterKeys: PublicKey[] | null = null;
+  private _writerKeysVersion = 0;
 
   // List of document encryption keys. Lower index numbers mean more recent.
   // Since the document is created from change history, all keys are needed.
@@ -635,31 +641,50 @@ export class CollabswarmDocument<
    * the document-scoped cache on miss. Callers must not mutate the result.
    * The cache is invalidated by `_mergeWriters`, `_addWriter`, and
    * `_removeWriter` -- the only sanctioned mutation paths for `_writers`.
+   *
+   * Race-safety: we capture `_writerKeysVersion` before awaiting and only
+   * assign the result back to the cache if the version is unchanged. A
+   * concurrent invalidation bumps the version, so an in-flight fetch from
+   * before the invalidation can no longer overwrite the (now-null) cache
+   * with a stale writer list -- preventing acceptance of signatures from a
+   * just-revoked writer.
    */
   private async _getWriterKeys(): Promise<PublicKey[]> {
-    if (this._cachedWriterKeys === null) {
-      this._cachedWriterKeys = await this._writers.users();
+    if (this._cachedWriterKeys !== null) {
+      return this._cachedWriterKeys;
     }
-    return this._cachedWriterKeys;
+    const versionAtStart = this._writerKeysVersion;
+    const fetched = await this._writers.users();
+    if (this._writerKeysVersion === versionAtStart) {
+      this._cachedWriterKeys = fetched;
+    }
+    return fetched;
+  }
+
+  /** Bump the writer-keys version so any in-flight `_getWriterKeys` aborts
+   *  its assignment, and clear the cache for the next caller. */
+  private _invalidateWriterKeyCache(): void {
+    this._cachedWriterKeys = null;
+    this._writerKeysVersion++;
   }
 
   /** Apply a writer ACL change and invalidate the cached key list. */
   private _mergeWriters(changes: ChangesType): void {
     this._writers.merge(changes);
-    this._cachedWriterKeys = null;
+    this._invalidateWriterKeyCache();
   }
 
   /** Add a writer and invalidate the cached key list. */
   private async _addWriter(publicKey: PublicKey): Promise<ChangesType> {
     const changes = await this._writers.add(publicKey);
-    this._cachedWriterKeys = null;
+    this._invalidateWriterKeyCache();
     return changes;
   }
 
   /** Remove a writer and invalidate the cached key list. */
   private async _removeWriter(publicKey: PublicKey): Promise<ChangesType> {
     const changes = await this._writers.remove(publicKey);
-    this._cachedWriterKeys = null;
+    this._invalidateWriterKeyCache();
     return changes;
   }
 

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -142,6 +142,13 @@ export class CollabswarmDocument<
   // Document writers ACL.
   private _writers;
 
+  // Cached snapshot of `_writers.users()` for hot-path signature verification.
+  // Document-scoped (not per-DAG-node): every signature check needs the current
+  // trusted writer set, so a single lazy cache is sufficient. Invalidated to
+  // `null` whenever `_writers` is mutated via `_mergeWriters` / `_addWriter` /
+  // `_removeWriter`. All ACL mutations must go through those helpers.
+  private _cachedWriterKeys: PublicKey[] | null = null;
+
   // List of document encryption keys. Lower index numbers mean more recent.
   // Since the document is created from change history, all keys are needed.
   private _keychain;
@@ -515,7 +522,7 @@ export class CollabswarmDocument<
           }
           case crdtWriterChangeNode: {
             // Apply the changes that were sent directly.
-            this._writers.merge(sentChanges);
+            this._mergeWriters(sentChanges);
             newDocumentHashes.push(sentHash);
             break;
           }
@@ -561,7 +568,7 @@ export class CollabswarmDocument<
                   return;
                 }
                 case crdtWriterChangeNode: {
-                  this._writers.merge(missingChanges);
+                  this._mergeWriters(missingChanges);
                   this._hashes.add(missingHash);
                   await this._fireRemoteUpdateHandlers([missingHash]);
                   return;
@@ -603,7 +610,7 @@ export class CollabswarmDocument<
   private _applyACLFromTree(node: CRDTChangeNode<ChangesType>) {
     if (node.change) {
       if (node.kind === crdtWriterChangeNode) {
-        this._writers.merge(node.change);
+        this._mergeWriters(node.change);
       } else if (node.kind === crdtReaderChangeNode) {
         this._readers.merge(node.change);
       }
@@ -623,20 +630,50 @@ export class CollabswarmDocument<
     return this.swarm.config?.enableSigning !== false;
   }
 
+  /**
+   * Returns the current list of authorized writer public keys, populating
+   * the document-scoped cache on miss. Callers must not mutate the result.
+   * The cache is invalidated by `_mergeWriters`, `_addWriter`, and
+   * `_removeWriter` -- the only sanctioned mutation paths for `_writers`.
+   */
+  private async _getWriterKeys(): Promise<PublicKey[]> {
+    if (this._cachedWriterKeys === null) {
+      this._cachedWriterKeys = await this._writers.users();
+    }
+    return this._cachedWriterKeys;
+  }
+
+  /** Apply a writer ACL change and invalidate the cached key list. */
+  private _mergeWriters(changes: ChangesType): void {
+    this._writers.merge(changes);
+    this._cachedWriterKeys = null;
+  }
+
+  /** Add a writer and invalidate the cached key list. */
+  private async _addWriter(publicKey: PublicKey): Promise<ChangesType> {
+    const changes = await this._writers.add(publicKey);
+    this._cachedWriterKeys = null;
+    return changes;
+  }
+
+  /** Remove a writer and invalidate the cached key list. */
+  private async _removeWriter(publicKey: PublicKey): Promise<ChangesType> {
+    const changes = await this._writers.remove(publicKey);
+    this._cachedWriterKeys = null;
+    return changes;
+  }
+
   private async _verifyWriterSignature(raw: Uint8Array, signature: string) {
     if (!this._isSigningEnabled()) {
       return true;
     }
 
-    // TODO: Cache list of current writers per dag node for now.
+    const writerKeys = await this._getWriterKeys();
+    const signatureBytes = this._deserializeSignature(signature);
     const verificationTasks: Promise<boolean>[] = [];
-    for (const writerKey of await this._writers.users()) {
+    for (const writerKey of writerKeys) {
       verificationTasks.push(
-        this._authProvider.verify(
-          raw,
-          writerKey,
-          this._deserializeSignature(signature),
-        ),
+        this._authProvider.verify(raw, writerKey, signatureBytes),
       );
     }
     return firstTrue(verificationTasks);
@@ -654,8 +691,9 @@ export class CollabswarmDocument<
       return true;
     }
 
+    const writerKeys = await this._getWriterKeys();
     const verificationTasks: Promise<boolean>[] = [];
-    for (const writerKey of await this._writers.users()) {
+    for (const writerKey of writerKeys) {
       verificationTasks.push(
         this._authProvider.verify(payload, writerKey, signature),
       );
@@ -1336,7 +1374,7 @@ export class CollabswarmDocument<
         // On first load (_writers is empty / bootstrapping), we cannot
         // verify -- trust relies on the encrypted channel (only peers
         // with the document key can decrypt the response).
-        const preLoadWriters = await this._writers.users();
+        const preLoadWriters = await this._getWriterKeys();
         if (preLoadWriters.length > 0 && this._isSigningEnabled()) {
           if (!message.signature) {
             console.warn(
@@ -1665,7 +1703,7 @@ export class CollabswarmDocument<
 
       if (!isExisting) {
         // Add current user as a writer.
-        await this._writers.add(this._userPublicKey);
+        await this._addWriter(this._userPublicKey);
 
         // Add initial document key.
         console.log(`Adding a key to ${this.documentPath}`);
@@ -2246,7 +2284,7 @@ export class CollabswarmDocument<
     }
 
     // Construct a new writer ACL change.
-    const changes = await this._writers.add(writer);
+    const changes = await this._addWriter(writer);
 
     await this._makeChange(changes, crdtWriterChangeNode);
   }
@@ -2265,7 +2303,7 @@ export class CollabswarmDocument<
     }
 
     // Construct a new writer ACL change.
-    const changes = await this._writers.remove(writer);
+    const changes = await this._removeWriter(writer);
 
     await this._makeChange(changes, crdtWriterChangeNode);
 

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -152,7 +152,10 @@ export class CollabswarmDocument<
   // commits the result if the version is still current, so an in-flight fetch
   // that races with an invalidation cannot overwrite the new null state with
   // a stale list (which could otherwise admit signatures from a revoked writer).
-  private _cachedWriterKeys: PublicKey[] | null = null;
+  // Typed `ReadonlyArray` so an accidental mutation by an internal caller is
+  // a type error rather than a silent cache corruption that would affect
+  // later signature verification.
+  private _cachedWriterKeys: ReadonlyArray<PublicKey> | null = null;
   private _writerKeysVersion = 0;
 
   // List of document encryption keys. Lower index numbers mean more recent.
@@ -653,7 +656,7 @@ export class CollabswarmDocument<
    * would spin, but invalidations are bounded (one per ACL mutation) and
    * not adversarial.
    */
-  private async _getWriterKeys(): Promise<PublicKey[]> {
+  private async _getWriterKeys(): Promise<ReadonlyArray<PublicKey>> {
     while (true) {
       if (this._cachedWriterKeys !== null) {
         return this._cachedWriterKeys;

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -157,6 +157,15 @@ export class CollabswarmDocument<
   // later signature verification.
   private _cachedWriterKeys: ReadonlyArray<PublicKey> | null = null;
   private _writerKeysVersion = 0;
+  // Counter of in-flight `_writers` mutations (add/remove/merge). Some ACL
+  // implementations (e.g. UCANACL.remove, YjsACL.remove) mutate their
+  // backing state *before* their returned Promise resolves, so during the
+  // mutation window `_writers.users()` may already reflect the new state
+  // even though the helper has not yet reached its post-await invalidation
+  // line. While this counter is nonzero, `_getWriterKeys` bypasses the
+  // cache entirely and always re-fetches, so a signature check that races
+  // a mutation cannot observe the stale pre-mutation list.
+  private _writerMutationsInFlight = 0;
 
   // List of document encryption keys. Lower index numbers mean more recent.
   // Since the document is created from change history, all keys are needed.
@@ -645,32 +654,56 @@ export class CollabswarmDocument<
    * The cache is invalidated by `_mergeWriters`, `_addWriter`, and
    * `_removeWriter` -- the only sanctioned mutation paths for `_writers`.
    *
-   * Race-safety: we capture `_writerKeysVersion` before awaiting. If a
-   * concurrent invalidation bumps the version while the fetch is in
-   * flight, the fetched list reflects the *pre*-invalidation ACL and is
-   * unsafe to return -- handing it to the caller (signature verification)
-   * could verify a just-revoked writer one last time. So we discard the
-   * stale fetch and loop, re-reading the (now-cleared) cache and starting
-   * a fresh `users()` call. The loop converges once a fetch completes
-   * with no intervening invalidation; under continuous invalidation it
-   * would spin, but invalidations are bounded (one per ACL mutation) and
-   * not adversarial.
+   * Race-safety has two layers:
+   *  - Mutation-in-flight bypass: while `_writerMutationsInFlight > 0`,
+   *    skip the cache entirely. Some ACLs mutate their backing state
+   *    before their `add`/`remove` Promise resolves, so the cached list
+   *    can be stale even though the post-await invalidation has not yet
+   *    run. Bypassing forces a fresh `users()` read each call until all
+   *    mutations have finished and the cache is re-populated by a clean
+   *    miss.
+   *  - Version check on cache fill: capture `_writerKeysVersion` before
+   *    awaiting. If the version advances mid-fetch, the fetched list
+   *    reflects the *pre*-invalidation ACL and is unsafe to return --
+   *    discard it and loop. The loop converges once a fetch completes
+   *    with no intervening invalidation; under continuous invalidation
+   *    it would spin, but invalidations are bounded (one per ACL
+   *    mutation) and not adversarial.
    */
   private async _getWriterKeys(): Promise<ReadonlyArray<PublicKey>> {
     while (true) {
-      if (this._cachedWriterKeys !== null) {
+      if (
+        this._writerMutationsInFlight === 0 &&
+        this._cachedWriterKeys !== null
+      ) {
         return this._cachedWriterKeys;
       }
       const versionAtStart = this._writerKeysVersion;
       const fetched = await this._writers.users();
-      if (this._writerKeysVersion === versionAtStart) {
+      // Only commit to the cache if (a) the version is still current AND
+      // (b) no mutations are in flight. Either condition means the fetch
+      // could be racing a still-incomplete mutation; in that case return
+      // the freshly fetched list to the caller but leave the cache null
+      // so the next caller re-fetches.
+      if (
+        this._writerKeysVersion === versionAtStart &&
+        this._writerMutationsInFlight === 0
+      ) {
         this._cachedWriterKeys = fetched;
         return fetched;
       }
-      // Version advanced during fetch -- the fetched list reflects the
-      // pre-invalidation ACL. Discard it and retry with the post-
-      // invalidation state to avoid handing a stale list to signature
-      // verification.
+      if (this._writerKeysVersion !== versionAtStart) {
+        // Version advanced during fetch -- the fetched list reflects the
+        // pre-invalidation ACL. Discard it and retry with the post-
+        // invalidation state to avoid handing a stale list to signature
+        // verification.
+        continue;
+      }
+      // Mutation still in flight but version unchanged: the fetched list
+      // reflects whatever the ACL exposed at this moment, which is the
+      // best the caller can get. Don't cache (so subsequent reads see
+      // the post-mutation state once it lands), but return the value.
+      return fetched;
     }
   }
 
@@ -681,24 +714,54 @@ export class CollabswarmDocument<
     this._writerKeysVersion++;
   }
 
+  /**
+   * Run a writer-ACL mutation under a guard that closes the gap between
+   * "underlying ACL state has changed" and "_getWriterKeys reflects the
+   * change." We invalidate the cache *before* the mutation (so any
+   * concurrent `_getWriterKeys` re-fetches against whatever state the
+   * ACL exposes at that moment) AND set a mutation-in-flight flag that
+   * forces `_getWriterKeys` to bypass the cache entirely while the
+   * mutation runs. Both bookkeeping operations live in the prelude/
+   * finally so they cannot drift out of sync with the underlying call.
+   */
+  private async _runWriterMutation<T>(op: () => Promise<T> | T): Promise<T> {
+    this._writerMutationsInFlight++;
+    this._invalidateWriterKeyCache();
+    try {
+      return await op();
+    } finally {
+      this._writerMutationsInFlight--;
+      // Invalidate again post-mutation: the underlying ACL is now
+      // authoritative and any value that landed in the cache during the
+      // window must be discarded. Idempotent and cheap.
+      this._invalidateWriterKeyCache();
+    }
+  }
+
   /** Apply a writer ACL change and invalidate the cached key list. */
   private _mergeWriters(changes: ChangesType): void {
-    this._writers.merge(changes);
+    // Synchronous mutation: increment-mutate-decrement around the
+    // `merge()` call so any concurrent `_getWriterKeys` running on
+    // another microtask sees the in-flight flag. Both invalidations
+    // (pre and post) match the async helper's behavior.
+    this._writerMutationsInFlight++;
     this._invalidateWriterKeyCache();
+    try {
+      this._writers.merge(changes);
+    } finally {
+      this._writerMutationsInFlight--;
+      this._invalidateWriterKeyCache();
+    }
   }
 
   /** Add a writer and invalidate the cached key list. */
   private async _addWriter(publicKey: PublicKey): Promise<ChangesType> {
-    const changes = await this._writers.add(publicKey);
-    this._invalidateWriterKeyCache();
-    return changes;
+    return this._runWriterMutation(() => this._writers.add(publicKey));
   }
 
   /** Remove a writer and invalidate the cached key list. */
   private async _removeWriter(publicKey: PublicKey): Promise<ChangesType> {
-    const changes = await this._writers.remove(publicKey);
-    this._invalidateWriterKeyCache();
-    return changes;
+    return this._runWriterMutation(() => this._writers.remove(publicKey));
   }
 
   private async _verifyWriterSignature(raw: Uint8Array, signature: string) {

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -1426,7 +1426,21 @@ export class CollabswarmDocument<
           const raw = this._syncMessageSerializer.serializeSyncMessage(
             messageWithoutSignature,
           );
-          const signatureBytes = this._deserializeSignature(signature);
+          // Mirror `_verifyWriterSignature`: a malformed/non-string signature
+          // can cause `js-base64` to throw. Treat decode failure as a
+          // verification failure for this peer (skip and let the caller try
+          // the next one) rather than letting the exception escape -- the
+          // outer snapshot-load attempt swallows errors via a blanket
+          // catch{}, which would hide the malformed input entirely.
+          let signatureBytes: Uint8Array;
+          try {
+            signatureBytes = this._deserializeSignature(signature);
+          } catch {
+            console.warn(
+              `Load response for ${this.documentPath}: malformed signature, skipping peer`,
+            );
+            return false;
+          }
           const verifyTasks = preLoadWriters.map((writerKey) =>
             this._authProvider.verify(raw, writerKey, signatureBytes),
           );

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -1427,41 +1427,43 @@ export class CollabswarmDocument<
         // On first load (_writers is empty / bootstrapping), we cannot
         // verify -- trust relies on the encrypted channel (only peers
         // with the document key can decrypt the response).
-        const preLoadWriters = await this._getWriterKeys();
-        if (preLoadWriters.length > 0 && this._isSigningEnabled()) {
-          if (!message.signature) {
-            console.warn(
-              `Load response for ${this.documentPath}: missing signature, skipping peer`,
+        if (this._isSigningEnabled()) {
+          const preLoadWriters = await this._getWriterKeys();
+          if (preLoadWriters.length > 0) {
+            if (!message.signature) {
+              console.warn(
+                `Load response for ${this.documentPath}: missing signature, skipping peer`,
+              );
+              return false;
+            }
+            const { signature, ...messageWithoutSignature } = message;
+            const raw = this._syncMessageSerializer.serializeSyncMessage(
+              messageWithoutSignature,
             );
-            return false;
-          }
-          const { signature, ...messageWithoutSignature } = message;
-          const raw = this._syncMessageSerializer.serializeSyncMessage(
-            messageWithoutSignature,
-          );
-          // Mirror `_verifyWriterSignature`: a malformed/non-string signature
-          // can cause `js-base64` to throw. Treat decode failure as a
-          // verification failure for this peer (skip and let the caller try
-          // the next one) rather than letting the exception escape -- the
-          // outer snapshot-load attempt swallows errors via a blanket
-          // catch{}, which would hide the malformed input entirely.
-          let signatureBytes: Uint8Array;
-          try {
-            signatureBytes = this._deserializeSignature(signature);
-          } catch {
-            console.warn(
-              `Load response for ${this.documentPath}: malformed signature, skipping peer`,
+            // Mirror `_verifyWriterSignature`: a malformed/non-string signature
+            // can cause `js-base64` to throw. Treat decode failure as a
+            // verification failure for this peer (skip and let the caller try
+            // the next one) rather than letting the exception escape -- the
+            // outer snapshot-load attempt swallows errors via a blanket
+            // catch{}, which would hide the malformed input entirely.
+            let signatureBytes: Uint8Array;
+            try {
+              signatureBytes = this._deserializeSignature(signature);
+            } catch {
+              console.warn(
+                `Load response for ${this.documentPath}: malformed signature, skipping peer`,
+              );
+              return false;
+            }
+            const verifyTasks = preLoadWriters.map((writerKey) =>
+              this._authProvider.verify(raw, writerKey, signatureBytes),
             );
-            return false;
-          }
-          const verifyTasks = preLoadWriters.map((writerKey) =>
-            this._authProvider.verify(raw, writerKey, signatureBytes),
-          );
-          if (!(await firstTrue(verifyTasks))) {
-            console.warn(
-              `Load response for ${this.documentPath} failed writer signature verification, skipping peer`,
-            );
-            return false;
+            if (!(await firstTrue(verifyTasks))) {
+              console.warn(
+                `Load response for ${this.documentPath} failed writer signature verification, skipping peer`,
+              );
+              return false;
+            }
           }
         }
 

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -694,7 +694,22 @@ export class CollabswarmDocument<
     }
 
     const writerKeys = await this._getWriterKeys();
-    const signatureBytes = this._deserializeSignature(signature);
+    // Short-circuit: with no writers, no signature can verify. Avoids the
+    // base64 decode for an unverifiable input.
+    if (writerKeys.length === 0) {
+      return false;
+    }
+    // Malformed base64 throws inside js-base64. A bad signature must surface
+    // as a verification failure, not an exception -- the topic validator path
+    // turns thrown errors into Ignore (effectively dropping the message
+    // silently), which is a DoS surface for malformed input. Treat decode
+    // failure as `false`.
+    let signatureBytes: Uint8Array;
+    try {
+      signatureBytes = this._deserializeSignature(signature);
+    } catch {
+      return false;
+    }
     const verificationTasks: Promise<boolean>[] = [];
     for (const writerKey of writerKeys) {
       verificationTasks.push(

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -642,23 +642,33 @@ export class CollabswarmDocument<
    * The cache is invalidated by `_mergeWriters`, `_addWriter`, and
    * `_removeWriter` -- the only sanctioned mutation paths for `_writers`.
    *
-   * Race-safety: we capture `_writerKeysVersion` before awaiting and only
-   * assign the result back to the cache if the version is unchanged. A
-   * concurrent invalidation bumps the version, so an in-flight fetch from
-   * before the invalidation can no longer overwrite the (now-null) cache
-   * with a stale writer list -- preventing acceptance of signatures from a
-   * just-revoked writer.
+   * Race-safety: we capture `_writerKeysVersion` before awaiting. If a
+   * concurrent invalidation bumps the version while the fetch is in
+   * flight, the fetched list reflects the *pre*-invalidation ACL and is
+   * unsafe to return -- handing it to the caller (signature verification)
+   * could verify a just-revoked writer one last time. So we discard the
+   * stale fetch and loop, re-reading the (now-cleared) cache and starting
+   * a fresh `users()` call. The loop converges once a fetch completes
+   * with no intervening invalidation; under continuous invalidation it
+   * would spin, but invalidations are bounded (one per ACL mutation) and
+   * not adversarial.
    */
   private async _getWriterKeys(): Promise<PublicKey[]> {
-    if (this._cachedWriterKeys !== null) {
-      return this._cachedWriterKeys;
+    while (true) {
+      if (this._cachedWriterKeys !== null) {
+        return this._cachedWriterKeys;
+      }
+      const versionAtStart = this._writerKeysVersion;
+      const fetched = await this._writers.users();
+      if (this._writerKeysVersion === versionAtStart) {
+        this._cachedWriterKeys = fetched;
+        return fetched;
+      }
+      // Version advanced during fetch -- the fetched list reflects the
+      // pre-invalidation ACL. Discard it and retry with the post-
+      // invalidation state to avoid handing a stale list to signature
+      // verification.
     }
-    const versionAtStart = this._writerKeysVersion;
-    const fetched = await this._writers.users();
-    if (this._writerKeysVersion === versionAtStart) {
-      this._cachedWriterKeys = fetched;
-    }
-    return fetched;
   }
 
   /** Bump the writer-keys version so any in-flight `_getWriterKeys` aborts

--- a/packages/collabswarm/src/collabswarm.test.ts
+++ b/packages/collabswarm/src/collabswarm.test.ts
@@ -340,29 +340,43 @@ describe('writer key cache', () => {
   // Minimal harness mirroring the document-scoped cache and the three
   // mutation paths (merge / add / remove). Production code lives in
   // CollabswarmDocument (collabswarm-document.ts).
+  //
+  // The version counter exists for race-safety: an in-flight `getKeys()` that
+  // started before an invalidation captures the version at fetch time and
+  // refuses to commit its result if the version has advanced. Without it, a
+  // stale fetch could overwrite the freshly-invalidated null cache with a
+  // pre-revocation writer list.
   class WriterCacheHarness<T> {
     private _cached: T[] | null = null;
+    private _version = 0;
     public usersCalls = 0;
     constructor(private readonly _backing: { users: () => Promise<T[]>; merge: () => void; add: () => Promise<void>; remove: () => Promise<void>; }) {}
 
     async getKeys(): Promise<T[]> {
-      if (this._cached === null) {
-        this.usersCalls++;
-        this._cached = await this._backing.users();
+      if (this._cached !== null) return this._cached;
+      this.usersCalls++;
+      const versionAtStart = this._version;
+      const fetched = await this._backing.users();
+      if (this._version === versionAtStart) {
+        this._cached = fetched;
       }
-      return this._cached;
+      return fetched;
+    }
+    private _invalidate(): void {
+      this._cached = null;
+      this._version++;
     }
     merge(): void {
       this._backing.merge();
-      this._cached = null;
+      this._invalidate();
     }
     async add(): Promise<void> {
       await this._backing.add();
-      this._cached = null;
+      this._invalidate();
     }
     async remove(): Promise<void> {
       await this._backing.remove();
-      this._cached = null;
+      this._invalidate();
     }
   }
 
@@ -418,6 +432,53 @@ describe('writer key cache', () => {
     await cache.remove();
     expect(await cache.getKeys()).toEqual(['k1', 'merged']);
     expect(cache.usersCalls).toBe(4);
+  });
+
+  test('invalidation during in-flight users() fetch does not overwrite the cleared cache', async () => {
+    // Reproduces the race fixed in the writer-key cache: while a getKeys()
+    // call is awaiting users(), an invalidation (e.g. revoking a writer)
+    // races in. The pre-invalidation fetch must NOT commit its (now-stale)
+    // result back to the cache, or the next reader could see the revoked
+    // writer in the trusted set.
+    const pendingResolves: Array<(keys: string[]) => void> = [];
+    let usersCalls = 0;
+    let currentKeys = ['k1', 'revoked'];
+    const backing = {
+      users: () => {
+        usersCalls++;
+        return new Promise<string[]>((resolve) => {
+          pendingResolves.push(resolve);
+        });
+      },
+      merge: () => { currentKeys = currentKeys.filter((k) => k !== 'revoked'); },
+      add: async () => {},
+      remove: async () => {},
+    };
+    const cache = new WriterCacheHarness<string>(backing);
+
+    // Start a getKeys() that captures the OLD writer set.
+    const inFlight = cache.getKeys();
+    expect(usersCalls).toBe(1);
+    expect(pendingResolves.length).toBe(1);
+
+    // Race: an ACL update revokes the writer mid-fetch.
+    cache.merge();
+
+    // Resolve the pre-invalidation fetch with the stale list.
+    pendingResolves[0](['k1', 'revoked']);
+    const result = await inFlight;
+    // The resolved value still reflects what users() returned, but...
+    expect(result).toEqual(['k1', 'revoked']);
+
+    // ...the next read must NOT reuse it: the cache was cleared by merge,
+    // and the in-flight fetch must have refused to assign back. So
+    // getKeys() re-queries the backing.
+    const nextPromise = cache.getKeys();
+    expect(usersCalls).toBe(2);
+    expect(pendingResolves.length).toBe(2);
+    pendingResolves[1](currentKeys.slice());
+    const next = await nextPromise;
+    expect(next).toEqual(['k1']); // would be ['k1', 'revoked'] without the version guard
   });
 });
 

--- a/packages/collabswarm/src/collabswarm.test.ts
+++ b/packages/collabswarm/src/collabswarm.test.ts
@@ -329,3 +329,95 @@ describe('getReaders() dedup logic', () => {
   });
 });
 
+/**
+ * Tests for the writer-key caching pattern in CollabswarmDocument's
+ * `_getWriterKeys` / `_mergeWriters` / `_addWriter` / `_removeWriter` helpers.
+ * Replicates the cache + invalidation logic against a mock ACL so we can
+ * exercise hit/miss and invalidation paths in isolation, without standing up
+ * a full libp2p/Helia stack.
+ */
+describe('writer key cache', () => {
+  // Minimal harness mirroring the document-scoped cache and the three
+  // mutation paths (merge / add / remove). Production code lives in
+  // CollabswarmDocument (collabswarm-document.ts).
+  class WriterCacheHarness<T> {
+    private _cached: T[] | null = null;
+    public usersCalls = 0;
+    constructor(private readonly _backing: { users: () => Promise<T[]>; merge: () => void; add: () => Promise<void>; remove: () => Promise<void>; }) {}
+
+    async getKeys(): Promise<T[]> {
+      if (this._cached === null) {
+        this.usersCalls++;
+        this._cached = await this._backing.users();
+      }
+      return this._cached;
+    }
+    merge(): void {
+      this._backing.merge();
+      this._cached = null;
+    }
+    async add(): Promise<void> {
+      await this._backing.add();
+      this._cached = null;
+    }
+    async remove(): Promise<void> {
+      await this._backing.remove();
+      this._cached = null;
+    }
+  }
+
+  test('caches users() and reuses on subsequent calls', async () => {
+    const keys = ['k1', 'k2'];
+    const backing = {
+      users: async () => keys.slice(),
+      merge: () => {},
+      add: async () => {},
+      remove: async () => {},
+    };
+    const cache = new WriterCacheHarness<string>(backing);
+
+    const a = await cache.getKeys();
+    const b = await cache.getKeys();
+    const c = await cache.getKeys();
+
+    expect(a).toEqual(keys);
+    expect(b).toEqual(keys);
+    expect(c).toEqual(keys);
+    // backing.users() should have been called exactly once across three lookups
+    expect(cache.usersCalls).toBe(1);
+  });
+
+  test('invalidates the cache on merge / add / remove', async () => {
+    let currentKeys = ['k1'];
+    const backing = {
+      users: async () => currentKeys.slice(),
+      merge: () => { currentKeys = [...currentKeys, 'merged']; },
+      add: async () => { currentKeys = [...currentKeys, 'added']; },
+      remove: async () => { currentKeys = currentKeys.slice(0, -1); },
+    };
+    const cache = new WriterCacheHarness<string>(backing);
+
+    expect(await cache.getKeys()).toEqual(['k1']);
+    expect(cache.usersCalls).toBe(1);
+
+    // merge invalidates -- next read sees the new state and re-queries.
+    cache.merge();
+    expect(await cache.getKeys()).toEqual(['k1', 'merged']);
+    expect(cache.usersCalls).toBe(2);
+
+    // Reads after merge stay cached.
+    expect(await cache.getKeys()).toEqual(['k1', 'merged']);
+    expect(cache.usersCalls).toBe(2);
+
+    // add invalidates.
+    await cache.add();
+    expect(await cache.getKeys()).toEqual(['k1', 'merged', 'added']);
+    expect(cache.usersCalls).toBe(3);
+
+    // remove invalidates.
+    await cache.remove();
+    expect(await cache.getKeys()).toEqual(['k1', 'merged']);
+    expect(cache.usersCalls).toBe(4);
+  });
+});
+

--- a/packages/collabswarm/src/collabswarm.test.ts
+++ b/packages/collabswarm/src/collabswarm.test.ts
@@ -482,3 +482,99 @@ describe('writer key cache', () => {
   });
 });
 
+/**
+ * Tests for the malformed-signature defense in `_verifyWriterSignature`.
+ * The production code lives in CollabswarmDocument; the harness below
+ * replicates its decode-then-verify control flow so we can drive it with
+ * forced-throw decoders (matching the pattern used elsewhere in this file).
+ *
+ * Why the guard exists: `Base64.toUint8Array` *can* throw on certain inputs
+ * (notably non-string values that slip through type erasure in over-the-wire
+ * messages). In the topic validator path, a thrown error is caught and
+ * mapped to `Ignore`, silently dropping the message -- which is a usable
+ * DoS surface for malformed input. Catching decode failures and returning
+ * `false` instead surfaces the failure cleanly as "signature did not
+ * verify" without crashing.
+ */
+describe('verifyWriterSignature malformed-signature handling', () => {
+  // Replicates the relevant control flow from
+  // CollabswarmDocument._verifyWriterSignature so we can test the
+  // short-circuit and try/catch in isolation. If the production logic
+  // changes, mirror it here.
+  async function verifyWriterSignature<PublicKey>(opts: {
+    signingEnabled: boolean;
+    writerKeys: PublicKey[];
+    signature: string;
+    deserialize: (s: string) => Uint8Array;
+    verify: (raw: Uint8Array, key: PublicKey, sig: Uint8Array) => Promise<boolean>;
+    raw: Uint8Array;
+  }): Promise<boolean> {
+    if (!opts.signingEnabled) return true;
+    if (opts.writerKeys.length === 0) return false;
+    let signatureBytes: Uint8Array;
+    try {
+      signatureBytes = opts.deserialize(opts.signature);
+    } catch {
+      return false;
+    }
+    const tasks = opts.writerKeys.map((k) => opts.verify(opts.raw, k, signatureBytes));
+    const results = await Promise.all(tasks);
+    return results.some((r) => r);
+  }
+
+  test('returns false when base64 decode throws (does not propagate exception)', async () => {
+    // Force a throw to mimic js-base64 throwing on a malformed input
+    // (e.g. a non-string sneaking through, or a rejected encoding).
+    const throwingDecode = (_: string): Uint8Array => {
+      throw new TypeError('malformed base64');
+    };
+    let verifyCalled = false;
+    const result = await verifyWriterSignature<string>({
+      signingEnabled: true,
+      writerKeys: ['writer1', 'writer2'],
+      signature: 'not-actually-decoded-because-throw',
+      deserialize: throwingDecode,
+      verify: async () => { verifyCalled = true; return true; },
+      raw: new Uint8Array([1, 2, 3]),
+    });
+    expect(result).toBe(false);
+    // verify() must NOT be called when decode fails -- otherwise we'd be
+    // doing crypto on undefined bytes.
+    expect(verifyCalled).toBe(false);
+  });
+
+  test('returns false (without decoding) when writerKeys is empty', async () => {
+    // No writers -> nothing could possibly verify. Skip the decode entirely
+    // so a junk signature on a doc with no writers can't even reach
+    // js-base64 in the first place.
+    let decodeCalled = false;
+    const decode = (_: string): Uint8Array => {
+      decodeCalled = true;
+      return new Uint8Array();
+    };
+    const result = await verifyWriterSignature<string>({
+      signingEnabled: true,
+      writerKeys: [],
+      signature: 'anything',
+      deserialize: decode,
+      verify: async () => true,
+      raw: new Uint8Array([1, 2, 3]),
+    });
+    expect(result).toBe(false);
+    expect(decodeCalled).toBe(false);
+  });
+
+  test('still verifies normally when decode succeeds', async () => {
+    // Sanity: the try/catch guard must not break the happy path.
+    const decode = (s: string): Uint8Array => new Uint8Array([s.length]);
+    const result = await verifyWriterSignature<string>({
+      signingEnabled: true,
+      writerKeys: ['writer1'],
+      signature: 'AAAA',
+      deserialize: decode,
+      verify: async (_raw, _key, sig) => sig.length === 1 && sig[0] === 4,
+      raw: new Uint8Array([1, 2, 3]),
+    });
+    expect(result).toBe(true);
+  });
+});

--- a/packages/collabswarm/src/collabswarm.test.ts
+++ b/packages/collabswarm/src/collabswarm.test.ts
@@ -577,4 +577,96 @@ describe('verifyWriterSignature malformed-signature handling', () => {
     });
     expect(result).toBe(true);
   });
+
+  // Mirrors the pre-load signature verification block in
+  // `_sendLoadRequestAndSync` (collabswarm-document.ts ~line 1417). This
+  // path also `_deserializeSignature`s an over-the-wire `message.signature`
+  // before iterating writers. A malformed value would throw, escape the
+  // helper, and -- in the snapshot-load path -- be silently swallowed by
+  // the surrounding blanket `catch {}`. The fix wraps the decode in
+  // try/catch and treats decode failure as "skip this peer" (returns
+  // false), letting the caller try the next one.
+  async function preLoadVerify<PublicKey>(opts: {
+    preLoadWriters: PublicKey[];
+    signingEnabled: boolean;
+    messageSignature: string | undefined;
+    deserialize: (s: string) => Uint8Array;
+    verify: (raw: Uint8Array, key: PublicKey, sig: Uint8Array) => Promise<boolean>;
+    raw: Uint8Array;
+  }): Promise<boolean> {
+    if (opts.preLoadWriters.length === 0 || !opts.signingEnabled) return true;
+    if (!opts.messageSignature) return false;
+    let signatureBytes: Uint8Array;
+    try {
+      signatureBytes = opts.deserialize(opts.messageSignature);
+    } catch {
+      return false;
+    }
+    const tasks = opts.preLoadWriters.map((k) =>
+      opts.verify(opts.raw, k, signatureBytes),
+    );
+    const results = await Promise.all(tasks);
+    return results.some((r) => r);
+  }
+
+  test('pre-load verify: returns false on malformed-base64 signature without throwing', async () => {
+    // The reproducer for the round-2 Copilot comment: the load-response
+    // verification path used to call _deserializeSignature unguarded. A
+    // throwing decoder would propagate out of _sendLoadRequestAndSync
+    // (and be silently swallowed by the snapshot-load catch{}). With the
+    // try/catch in place, the helper returns false (skip this peer)
+    // instead of throwing.
+    const throwingDecode = (_: string): Uint8Array => {
+      throw new TypeError('malformed base64 in load response');
+    };
+    let verifyCalled = false;
+    const result = await preLoadVerify<string>({
+      preLoadWriters: ['writer1'],
+      signingEnabled: true,
+      messageSignature: 'not-actually-decoded-because-throw',
+      deserialize: throwingDecode,
+      verify: async () => { verifyCalled = true; return true; },
+      raw: new Uint8Array([9, 8, 7]),
+    });
+    expect(result).toBe(false);
+    // No crypto verification should occur on undefined bytes.
+    expect(verifyCalled).toBe(false);
+  });
+
+  test('pre-load verify: returns false on missing signature without invoking decode', async () => {
+    // Empty/undefined signature short-circuits before reaching the decoder
+    // (matches the production check `if (!message.signature) return false`).
+    let decodeCalled = false;
+    const decode = (_: string): Uint8Array => {
+      decodeCalled = true;
+      return new Uint8Array();
+    };
+    const result = await preLoadVerify<string>({
+      preLoadWriters: ['writer1'],
+      signingEnabled: true,
+      messageSignature: undefined,
+      deserialize: decode,
+      verify: async () => true,
+      raw: new Uint8Array([9, 8, 7]),
+    });
+    expect(result).toBe(false);
+    expect(decodeCalled).toBe(false);
+  });
+
+  test('pre-load verify: skips verification when no writers are known yet', async () => {
+    // First-load bootstrap: with no writer keys yet, the production code
+    // skips signature verification (trust relies on the encrypted channel).
+    // The helper returns true to signal "go ahead" to the sync path.
+    let verifyCalled = false;
+    const result = await preLoadVerify<string>({
+      preLoadWriters: [],
+      signingEnabled: true,
+      messageSignature: 'anything',
+      deserialize: () => new Uint8Array(),
+      verify: async () => { verifyCalled = true; return true; },
+      raw: new Uint8Array([9, 8, 7]),
+    });
+    expect(result).toBe(true);
+    expect(verifyCalled).toBe(false);
+  });
 });

--- a/packages/collabswarm/src/collabswarm.test.ts
+++ b/packages/collabswarm/src/collabswarm.test.ts
@@ -554,7 +554,6 @@ describe('writer key cache', () => {
     // a single retry.
     const pendingResolves: Array<(keys: string[]) => void> = [];
     let usersCalls = 0;
-    let currentKeys = ['v0'];
     const backing = {
       users: () => {
         usersCalls++;
@@ -562,7 +561,7 @@ describe('writer key cache', () => {
           pendingResolves.push(resolve);
         });
       },
-      merge: () => { /* state mutation handled outside */ },
+      merge: () => {},
       add: async () => {},
       remove: async () => {},
     };
@@ -571,16 +570,16 @@ describe('writer key cache', () => {
     const inFlight = cache.getKeys();
     expect(usersCalls).toBe(1);
 
-    // First invalidation while fetch 1 is in flight.
-    currentKeys = ['v1'];
+    // First invalidation while fetch 1 is in flight; resolve fetch 1 with
+    // the pre-invalidation list (which the loop must discard).
     cache.merge();
     pendingResolves[0](['v0']);
     await Promise.resolve();
     await Promise.resolve();
     expect(usersCalls).toBe(2);
 
-    // Second invalidation while fetch 2 is in flight.
-    currentKeys = ['v2'];
+    // Second invalidation while fetch 2 is in flight; resolve fetch 2 with
+    // the now-stale intermediate list.
     cache.merge();
     pendingResolves[1](['v1']);
     await Promise.resolve();
@@ -588,7 +587,7 @@ describe('writer key cache', () => {
     expect(usersCalls).toBe(3);
 
     // Now resolve fetch 3 with no further invalidation -- loop converges.
-    pendingResolves[2](currentKeys.slice());
+    pendingResolves[2](['v2']);
     const result = await inFlight;
     expect(result).toEqual(['v2']);
   });

--- a/packages/collabswarm/src/collabswarm.test.ts
+++ b/packages/collabswarm/src/collabswarm.test.ts
@@ -483,8 +483,9 @@ describe('writer key cache', () => {
     // Resolve the retry fetch with the post-invalidation list.
     pendingResolves[1](currentKeys.slice());
     const result = await inFlight;
-    // The caller sees the fresh list, not the stale one -- this is the
-    // critical fix for CodeRabbit's round-3 comment.
+    // The caller sees the fresh list, not the stale one. Otherwise a
+    // revoked writer's signature could verify one final time before the
+    // next caller saw the cleared cache.
     expect(result).toEqual(['k1']);
 
     // Cache should now be populated with the fresh list, so a follow-up
@@ -495,13 +496,12 @@ describe('writer key cache', () => {
   });
 
   test('in-flight getKeys() retries until version is current and returns the fresh list', async () => {
-    // Round-3 CodeRabbit fix: even the in-flight caller must not get the
-    // stale (pre-invalidation) writer list. Previously, a revocation
-    // racing the first cache fill could let the in-flight call return
-    // the pre-invalidation list, allowing one final signature
-    // verification against a just-revoked writer. The loop in getKeys()
-    // discards the stale fetch and re-fetches until the version is
-    // stable.
+    // The in-flight caller must not get the pre-invalidation writer
+    // list. A revocation racing the first cache fill, without the
+    // retry loop, would let the in-flight call return the stale list
+    // and authorize one final signature against a just-revoked writer.
+    // The loop discards the stale fetch and re-fetches until the
+    // version is stable before returning.
     const pendingResolves: Array<(keys: string[]) => void> = [];
     let usersCalls = 0;
     // Tracks the "current" backing state -- starts with revoked writer,
@@ -541,10 +541,9 @@ describe('writer key cache', () => {
     pendingResolves[1](currentKeys.slice());
     const result = await inFlight;
 
-    // Critical assertion: the in-flight caller sees the fresh list, NOT
-    // the stale ['k1', 'revoked'] list. Without the loop, this would
-    // still be the stale list and a revoked writer's signature could
-    // still verify once.
+    // The in-flight caller sees the fresh list, not the stale
+    // ['k1', 'revoked'] list -- a revoked writer's signature must not
+    // verify even on a single in-flight call.
     expect(result).toEqual(['k1']);
   });
 
@@ -723,12 +722,11 @@ describe('verifyWriterSignature malformed-signature handling', () => {
   }
 
   test('pre-load verify: returns false on malformed-base64 signature without throwing', async () => {
-    // The reproducer for the round-2 Copilot comment: the load-response
-    // verification path used to call _deserializeSignature unguarded. A
-    // throwing decoder would propagate out of _sendLoadRequestAndSync
-    // (and be silently swallowed by the snapshot-load catch{}). With the
-    // try/catch in place, the helper returns false (skip this peer)
-    // instead of throwing.
+    // A throwing decoder must not propagate out of the load-response
+    // verification path -- the snapshot-load attempt swallows errors via
+    // a blanket catch{}, which would hide malformed input entirely.
+    // Decode failure should surface as "skip this peer" so the caller
+    // can try the next one.
     const throwingDecode = (_: string): Uint8Array => {
       throw new TypeError('malformed base64 in load response');
     };

--- a/packages/collabswarm/src/collabswarm.test.ts
+++ b/packages/collabswarm/src/collabswarm.test.ts
@@ -341,11 +341,11 @@ describe('writer key cache', () => {
   // mutation paths (merge / add / remove). Production code lives in
   // CollabswarmDocument (collabswarm-document.ts).
   //
-  // The version counter exists for race-safety: an in-flight `getKeys()` that
-  // started before an invalidation captures the version at fetch time and
-  // refuses to commit its result if the version has advanced. Without it, a
-  // stale fetch could overwrite the freshly-invalidated null cache with a
-  // pre-revocation writer list.
+  // The version counter exists for race-safety: if an invalidation bumps
+  // the version while `getKeys()` is awaiting `users()`, the fetched list
+  // reflects the *pre*-invalidation ACL and is unsafe to return -- it
+  // could verify a just-revoked writer. So `getKeys()` loops, discarding
+  // the stale fetch and re-fetching with the post-invalidation state.
   class WriterCacheHarness<T> {
     private _cached: T[] | null = null;
     private _version = 0;
@@ -353,14 +353,17 @@ describe('writer key cache', () => {
     constructor(private readonly _backing: { users: () => Promise<T[]>; merge: () => void; add: () => Promise<void>; remove: () => Promise<void>; }) {}
 
     async getKeys(): Promise<T[]> {
-      if (this._cached !== null) return this._cached;
-      this.usersCalls++;
-      const versionAtStart = this._version;
-      const fetched = await this._backing.users();
-      if (this._version === versionAtStart) {
-        this._cached = fetched;
+      while (true) {
+        if (this._cached !== null) return this._cached;
+        this.usersCalls++;
+        const versionAtStart = this._version;
+        const fetched = await this._backing.users();
+        if (this._version === versionAtStart) {
+          this._cached = fetched;
+          return fetched;
+        }
+        // Version advanced during fetch -- discard stale result and retry.
       }
-      return fetched;
     }
     private _invalidate(): void {
       this._cached = null;
@@ -439,7 +442,9 @@ describe('writer key cache', () => {
     // call is awaiting users(), an invalidation (e.g. revoking a writer)
     // races in. The pre-invalidation fetch must NOT commit its (now-stale)
     // result back to the cache, or the next reader could see the revoked
-    // writer in the trusted set.
+    // writer in the trusted set. After the loop fix, the in-flight call
+    // ALSO retries internally so the caller never sees the stale list --
+    // see the sibling test below for that assertion.
     const pendingResolves: Array<(keys: string[]) => void> = [];
     let usersCalls = 0;
     let currentKeys = ['k1', 'revoked'];
@@ -464,21 +469,129 @@ describe('writer key cache', () => {
     // Race: an ACL update revokes the writer mid-fetch.
     cache.merge();
 
-    // Resolve the pre-invalidation fetch with the stale list.
+    // Resolve the pre-invalidation fetch with the stale list. The harness
+    // must NOT commit it to the cache (version advanced) and the loop
+    // must re-fetch -- so a second users() call appears immediately.
     pendingResolves[0](['k1', 'revoked']);
-    const result = await inFlight;
-    // The resolved value still reflects what users() returned, but...
-    expect(result).toEqual(['k1', 'revoked']);
-
-    // ...the next read must NOT reuse it: the cache was cleared by merge,
-    // and the in-flight fetch must have refused to assign back. So
-    // getKeys() re-queries the backing.
-    const nextPromise = cache.getKeys();
+    // Yield so the loop can observe the version mismatch and start the
+    // retry fetch.
+    await Promise.resolve();
+    await Promise.resolve();
     expect(usersCalls).toBe(2);
     expect(pendingResolves.length).toBe(2);
+
+    // Resolve the retry fetch with the post-invalidation list.
     pendingResolves[1](currentKeys.slice());
-    const next = await nextPromise;
-    expect(next).toEqual(['k1']); // would be ['k1', 'revoked'] without the version guard
+    const result = await inFlight;
+    // The caller sees the fresh list, not the stale one -- this is the
+    // critical fix for CodeRabbit's round-3 comment.
+    expect(result).toEqual(['k1']);
+
+    // Cache should now be populated with the fresh list, so a follow-up
+    // read is a hit (no new users() call).
+    const next = await cache.getKeys();
+    expect(next).toEqual(['k1']);
+    expect(usersCalls).toBe(2);
+  });
+
+  test('in-flight getKeys() retries until version is current and returns the fresh list', async () => {
+    // Round-3 CodeRabbit fix: even the in-flight caller must not get the
+    // stale (pre-invalidation) writer list. Previously, a revocation
+    // racing the first cache fill could let the in-flight call return
+    // the pre-invalidation list, allowing one final signature
+    // verification against a just-revoked writer. The loop in getKeys()
+    // discards the stale fetch and re-fetches until the version is
+    // stable.
+    const pendingResolves: Array<(keys: string[]) => void> = [];
+    let usersCalls = 0;
+    // Tracks the "current" backing state -- starts with revoked writer,
+    // becomes fresh after merge() invalidates.
+    let currentKeys = ['k1', 'revoked'];
+    const backing = {
+      users: () => {
+        usersCalls++;
+        return new Promise<string[]>((resolve) => {
+          pendingResolves.push(resolve);
+        });
+      },
+      merge: () => { currentKeys = ['k1']; },
+      add: async () => {},
+      remove: async () => {},
+    };
+    const cache = new WriterCacheHarness<string>(backing);
+
+    // Start the first (in-flight) getKeys() call.
+    const inFlight = cache.getKeys();
+    expect(usersCalls).toBe(1);
+
+    // Invalidate while the fetch is in flight.
+    cache.merge();
+
+    // Resolve the in-flight fetch with the *pre*-invalidation (stale) list.
+    pendingResolves[0](['k1', 'revoked']);
+    // Allow the loop to observe the version mismatch and kick off retry.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The harness must have started a SECOND fetch.
+    expect(usersCalls).toBe(2);
+    expect(pendingResolves.length).toBe(2);
+
+    // Resolve the retry with the fresh post-invalidation list.
+    pendingResolves[1](currentKeys.slice());
+    const result = await inFlight;
+
+    // Critical assertion: the in-flight caller sees the fresh list, NOT
+    // the stale ['k1', 'revoked'] list. Without the loop, this would
+    // still be the stale list and a revoked writer's signature could
+    // still verify once.
+    expect(result).toEqual(['k1']);
+  });
+
+  test('in-flight getKeys() retries multiple times under repeated invalidation', async () => {
+    // Bounded multi-retry: invalidate twice while a fetch is in flight
+    // each time. The loop should converge on the third fetch when no
+    // invalidation races it. Verifies the loop does not "give up" after
+    // a single retry.
+    const pendingResolves: Array<(keys: string[]) => void> = [];
+    let usersCalls = 0;
+    let currentKeys = ['v0'];
+    const backing = {
+      users: () => {
+        usersCalls++;
+        return new Promise<string[]>((resolve) => {
+          pendingResolves.push(resolve);
+        });
+      },
+      merge: () => { /* state mutation handled outside */ },
+      add: async () => {},
+      remove: async () => {},
+    };
+    const cache = new WriterCacheHarness<string>(backing);
+
+    const inFlight = cache.getKeys();
+    expect(usersCalls).toBe(1);
+
+    // First invalidation while fetch 1 is in flight.
+    currentKeys = ['v1'];
+    cache.merge();
+    pendingResolves[0](['v0']);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(usersCalls).toBe(2);
+
+    // Second invalidation while fetch 2 is in flight.
+    currentKeys = ['v2'];
+    cache.merge();
+    pendingResolves[1](['v1']);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(usersCalls).toBe(3);
+
+    // Now resolve fetch 3 with no further invalidation -- loop converges.
+    pendingResolves[2](currentKeys.slice());
+    const result = await inFlight;
+    expect(result).toEqual(['v2']);
   });
 });
 

--- a/packages/collabswarm/src/collabswarm.test.ts
+++ b/packages/collabswarm/src/collabswarm.test.ts
@@ -341,28 +341,47 @@ describe('writer key cache', () => {
   // mutation paths (merge / add / remove). Production code lives in
   // CollabswarmDocument (collabswarm-document.ts).
   //
-  // The version counter exists for race-safety: if an invalidation bumps
-  // the version while `getKeys()` is awaiting `users()`, the fetched list
-  // reflects the *pre*-invalidation ACL and is unsafe to return -- it
-  // could verify a just-revoked writer. So `getKeys()` loops, discarding
-  // the stale fetch and re-fetching with the post-invalidation state.
+  // Two race-safety mechanisms:
+  //  - Mutation-in-flight counter: while a mutation is running, `getKeys()`
+  //    bypasses the cache because some real ACLs (e.g. UCANACL.remove,
+  //    YjsACL.remove) mutate their backing state *before* their Promise
+  //    resolves -- so even though the post-await invalidation hasn't run
+  //    yet, the cached list is already stale. Bypassing forces a fresh
+  //    `users()` read, which returns the post-mutation state.
+  //  - Version counter: if an invalidation bumps the version while
+  //    `getKeys()` is awaiting `users()`, the fetched list reflects the
+  //    pre-invalidation ACL and is unsafe to return -- so `getKeys()`
+  //    discards it and retries.
   class WriterCacheHarness<T> {
     private _cached: T[] | null = null;
     private _version = 0;
+    private _mutationsInFlight = 0;
     public usersCalls = 0;
     constructor(private readonly _backing: { users: () => Promise<T[]>; merge: () => void; add: () => Promise<void>; remove: () => Promise<void>; }) {}
 
     async getKeys(): Promise<T[]> {
       while (true) {
-        if (this._cached !== null) return this._cached;
+        if (this._mutationsInFlight === 0 && this._cached !== null) {
+          return this._cached;
+        }
         this.usersCalls++;
         const versionAtStart = this._version;
         const fetched = await this._backing.users();
-        if (this._version === versionAtStart) {
+        if (
+          this._version === versionAtStart &&
+          this._mutationsInFlight === 0
+        ) {
           this._cached = fetched;
           return fetched;
         }
-        // Version advanced during fetch -- discard stale result and retry.
+        if (this._version !== versionAtStart) {
+          // Version advanced during fetch -- discard stale result and retry.
+          continue;
+        }
+        // Mutation still in flight -- return the freshly fetched value but
+        // do not cache; subsequent reads will re-fetch until mutations
+        // finish.
+        return fetched;
       }
     }
     private _invalidate(): void {
@@ -370,16 +389,34 @@ describe('writer key cache', () => {
       this._version++;
     }
     merge(): void {
-      this._backing.merge();
+      this._mutationsInFlight++;
       this._invalidate();
+      try {
+        this._backing.merge();
+      } finally {
+        this._mutationsInFlight--;
+        this._invalidate();
+      }
     }
     async add(): Promise<void> {
-      await this._backing.add();
+      this._mutationsInFlight++;
       this._invalidate();
+      try {
+        await this._backing.add();
+      } finally {
+        this._mutationsInFlight--;
+        this._invalidate();
+      }
     }
     async remove(): Promise<void> {
-      await this._backing.remove();
+      this._mutationsInFlight++;
       this._invalidate();
+      try {
+        await this._backing.remove();
+      } finally {
+        this._mutationsInFlight--;
+        this._invalidate();
+      }
     }
   }
 
@@ -590,6 +627,53 @@ describe('writer key cache', () => {
     pendingResolves[2](['v2']);
     const result = await inFlight;
     expect(result).toEqual(['v2']);
+  });
+
+  test('getKeys() during a backing mutation that mutates state before resolving observes the new state', async () => {
+    // Models real ACL implementations (e.g. UCANACL.remove, YjsACL.remove)
+    // that update their backing state *before* their returned Promise
+    // resolves. Without the in-flight mutation guard, a `getKeys()` call
+    // racing the mutation could see the cached pre-mutation list even
+    // though `users()` would already return the post-mutation list --
+    // letting a just-revoked writer's signature verify one final time.
+    let currentKeys = ['k1', 'revoked'];
+    let resolveRemove: (() => void) | null = null;
+    const backing = {
+      users: async () => currentKeys.slice(),
+      merge: () => {},
+      add: async () => {},
+      remove: () => {
+        // Mutate backing state immediately, then return a pending promise.
+        currentKeys = ['k1'];
+        return new Promise<void>((resolve) => {
+          resolveRemove = resolve;
+        });
+      },
+    };
+    const cache = new WriterCacheHarness<string>(backing);
+
+    // Prime the cache with the pre-mutation list.
+    expect(await cache.getKeys()).toEqual(['k1', 'revoked']);
+
+    // Kick off a remove. Backing mutation has already happened (currentKeys
+    // is now ['k1']), but the Promise is still pending.
+    const removePromise = cache.remove();
+
+    // While the mutation is in flight, getKeys() must observe the new
+    // state -- the cache is bypassed and a fresh users() runs.
+    const inFlightRead = await cache.getKeys();
+    expect(inFlightRead).toEqual(['k1']);
+
+    // Resolve the mutation. The post-mutation invalidation runs in finally.
+    resolveRemove!();
+    await removePromise;
+
+    // Subsequent reads continue to see the new state and re-prime the cache.
+    expect(await cache.getKeys()).toEqual(['k1']);
+    // A follow-up read is a hit -- no new users() call.
+    const callsBefore = cache.usersCalls;
+    expect(await cache.getKeys()).toEqual(['k1']);
+    expect(cache.usersCalls).toBe(callsBefore);
   });
 });
 


### PR DESCRIPTION
## Summary
Resolves the `// TODO: Cache list of current writers per dag node for now.` in `packages/collabswarm/src/collabswarm-document.ts`. `_verifyWriterSignature` and `_verifySnapshotSignature` are both invoked on hot paths (sync-message dispatch on a busy mesh, snapshot validation) and each called `await this._writers.users()` per invocation. Even with the per-key LRU inside `YjsACL`, that call still allocates a closure, iterates the Yjs map, and `Promise.all`s a deserialize-or-cache-hit for every writer -- wasted work when the writer set hasn't changed.

## What changed
- New private field `_cachedWriterKeys: PublicKey[] | null` on `CollabswarmDocument`, populated lazily by a new `_getWriterKeys()` helper.
- Both verify methods now use the cache instead of calling `_writers.users()` directly.
- `_deserializeSignature(signature)` hoisted out of the verify loop -- decoding once per call is enough.
- All `_writers` mutations are now routed through three new private helpers -- `_mergeWriters`, `_addWriter`, `_removeWriter` -- that invalidate the cache after the underlying ACL operation. Callsites updated: `_syncDocumentChanges` (direct merge and post-fetch merge), `_applyACLFromTree`, `open()` bootstrap, `addWriter`, `removeWriter`. The pre-load verification path in `loadFromPeer` also routes through `_getWriterKeys` so the cache is warmed and reused.

## Cache-scope decision: document-scoped, not per-DAG-node
The TODO comment said "per dag node," but a per-DAG-node cache is not warranted:

1. Every signature check needs the *current* trusted writer set, not a per-block snapshot. There is no semantic in the verify path that varies "per DAG node."
2. A per-DAG-node cache would add a keyed structure with no obvious keying scheme and no measured win, because writer sets are small and update rarely.
3. The simpler design -- a single document-scoped cache invalidated by the three sanctioned mutation paths -- captures the same wins for a fraction of the complexity.

If a future workload exposes a real need for per-block caching, it can be added on top of this without changing call sites.

## Invalidation points
The cache is invalidated to `null` whenever `_writers` is mutated:
- Sync of remote writer-ACL changes (direct + post-blockstore-fetch).
- ACL-tree pre-pass before snapshot verification (`_applyACLFromTree`).
- Bootstrap of a brand-new document in `open()`.
- Public `addWriter` / `removeWriter` API calls.

## Test plan
- [x] `yarn workspace @collabswarm/collabswarm tsc` passes
- [x] `yarn workspace @collabswarm/collabswarm test` passes -- 300/300 (298 from main + 2 new unit cases)
- [x] Added "writer key cache" describe block with mock-ACL harness exercising the cache-hit, cache-miss, and invalidation paths (mirrors the existing `getReaders() dedup logic` testing style)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable signature verification that fails gracefully on malformed signatures or missing keys; peers with bad signatures are skipped with warnings.
  * Improved onboarding and sync stability so new documents correctly record the creator as a writer and keep access lists consistent across updates.

* **Tests**
  * Added comprehensive writer-key cache tests covering cache hits, invalidation, and race/in-flight scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->