### PR TITLE
Remove debug console.log from useCollabswarm and ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ client-config.env
 dist-bench/
 paper/results/
 
+# macOS metadata
+.DS_Store
+

--- a/packages/collabswarm-react/src/hooks.ts
+++ b/packages/collabswarm-react/src/hooks.ts
@@ -94,7 +94,6 @@ export function useCollabswarm<
 
   useEffect(() => {
     (async () => {
-      console.log(`Calling useCollabswarm(...) init effect`);
       if (privateKey && publicKey) {
         const collabswarm = new Collabswarm(
           privateKey,


### PR DESCRIPTION
## Summary

- **Remove debug log:** Drops the `console.log(\`Calling useCollabswarm(...) init effect\`)` at `packages/collabswarm-react/src/hooks.ts:97`. This was leftover development noise that fired on every hook initialisation.
- **Ignore .DS_Store:** Adds `.DS_Store` to the root `.gitignore` so macOS metadata files are never accidentally staged.

No functional changes — all 42 `collabswarm-react` tests pass, `tsc` is clean.