### PR TITLE
Standardize package.json repository, exports, and tsconfig target across workspaces

### DIFF
--- a/packages/collabswarm-automerge/package.json
+++ b/packages/collabswarm-automerge/package.json
@@ -2,6 +2,11 @@
   "name": "@collabswarm/collabswarm-automerge",
   "description": "",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/swarmbase/swarmbase.git",
+    "directory": "packages/collabswarm-automerge"
+  },
   "scripts": {
     "tsc": "tsc -b",
     "prepublishOnly": "yarn tsc",

--- a/packages/collabswarm-automerge/tsconfig.json
+++ b/packages/collabswarm-automerge/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2022",
     "module": "CommonJS",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,

--- a/packages/collabswarm-index/package.json
+++ b/packages/collabswarm-index/package.json
@@ -2,6 +2,11 @@
   "name": "@collabswarm/collabswarm-index",
   "description": "Distributed indexing and query engine for SwarmDB",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/swarmbase/swarmbase.git",
+    "directory": "packages/collabswarm-index"
+  },
   "scripts": {
     "tsc": "tsc -b",
     "prepublishOnly": "yarn tsc",

--- a/packages/collabswarm-index/tsconfig.json
+++ b/packages/collabswarm-index/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2022",
     "module": "CommonJS",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,

--- a/packages/collabswarm-react/package.json
+++ b/packages/collabswarm-react/package.json
@@ -2,6 +2,11 @@
   "name": "@collabswarm/collabswarm-react",
   "description": "React hooks for collabswarm documents",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/swarmbase/swarmbase.git",
+    "directory": "packages/collabswarm-react"
+  },
   "scripts": {
     "clean": "tsc -b --clean",
     "tsc": "tsc -b --clean && tsc -b",
@@ -12,7 +17,10 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {
-    ".": "./dist/src/index.js"
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/collabswarm-react/tsconfig.json
+++ b/packages/collabswarm-react/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2022",
     "module": "CommonJS",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,

--- a/packages/collabswarm-redux/package.json
+++ b/packages/collabswarm-redux/package.json
@@ -2,6 +2,11 @@
   "name": "@collabswarm/collabswarm-redux",
   "description": "Redux bindings for collabswarm",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/swarmbase/swarmbase.git",
+    "directory": "packages/collabswarm-redux"
+  },
   "scripts": {
     "tsc": "tsc -b",
     "prepublishOnly": "yarn tsc",

--- a/packages/collabswarm-redux/tsconfig.json
+++ b/packages/collabswarm-redux/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2022",
     "module": "CommonJS",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,

--- a/packages/collabswarm-yjs/package.json
+++ b/packages/collabswarm-yjs/package.json
@@ -2,6 +2,11 @@
   "name": "@collabswarm/collabswarm-yjs",
   "description": "",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/swarmbase/swarmbase.git",
+    "directory": "packages/collabswarm-yjs"
+  },
   "scripts": {
     "tsc": "tsc -b",
     "prepublishOnly": "yarn tsc",

--- a/packages/collabswarm-yjs/tsconfig.json
+++ b/packages/collabswarm-yjs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2022",
     "module": "CommonJS",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,

--- a/packages/collabswarm/package.json
+++ b/packages/collabswarm/package.json
@@ -2,6 +2,11 @@
   "name": "@collabswarm/collabswarm",
   "description": "",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/swarmbase/swarmbase.git",
+    "directory": "packages/collabswarm"
+  },
   "scripts": {
     "tsc": "tsc -b",
     "prepublishOnly": "yarn tsc",

--- a/packages/collabswarm/tsconfig.json
+++ b/packages/collabswarm/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2022",
     "module": "CommonJS",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,


### PR DESCRIPTION
## Summary

Three metadata cleanups across all 6 publishable packages:

### 1. Added `repository` field to all package.json files

None of the packages had a `repository` field. Added to all six:

- `packages/collabswarm`
- `packages/collabswarm-react`
- `packages/collabswarm-redux`
- `packages/collabswarm-automerge`
- `packages/collabswarm-yjs`
- `packages/collabswarm-index`

Each entry uses the monorepo `directory` sub-field so npm correctly links to the package subdirectory.

### 2. Fixed `exports` in `collabswarm-react/package.json`

The entry was a bare string (`"./dist/src/index.js"`) instead of the conditional-exports object used by `collabswarm` and `collabswarm-index`. Corrected to:

```json
".": {
  "types": "./dist/src/index.d.ts",
  "default": "./dist/src/index.js"
}
```

The `.d.ts` path was verified against the actual build output before committing.

### 3. Aligned `tsconfig.json` `target` to `ES2022` across all packages

Previously `collabswarm` used `ESNext` while the other five used `ES2015`. Neither was ideal:
- `ESNext` is unstable — it tracks the moving TypeScript/TC39 tip and can silently change semantics across TypeScript releases.
- `ES2015` is unnecessarily conservative for a library targeting Node 22+ and modern browsers (per CLAUDE.md), and causes unnecessary down-leveling of async/await, class fields, etc.

`ES2022` is a stable, well-specified target that covers all features in use across the codebase (class fields, `at()`, `Object.hasOwn`, top-level await) and is natively supported by Node 16+ and all modern browsers. No ES2023+ features (`findLast`, `toReversed`, `toSpliced`, `Array.with`, etc.) were found in the source.

All 6 packages now emit to `ES2022`.

## Test plan

- [x] `yarn build` — all 6 packages compile cleanly after the `tsconfig` change
- [x] `yarn test` — 618 tests across all 6 packages pass, 0 failures
- [x] `dist/src/index.d.ts` confirmed present for `collabswarm-react` after build