### PR TITLE
Extract defaultStateSelector helper for collabswarm-redux

### DIFF
--- a/packages/collabswarm-redux/src/actions.ts
+++ b/packages/collabswarm-redux/src/actions.ts
@@ -1,6 +1,7 @@
 import { Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 import { CollabswarmState } from './reducers';
+import { defaultStateSelector } from './default-state-selector';
 import {
   Collabswarm,
   CollabswarmDocument,
@@ -46,15 +47,7 @@ export function initializeAsync<
     PrivateKey,
     PublicKey,
     DocumentKey
-  > = (s) =>
-    s as unknown as CollabswarmState<
-      DocType,
-      ChangesType,
-      ChangeFnType,
-      PrivateKey,
-      PublicKey,
-      DocumentKey
-    >,
+  > = defaultStateSelector,
 ): ThunkAction<
   Promise<
     Collabswarm<
@@ -169,15 +162,7 @@ export function connectAsync<
     PrivateKey,
     PublicKey,
     DocumentKey
-  > = (s) =>
-    s as unknown as CollabswarmState<
-      DocType,
-      ChangesType,
-      ChangeFnType,
-      PrivateKey,
-      PublicKey,
-      DocumentKey
-    >,
+  > = defaultStateSelector,
 ): ThunkAction<Promise<void>, RootStateType, unknown, ConnectAction> {
   return async (dispatch, getState) => {
     const { node } = selectCollabswarmState(getState());
@@ -228,15 +213,7 @@ export function openDocumentAsync<
     PrivateKey,
     PublicKey,
     DocumentKey
-  > = (s) =>
-    s as unknown as CollabswarmState<
-      DocType,
-      ChangesType,
-      ChangeFnType,
-      PrivateKey,
-      PublicKey,
-      DocumentKey
-    >,
+  > = defaultStateSelector,
 ): ThunkAction<
   Promise<CollabswarmDocument<
     DocType,
@@ -379,15 +356,7 @@ export function closeDocumentAsync<
     PrivateKey,
     PublicKey,
     DocumentKey
-  > = (s) =>
-    s as unknown as CollabswarmState<
-      DocType,
-      ChangesType,
-      ChangeFnType,
-      PrivateKey,
-      PublicKey,
-      DocumentKey
-    >,
+  > = defaultStateSelector,
 ): ThunkAction<
   Promise<void>,
   RootStateType,
@@ -459,15 +428,7 @@ export function changeDocumentAsync<
     PrivateKey,
     PublicKey,
     DocumentKey
-  > = (s) =>
-    s as unknown as CollabswarmState<
-      DocType,
-      ChangesType,
-      ChangeFnType,
-      PrivateKey,
-      PublicKey,
-      DocumentKey
-    >,
+  > = defaultStateSelector,
 ): ThunkAction<
   Promise<DocType>,
   RootStateType,

--- a/packages/collabswarm-redux/src/default-state-selector.ts
+++ b/packages/collabswarm-redux/src/default-state-selector.ts
@@ -1,0 +1,41 @@
+import { CollabswarmState } from './reducers';
+
+/**
+ * Default selector used when the collabswarm state sits at the root of the
+ * Redux store (i.e. the store IS the CollabswarmState with no nesting).
+ *
+ * Callers whose Redux store has a nested layout must pass their own selector
+ * to each *Async() action creator — this helper deliberately casts the
+ * unknown root state as if it IS the collabswarm slice.
+ *
+ * The cast cannot be made type-safe without locking the RootStateType generic
+ * to CollabswarmState, which would prevent callers from using nested stores.
+ * Extracting it here removes the five identical inline casts from actions.ts
+ * without changing any runtime behaviour.
+ */
+export function defaultStateSelector<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey,
+>(
+  state: unknown,
+): CollabswarmState<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+> {
+  return state as CollabswarmState<
+    DocType,
+    ChangesType,
+    ChangeFnType,
+    PrivateKey,
+    PublicKey,
+    DocumentKey
+  >;
+}

--- a/packages/collabswarm-redux/src/default-state-selector.ts
+++ b/packages/collabswarm-redux/src/default-state-selector.ts
@@ -1,17 +1,48 @@
 import type { CollabswarmState } from './reducers';
 
 /**
+ * Local alias for the fully-parameterised `CollabswarmState` shape used by
+ * {@link defaultStateSelector}. Keeping the generic list in one place avoids
+ * having to keep the return type and the internal cast in sync by hand.
+ *
+ * @internal
+ */
+type State<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey,
+> = CollabswarmState<
+  DocType,
+  ChangesType,
+  ChangeFnType,
+  PrivateKey,
+  PublicKey,
+  DocumentKey
+>;
+
+/**
  * Default selector used when the collabswarm state sits at the root of the
  * Redux store (i.e. the store IS the CollabswarmState with no nesting).
  *
  * Callers whose Redux store has a nested layout must pass their own selector
  * to each *Async() action creator — this helper deliberately casts the
- * unknown root state as if it IS the collabswarm slice.
+ * `unknown` root state as if it IS the collabswarm slice. Because `state` is
+ * already typed as `unknown`, a single `state as CollabswarmState<...>` cast
+ * is sufficient (TypeScript allows asserting `unknown` to any type directly,
+ * so the `as unknown as ...` double-cast used at each former inline call site
+ * collapses to a single assertion here).
  *
  * The cast cannot be made type-safe without locking the RootStateType generic
  * to CollabswarmState, which would prevent callers from using nested stores.
  * Extracting it here removes the five identical inline casts from actions.ts
  * without changing any runtime behaviour.
+ *
+ * @internal This helper is package-internal — exported only so that
+ * `actions.ts` can use it as the default selector. External consumers should
+ * provide their own selector matching their store layout.
  */
 export function defaultStateSelector<
   DocType,
@@ -22,7 +53,7 @@ export function defaultStateSelector<
   DocumentKey,
 >(
   state: unknown,
-): CollabswarmState<
+): State<
   DocType,
   ChangesType,
   ChangeFnType,
@@ -30,7 +61,7 @@ export function defaultStateSelector<
   PublicKey,
   DocumentKey
 > {
-  return state as CollabswarmState<
+  return state as State<
     DocType,
     ChangesType,
     ChangeFnType,

--- a/packages/collabswarm-redux/src/default-state-selector.ts
+++ b/packages/collabswarm-redux/src/default-state-selector.ts
@@ -1,4 +1,4 @@
-import { CollabswarmState } from './reducers';
+import type { CollabswarmState } from './reducers';
 
 /**
  * Default selector used when the collabswarm state sits at the root of the


### PR DESCRIPTION
## Summary

- Five action creators in `packages/collabswarm-redux/src/actions.ts` each had an identical inline default-argument cast: `(s) => s as unknown as CollabswarmState<DocType, ChangesType, ChangeFnType, PrivateKey, PublicKey, DocumentKey>`.
- Extracted a single `defaultStateSelector` function into the new sibling file `packages/collabswarm-redux/src/default-state-selector.ts` and replaced all five inline casts with a reference to it.
- The helper is **not** re-exported from `index.ts` — it is package-internal, matching the convention that `index.ts` only exports public API symbols.

## Why the cast can't be made type-safe

Making `defaultStateSelector` fully type-safe would require constraining `RootStateType extends CollabswarmState<...>`, which would prevent callers with nested Redux stores from ever passing a narrower selector. The `as unknown as` cast is therefore deliberate; this PR only removes the repetition, not the cast itself.

## Test plan

- [x] `yarn workspace @collabswarm/collabswarm-redux tsc` — no errors
- [x] `yarn workspace @collabswarm/collabswarm-redux test` — 30/30 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal state selector logic across asynchronous operations to reduce code duplication.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/swarmbase/swarmbase/pull/260)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->