### PR TITLE
Extract shared Merkle-DAG serialization helpers from yjs/automerge providers

### DIFF
--- a/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
@@ -526,6 +526,37 @@ describe('AutomergeJSONSerializer', () => {
     );
   });
 
+  // Regression: a truthy guard (`if (raw.snapshot)`) silently dropped
+  // defined-but-falsy snapshot values rather than rejecting the malformed
+  // payload. The fix routes any non-`undefined` value through the validator
+  // so peers can't bypass it by sending `snapshot: null/0/""`.
+  test('deserializeSyncMessage rejects "snapshot: null" (validation bypass regression)', () => {
+    const wire = buildWire({ documentId: 'doc', snapshot: null });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'snapshot' must be an object when present.*got null/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects "snapshot: 0"', () => {
+    const wire = buildWire({ documentId: 'doc', snapshot: 0 });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'snapshot' must be an object when present.*got number/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects "snapshot: \\"\\"" (empty string)', () => {
+    const wire = buildWire({ documentId: 'doc', snapshot: '' });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'snapshot' must be an object when present.*got string/,
+    );
+  });
+
+  test('deserializeSyncMessage accepts omitted "snapshot" field', () => {
+    const wire = buildWire({ documentId: 'doc' });
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.snapshot).toBeUndefined();
+  });
+
   // Regression: prior to building the returned object explicitly, the
   // deserializer spread `...raw` straight onto the result. A malicious peer
   // could append junk keys (or attempt prototype-pollution-style keys) and

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
@@ -426,4 +426,42 @@ describe('AutomergeJSONSerializer', () => {
     const deserialized = serializer.deserializeSyncMessage(wire);
     expect(deserialized.changes).toBeUndefined();
   });
+
+  // Regression: prior to the upfront object guard, a malformed peer payload
+  // like JSON `null` flowed straight to `raw.snapshot` access and threw a
+  // bare `TypeError: Cannot read properties of null`. The guard mirrors
+  // `YjsJSONSerializer.deserializeSyncMessage` and produces a descriptive
+  // `Error` so the malformed payload can be attributed back to the peer
+  // instead of crashing the deserializer (a trivial DoS vector).
+  test('deserializeSyncMessage rejects a top-level JSON null payload', () => {
+    const wire = buildWire(null);
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(Error);
+    expect(() => serializer.deserializeSyncMessage(wire)).not.toThrow(
+      TypeError,
+    );
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*expected a plain object.*got null/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects a top-level JSON array payload', () => {
+    const wire = buildWire([1, 2, 3]);
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*expected a plain object.*got array/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects a top-level JSON number payload', () => {
+    const wire = buildWire(42);
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*expected a plain object.*got number/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects a top-level JSON string payload', () => {
+    const wire = buildWire('not-an-object');
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*expected a plain object.*got string/,
+    );
+  });
 });

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
@@ -391,4 +391,39 @@ describe('AutomergeJSONSerializer', () => {
     expect(deserialized.keyID).toBeUndefined();
     expect(deserialized.blindIndexTokens).toBeUndefined();
   });
+
+  // Build a sync-message Uint8Array wire payload directly from a JS object,
+  // bypassing `serializeSyncMessage`'s type-safety so we can test that
+  // `deserializeSyncMessage` rejects every defined-but-malformed shape of
+  // `changes` rather than silently passing the falsy value through.
+  function buildWire(obj: unknown): Uint8Array {
+    return new TextEncoder().encode(JSON.stringify(obj));
+  }
+
+  test('deserializeSyncMessage rejects "changes: null" (validation bypass regression)', () => {
+    const wire = buildWire({ documentId: 'doc', changes: null });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /expected a plain object.*got null/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects "changes: 0"', () => {
+    const wire = buildWire({ documentId: 'doc', changes: 0 });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /expected a plain object.*got number/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects "changes: \\"\\"" (empty string)', () => {
+    const wire = buildWire({ documentId: 'doc', changes: '' });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /expected a plain object.*got string/,
+    );
+  });
+
+  test('deserializeSyncMessage accepts omitted "changes" field', () => {
+    const wire = buildWire({ documentId: 'doc' });
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.changes).toBeUndefined();
+  });
 });

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
@@ -464,4 +464,97 @@ describe('AutomergeJSONSerializer', () => {
       /Invalid sync message.*expected a plain object.*got string/,
     );
   });
+
+  // Regression: prior to validating `documentId`, a malformed peer payload
+  // missing the field (or sending a non-string value) would propagate
+  // `documentId: undefined`/non-string downstream and violate the required
+  // field contract of `CRDTSyncMessage`. The fix rejects the payload with a
+  // descriptive error attributable back to the peer.
+  test('deserializeSyncMessage rejects payload missing documentId', () => {
+    const wire = buildWire({ changeId: 'c1' });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'documentId' must be a string.*got undefined/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects payload with non-string documentId (number)', () => {
+    const wire = buildWire({ documentId: 42 });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'documentId' must be a string.*got number/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects payload with null documentId', () => {
+    const wire = buildWire({ documentId: null });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'documentId' must be a string.*got null/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects payload with object documentId', () => {
+    const wire = buildWire({ documentId: { id: 'doc' } });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'documentId' must be a string.*got object/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects non-string changeId', () => {
+    const wire = buildWire({ documentId: 'doc', changeId: 7 });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'changeId' must be a string when present.*got number/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects non-string signature', () => {
+    const wire = buildWire({ documentId: 'doc', signature: 7 });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'signature' must be a string when present.*got number/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects non-array keychainChanges', () => {
+    const wire = buildWire({ documentId: 'doc', keychainChanges: 'not-an-array' });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'keychainChanges' must be an array when present.*got string/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects array snapshot', () => {
+    const wire = buildWire({ documentId: 'doc', snapshot: [1, 2, 3] });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'snapshot' must be an object when present.*got array/,
+    );
+  });
+
+  // Regression: prior to building the returned object explicitly, the
+  // deserializer spread `...raw` straight onto the result. A malicious peer
+  // could append junk keys (or attempt prototype-pollution-style keys) and
+  // they would leak through to downstream consumers. The fix only propagates
+  // fields declared on `CRDTSyncMessage`.
+  test('deserializeSyncMessage strips peer-supplied junk keys', () => {
+    const wire = buildWire({
+      documentId: 'doc',
+      changeId: 'cid',
+      somethingExtra: 'evil',
+      anotherJunkField: { nested: true },
+      __evilNonProtoKey: 'still-junk',
+    });
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.documentId).toBe('doc');
+    expect(deserialized.changeId).toBe('cid');
+    expect((deserialized as Record<string, unknown>).somethingExtra).toBeUndefined();
+    expect((deserialized as Record<string, unknown>).anotherJunkField).toBeUndefined();
+    expect((deserialized as Record<string, unknown>).__evilNonProtoKey).toBeUndefined();
+  });
+
+  test('deserializeSyncMessage round-trips a minimal valid payload', () => {
+    const wire = buildWire({ documentId: 'doc' });
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.documentId).toBe('doc');
+    expect(deserialized.changes).toBeUndefined();
+    expect(deserialized.changeId).toBeUndefined();
+    expect(deserialized.signature).toBeUndefined();
+    expect(deserialized.keychainChanges).toBeUndefined();
+    expect(deserialized.snapshot).toBeUndefined();
+  });
 });

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -449,7 +449,14 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
   }
 
   deserializeSyncMessage(message: Uint8Array): CRDTSyncMessage<BinaryChange[], CryptoKey> {
-    const raw = this.deserialize(this.decode(message)) as any;
+    const raw = this.deserialize(this.decode(message)) as {
+      documentId?: string;
+      changeId?: string;
+      changes?: iCRDTChangeNode;
+      keychainChanges?: string[];
+      snapshot?: any;
+      signature?: string;
+    };
     let snapshot: any;
     if (raw.snapshot) {
       snapshot = { ...raw.snapshot };

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -454,7 +454,26 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
   }
 
   deserializeSyncMessage(message: Uint8Array): CRDTSyncMessage<BinaryChange[], CryptoKey> {
-    const raw = this.deserialize(this.decode(message)) as {
+    const decoded = this.deserialize(this.decode(message));
+    // Wire input is untrusted: a malformed peer can send `null`, an array, or
+    // a primitive in place of a sync-message object. Reading properties on
+    // those values would throw a bare `TypeError` (`Cannot read properties of
+    // null`) that is hard to attribute back to the peer; reject up front with
+    // a descriptive error instead. This also denies a trivial DoS path where
+    // a peer crashes the deserializer by sending e.g. JSON `null`. Mirrors
+    // the equivalent guard in `YjsJSONSerializer.deserializeSyncMessage`.
+    if (typeof decoded !== 'object' || decoded === null || Array.isArray(decoded)) {
+      throw new Error(
+        `Invalid sync message: expected a plain object (got ${
+          decoded === null
+            ? 'null'
+            : Array.isArray(decoded)
+              ? 'array'
+              : typeof decoded
+        })`,
+      );
+    }
+    const raw = decoded as {
       documentId?: string;
       changeId?: string;
       changes?: iCRDTChangeNode;

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -506,14 +506,27 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
       );
     }
     let snapshot: any;
-    if (raw.snapshot) {
+    // Any value other than `undefined` (including `null`, `0`, `""`, etc.)
+    // must be routed through the validator -- using a truthy guard like
+    // `raw.snapshot && ...` would let a malformed peer message bypass the
+    // object/array shape check by sending e.g. `snapshot: null`, with the
+    // falsy value flowing through and silently being dropped.
+    if (raw.snapshot !== undefined) {
       // `raw.snapshot` is untrusted; reject anything that isn't a plain object
-      // before spreading it (a peer-supplied array or primitive would otherwise
-      // be silently coerced via spread).
-      if (typeof raw.snapshot !== 'object' || Array.isArray(raw.snapshot)) {
+      // before spreading it (a peer-supplied array, null, or primitive would
+      // otherwise be silently coerced via spread or dropped on the floor).
+      if (
+        raw.snapshot === null ||
+        typeof raw.snapshot !== 'object' ||
+        Array.isArray(raw.snapshot)
+      ) {
         throw new Error(
           `Invalid sync message: 'snapshot' must be an object when present (got ${
-            Array.isArray(raw.snapshot) ? 'array' : typeof raw.snapshot
+            raw.snapshot === null
+              ? 'null'
+              : Array.isArray(raw.snapshot)
+                ? 'array'
+                : typeof raw.snapshot
           })`,
         );
       }

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -474,16 +474,50 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
       );
     }
     const raw = decoded as {
-      documentId?: string;
-      changeId?: string;
-      changes?: iCRDTChangeNode;
-      keychainChanges?: string[];
-      snapshot?: any;
-      signature?: string;
+      documentId?: unknown;
+      changeId?: unknown;
+      changes?: unknown;
+      keychainChanges?: unknown;
+      snapshot?: unknown;
+      signature?: unknown;
     };
+    // `documentId` is a required field on the wire contract. A malformed peer
+    // could omit it or send a non-string value (number, object, null), which
+    // would otherwise propagate as `documentId: undefined`/non-string into
+    // downstream consumers that key documents by string ID. Validate up front
+    // and attribute the failure back to the peer with a descriptive error.
+    if (typeof raw.documentId !== 'string') {
+      throw new Error(
+        `Invalid sync message: 'documentId' must be a string (got ${
+          raw.documentId === null ? 'null' : typeof raw.documentId
+        })`,
+      );
+    }
+    // Validate optional scalar fields that have a fixed expected type. Skipped
+    // when omitted (`undefined`) so callers can send partial sync messages.
+    if (raw.changeId !== undefined && typeof raw.changeId !== 'string') {
+      throw new Error(
+        `Invalid sync message: 'changeId' must be a string when present (got ${typeof raw.changeId})`,
+      );
+    }
+    if (raw.signature !== undefined && typeof raw.signature !== 'string') {
+      throw new Error(
+        `Invalid sync message: 'signature' must be a string when present (got ${typeof raw.signature})`,
+      );
+    }
     let snapshot: any;
     if (raw.snapshot) {
-      snapshot = { ...raw.snapshot };
+      // `raw.snapshot` is untrusted; reject anything that isn't a plain object
+      // before spreading it (a peer-supplied array or primitive would otherwise
+      // be silently coerced via spread).
+      if (typeof raw.snapshot !== 'object' || Array.isArray(raw.snapshot)) {
+        throw new Error(
+          `Invalid sync message: 'snapshot' must be an object when present (got ${
+            Array.isArray(raw.snapshot) ? 'array' : typeof raw.snapshot
+          })`,
+        );
+      }
+      snapshot = { ...(raw.snapshot as Record<string, unknown>) };
       // Decode base64-encoded BinaryChange[] back to Uint8Array[].
       if (Array.isArray(snapshot.state)) {
         snapshot.state = snapshot.state.map(
@@ -494,23 +528,38 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
         snapshot.signature = Base64.toUint8Array(snapshot.signature);
       }
     }
-    return {
-      ...raw,
-      // Any value other than `undefined` (including `null`, `0`, `""`, etc.)
-      // must be routed through the validator -- using a truthy guard like
-      // `raw.changes && ...` would let a malformed peer message bypass
-      // `deserializeChangeNodeFromJSON`'s shape checks by sending e.g.
-      // `changes: null`, with the falsy value flowing through to
-      // downstream consumers via the spread above.
-      changes:
-        raw.changes === undefined
-          ? undefined
-          : deserializeChangeNodeFromJSON(raw.changes, deserializeBinaryChanges),
-      keychainChanges:
-        raw.keychainChanges
-          ? deserializeBinaryChanges(raw.keychainChanges)
-          : undefined,
-      snapshot,
-    } as CRDTSyncMessage<BinaryChange[], CryptoKey>;
+    let keychainChanges: BinaryChange[] | undefined;
+    if (raw.keychainChanges !== undefined) {
+      if (!Array.isArray(raw.keychainChanges)) {
+        throw new Error(
+          `Invalid sync message: 'keychainChanges' must be an array when present (got ${typeof raw.keychainChanges})`,
+        );
+      }
+      keychainChanges = deserializeBinaryChanges(raw.keychainChanges as string[]);
+    }
+    // Build the returned object explicitly rather than spreading `...raw` so
+    // that peer-supplied junk keys (e.g. `__proto__`, `constructor`, or any
+    // unrecognized field) don't leak into the deserialized sync message. Only
+    // fields declared on `CRDTSyncMessage` are propagated.
+    const result: CRDTSyncMessage<BinaryChange[], CryptoKey> = {
+      documentId: raw.documentId,
+    };
+    if (raw.changeId !== undefined) result.changeId = raw.changeId as string;
+    if (raw.signature !== undefined) result.signature = raw.signature as string;
+    // Any value other than `undefined` (including `null`, `0`, `""`, etc.)
+    // must be routed through the validator -- using a truthy guard like
+    // `raw.changes && ...` would let a malformed peer message bypass
+    // `deserializeChangeNodeFromJSON`'s shape checks by sending e.g.
+    // `changes: null`, with the falsy value flowing through to
+    // downstream consumers.
+    if (raw.changes !== undefined) {
+      result.changes = deserializeChangeNodeFromJSON(
+        raw.changes as iCRDTChangeNode,
+        deserializeBinaryChanges,
+      );
+    }
+    if (keychainChanges !== undefined) result.keychainChanges = keychainChanges;
+    if (snapshot !== undefined) result.snapshot = snapshot;
+    return result;
   }
 }

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -437,9 +437,14 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
     return this.encode(
       this.serialize({
         ...message,
+        // Mirror the deserializer: only `undefined` skips the
+        // serialization path. Any defined value flows through
+        // `serializeChangeNodeForJSON` so the wire shape matches what
+        // the deserializer will validate on the receiving end.
         changes:
-          message.changes &&
-          serializeChangeNodeForJSON(message.changes, serializeBinaryChanges),
+          message.changes === undefined
+            ? undefined
+            : serializeChangeNodeForJSON(message.changes, serializeBinaryChanges),
         keychainChanges:
           message.keychainChanges &&
           serializeBinaryChanges(message.keychainChanges),
@@ -472,9 +477,16 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
     }
     return {
       ...raw,
+      // Any value other than `undefined` (including `null`, `0`, `""`, etc.)
+      // must be routed through the validator -- using a truthy guard like
+      // `raw.changes && ...` would let a malformed peer message bypass
+      // `deserializeChangeNodeFromJSON`'s shape checks by sending e.g.
+      // `changes: null`, with the falsy value flowing through to
+      // downstream consumers via the spread above.
       changes:
-        raw.changes &&
-        deserializeChangeNodeFromJSON(raw.changes, deserializeBinaryChanges),
+        raw.changes === undefined
+          ? undefined
+          : deserializeChangeNodeFromJSON(raw.changes, deserializeBinaryChanges),
       keychainChanges:
         raw.keychainChanges
           ? deserializeBinaryChanges(raw.keychainChanges)

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -17,16 +17,15 @@ import {
   ACLProvider,
   CollabswarmDocumentChangeHandler,
   CRDTChangeBlock,
-  CRDTChangeNode,
-  CRDTChangeNodeDeferred,
-  crdtChangeNodeDeferred,
-  CRDTChangeNodeKind,
+  CRDTChangeNodeWire,
   CRDTProvider,
   CRDTSyncMessage,
+  deserializeChangeNodeFromJSON,
   JSONSerializer,
   Keychain,
   KeychainProvider,
   LRUCache,
+  serializeChangeNodeForJSON,
 } from '@collabswarm/collabswarm';
 import { validateChangeBlockMetadata } from '@collabswarm/collabswarm';
 import { Base64 } from 'js-base64';
@@ -367,44 +366,7 @@ export class AutomergeKeychainProvider
  * Intermediate wire type for Automerge Merkle-DAG nodes where each
  * BinaryChange[] is represented as base64-encoded strings.
  */
-type iCRDTChangeNode = {
-  kind: CRDTChangeNodeKind;
-  keyID?: string;
-  change?: string[];
-  children?: { [hash: string]: iCRDTChangeNode } | CRDTChangeNodeDeferred;
-};
-
-function serializeBinaryChangesInMerkleDAG(
-  node: CRDTChangeNode<BinaryChange[]>,
-): iCRDTChangeNode {
-  const change = node.change
-    ? node.change.map((c: Uint8Array) => Base64.fromUint8Array(c))
-    : undefined;
-  if (node.children !== undefined && node.children !== crdtChangeNodeDeferred) {
-    const children: { [hash: string]: iCRDTChangeNode } = {};
-    for (const [hash, child] of Object.entries(node.children)) {
-      children[hash] = serializeBinaryChangesInMerkleDAG(child);
-    }
-    return { ...node, change, children };
-  }
-  return { ...node, change, children: node.children };
-}
-
-function deserializeBinaryChangesInMerkleDAG(
-  node: iCRDTChangeNode,
-): CRDTChangeNode<BinaryChange[]> {
-  const change = node.change
-    ? (node.change.map((c: string) => Base64.toUint8Array(c)) as BinaryChange[])
-    : undefined;
-  if (node.children !== undefined && node.children !== crdtChangeNodeDeferred) {
-    const children: { [hash: string]: CRDTChangeNode<BinaryChange[]> } = {};
-    for (const [hash, child] of Object.entries(node.children)) {
-      children[hash] = deserializeBinaryChangesInMerkleDAG(child);
-    }
-    return { ...node, change, children };
-  }
-  return { ...node, change, children: node.children };
-}
+type iCRDTChangeNode = CRDTChangeNodeWire<string[]>;
 
 function serializeBinaryChanges(changes: BinaryChange[]): string[] {
   return changes.map((c: Uint8Array) => Base64.fromUint8Array(c));
@@ -476,7 +438,8 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
       this.serialize({
         ...message,
         changes:
-          message.changes && serializeBinaryChangesInMerkleDAG(message.changes),
+          message.changes &&
+          serializeChangeNodeForJSON(message.changes, serializeBinaryChanges),
         keychainChanges:
           message.keychainChanges &&
           serializeBinaryChanges(message.keychainChanges),
@@ -503,7 +466,8 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
     return {
       ...raw,
       changes:
-        raw.changes && deserializeBinaryChangesInMerkleDAG(raw.changes),
+        raw.changes &&
+        deserializeChangeNodeFromJSON(raw.changes, deserializeBinaryChanges),
       keychainChanges:
         raw.keychainChanges
           ? deserializeBinaryChanges(raw.keychainChanges)

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -20,6 +20,7 @@ import {
   CRDTChangeNodeWire,
   CRDTProvider,
   CRDTSyncMessage,
+  describeValue,
   deserializeChangeNodeFromJSON,
   JSONSerializer,
   Keychain,
@@ -464,13 +465,9 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
     // the equivalent guard in `YjsJSONSerializer.deserializeSyncMessage`.
     if (typeof decoded !== 'object' || decoded === null || Array.isArray(decoded)) {
       throw new Error(
-        `Invalid sync message: expected a plain object (got ${
-          decoded === null
-            ? 'null'
-            : Array.isArray(decoded)
-              ? 'array'
-              : typeof decoded
-        })`,
+        `Invalid sync message: expected a plain object (got ${describeValue(
+          decoded,
+        )})`,
       );
     }
     const raw = decoded as {
@@ -488,21 +485,25 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
     // and attribute the failure back to the peer with a descriptive error.
     if (typeof raw.documentId !== 'string') {
       throw new Error(
-        `Invalid sync message: 'documentId' must be a string (got ${
-          raw.documentId === null ? 'null' : typeof raw.documentId
-        })`,
+        `Invalid sync message: 'documentId' must be a string (got ${describeValue(
+          raw.documentId,
+        )})`,
       );
     }
     // Validate optional scalar fields that have a fixed expected type. Skipped
     // when omitted (`undefined`) so callers can send partial sync messages.
     if (raw.changeId !== undefined && typeof raw.changeId !== 'string') {
       throw new Error(
-        `Invalid sync message: 'changeId' must be a string when present (got ${typeof raw.changeId})`,
+        `Invalid sync message: 'changeId' must be a string when present (got ${describeValue(
+          raw.changeId,
+        )})`,
       );
     }
     if (raw.signature !== undefined && typeof raw.signature !== 'string') {
       throw new Error(
-        `Invalid sync message: 'signature' must be a string when present (got ${typeof raw.signature})`,
+        `Invalid sync message: 'signature' must be a string when present (got ${describeValue(
+          raw.signature,
+        )})`,
       );
     }
     let snapshot: any;
@@ -521,13 +522,9 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
         Array.isArray(raw.snapshot)
       ) {
         throw new Error(
-          `Invalid sync message: 'snapshot' must be an object when present (got ${
-            raw.snapshot === null
-              ? 'null'
-              : Array.isArray(raw.snapshot)
-                ? 'array'
-                : typeof raw.snapshot
-          })`,
+          `Invalid sync message: 'snapshot' must be an object when present (got ${describeValue(
+            raw.snapshot,
+          )})`,
         );
       }
       snapshot = { ...(raw.snapshot as Record<string, unknown>) };
@@ -545,7 +542,9 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
     if (raw.keychainChanges !== undefined) {
       if (!Array.isArray(raw.keychainChanges)) {
         throw new Error(
-          `Invalid sync message: 'keychainChanges' must be an array when present (got ${typeof raw.keychainChanges})`,
+          `Invalid sync message: 'keychainChanges' must be an array when present (got ${describeValue(
+            raw.keychainChanges,
+          )})`,
         );
       }
       keychainChanges = deserializeBinaryChanges(raw.keychainChanges as string[]);

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -137,12 +137,25 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
       );
     }
     // Decode snapshot base64 fields back to Uint8Array.
+    // Any value other than `undefined` (including `null`, `0`, `""`, etc.)
+    // must be routed through the validator -- using a truthy guard like
+    // `raw.snapshot && ...` would let a malformed peer message bypass the
+    // object/array shape check by sending e.g. `snapshot: null`, with the
+    // falsy value flowing through and silently being dropped.
     let snapshot: any;
-    if (raw.snapshot) {
-      if (typeof raw.snapshot !== 'object' || Array.isArray(raw.snapshot)) {
+    if (raw.snapshot !== undefined) {
+      if (
+        raw.snapshot === null ||
+        typeof raw.snapshot !== 'object' ||
+        Array.isArray(raw.snapshot)
+      ) {
         throw new Error(
           `Invalid sync message: 'snapshot' must be an object when present (got ${
-            Array.isArray(raw.snapshot) ? 'array' : typeof raw.snapshot
+            raw.snapshot === null
+              ? 'null'
+              : Array.isArray(raw.snapshot)
+                ? 'array'
+                : typeof raw.snapshot
           })`,
         );
       }

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -91,22 +91,62 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
     );
   }
   deserializeSyncMessage(message: Uint8Array): CRDTSyncMessage<Uint8Array> {
-    const raw = this.deserialize(this.decode(message));
-    if (typeof raw !== 'object' || raw === null || typeof (raw as Record<string, unknown>).documentId !== 'string') {
-      throw new Error('Invalid sync message: expected object with documentId string');
+    const decoded = this.deserialize(this.decode(message));
+    // Wire input is untrusted: reject non-object payloads up front with a
+    // descriptive error so the malformed payload can be attributed back to
+    // the peer instead of throwing a bare `TypeError`. Mirrors the guard in
+    // `AutomergeJSONSerializer.deserializeSyncMessage`.
+    if (typeof decoded !== 'object' || decoded === null || Array.isArray(decoded)) {
+      throw new Error(
+        `Invalid sync message: expected a plain object (got ${
+          decoded === null
+            ? 'null'
+            : Array.isArray(decoded)
+              ? 'array'
+              : typeof decoded
+        })`,
+      );
     }
-    const deserialized = raw as {
-      documentId: string;
-      changeId?: string;
-      changes?: iCRDTChangeNode;
-      keychainChanges?: string;
-      snapshot?: any;
-      signature?: string;
+    const raw = decoded as {
+      documentId?: unknown;
+      changeId?: unknown;
+      changes?: unknown;
+      keychainChanges?: unknown;
+      snapshot?: unknown;
+      signature?: unknown;
     };
+    // `documentId` is a required field on the wire contract. A malformed peer
+    // could omit it or send a non-string value, which would otherwise
+    // propagate as `documentId: undefined`/non-string into downstream
+    // consumers that key documents by string ID.
+    if (typeof raw.documentId !== 'string') {
+      throw new Error(
+        `Invalid sync message: 'documentId' must be a string (got ${
+          raw.documentId === null ? 'null' : typeof raw.documentId
+        })`,
+      );
+    }
+    if (raw.changeId !== undefined && typeof raw.changeId !== 'string') {
+      throw new Error(
+        `Invalid sync message: 'changeId' must be a string when present (got ${typeof raw.changeId})`,
+      );
+    }
+    if (raw.signature !== undefined && typeof raw.signature !== 'string') {
+      throw new Error(
+        `Invalid sync message: 'signature' must be a string when present (got ${typeof raw.signature})`,
+      );
+    }
     // Decode snapshot base64 fields back to Uint8Array.
     let snapshot: any;
-    if (deserialized.snapshot) {
-      snapshot = { ...deserialized.snapshot };
+    if (raw.snapshot) {
+      if (typeof raw.snapshot !== 'object' || Array.isArray(raw.snapshot)) {
+        throw new Error(
+          `Invalid sync message: 'snapshot' must be an object when present (got ${
+            Array.isArray(raw.snapshot) ? 'array' : typeof raw.snapshot
+          })`,
+        );
+      }
+      snapshot = { ...(raw.snapshot as Record<string, unknown>) };
       if (typeof snapshot.state === 'string') {
         snapshot.state = Base64.toUint8Array(snapshot.state);
       }
@@ -114,26 +154,37 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
         snapshot.signature = Base64.toUint8Array(snapshot.signature);
       }
     }
-    return {
-      ...deserialized,
-      // Any value other than `undefined` (including `null`, `0`, `""`, etc.)
-      // must be routed through the validator -- using a truthy guard like
-      // `deserialized.changes && ...` would let a malformed peer message
-      // bypass `deserializeChangeNodeFromJSON`'s shape checks by sending
-      // e.g. `changes: null`, with the falsy value flowing through to
-      // downstream consumers via the spread above.
-      changes:
-        deserialized.changes === undefined
-          ? undefined
-          : deserializeChangeNodeFromJSON(
-              deserialized.changes,
-              Base64.toUint8Array,
-            ),
-      keychainChanges: deserialized.keychainChanges
-        ? Base64.toUint8Array(deserialized.keychainChanges)
-        : undefined,
-      snapshot,
+    let keychainChanges: Uint8Array | undefined;
+    if (raw.keychainChanges !== undefined) {
+      if (typeof raw.keychainChanges !== 'string') {
+        throw new Error(
+          `Invalid sync message: 'keychainChanges' must be a string when present (got ${typeof raw.keychainChanges})`,
+        );
+      }
+      keychainChanges = Base64.toUint8Array(raw.keychainChanges);
+    }
+    // Build the returned object explicitly rather than spreading `...raw` so
+    // that peer-supplied junk keys don't leak into the deserialized sync
+    // message. Only fields declared on `CRDTSyncMessage` are propagated.
+    const result: CRDTSyncMessage<Uint8Array> = {
+      documentId: raw.documentId,
     };
+    if (raw.changeId !== undefined) result.changeId = raw.changeId as string;
+    if (raw.signature !== undefined) result.signature = raw.signature as string;
+    // Any value other than `undefined` (including `null`, `0`, `""`, etc.)
+    // must be routed through the validator -- using a truthy guard like
+    // `raw.changes && ...` would let a malformed peer message bypass
+    // `deserializeChangeNodeFromJSON`'s shape checks by sending e.g.
+    // `changes: null`, with the falsy value flowing through.
+    if (raw.changes !== undefined) {
+      result.changes = deserializeChangeNodeFromJSON(
+        raw.changes as iCRDTChangeNode,
+        Base64.toUint8Array,
+      );
+    }
+    if (keychainChanges !== undefined) result.keychainChanges = keychainChanges;
+    if (snapshot !== undefined) result.snapshot = snapshot;
+    return result;
   }
 }
 

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -75,9 +75,14 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
     return this.encode(
       this.serialize({
         ...message,
+        // Mirror the deserializer: only `undefined` skips the
+        // serialization path. Any defined value flows through
+        // `serializeChangeNodeForJSON` so the wire shape matches what
+        // the deserializer will validate on the receiving end.
         changes:
-          message.changes &&
-          serializeChangeNodeForJSON(message.changes, Base64.fromUint8Array),
+          message.changes === undefined
+            ? undefined
+            : serializeChangeNodeForJSON(message.changes, Base64.fromUint8Array),
         keychainChanges:
           message.keychainChanges &&
           Base64.fromUint8Array(message.keychainChanges),
@@ -111,12 +116,19 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
     }
     return {
       ...deserialized,
+      // Any value other than `undefined` (including `null`, `0`, `""`, etc.)
+      // must be routed through the validator -- using a truthy guard like
+      // `deserialized.changes && ...` would let a malformed peer message
+      // bypass `deserializeChangeNodeFromJSON`'s shape checks by sending
+      // e.g. `changes: null`, with the falsy value flowing through to
+      // downstream consumers via the spread above.
       changes:
-        deserialized.changes &&
-        deserializeChangeNodeFromJSON(
-          deserialized.changes,
-          Base64.toUint8Array,
-        ),
+        deserialized.changes === undefined
+          ? undefined
+          : deserializeChangeNodeFromJSON(
+              deserialized.changes,
+              Base64.toUint8Array,
+            ),
       keychainChanges: deserialized.keychainChanges
         ? Base64.toUint8Array(deserialized.keychainChanges)
         : undefined,

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -3,77 +3,25 @@ import {
   ACLProvider,
   CollabswarmDocumentChangeHandler,
   CRDTChangeBlock,
-  CRDTChangeNode,
-  CRDTChangeNodeDeferred,
-  crdtChangeNodeDeferred,
-  CRDTChangeNodeKind,
+  CRDTChangeNodeWire,
   CRDTProvider,
   CRDTSyncMessage,
+  deserializeChangeNodeFromJSON,
   JSONSerializer,
   Keychain,
   KeychainProvider,
   LRUCache,
+  serializeChangeNodeForJSON,
 } from '@collabswarm/collabswarm';
 import { validateChangeBlockMetadata } from '@collabswarm/collabswarm';
 import { applyUpdateV2, Doc, encodeStateAsUpdateV2, encodeStateVector } from 'yjs';
 import * as uuid from 'uuid';
 import { Base64 } from 'js-base64';
 
-type iCRDTChangeNode = {
-  kind: CRDTChangeNodeKind;
-  keyID?: string;
-  // Binary data is stored as a base64 string for JSON serialization.
-  // Base64 has only ~33% payload expansion and is the standard encoding for
-  // binary data in JSON, so this is an acceptable trade-off.
-  change?: string;
-  children?: { [hash: string]: iCRDTChangeNode } | CRDTChangeNodeDeferred;
-};
-
-function serializeUint8ArrayInMerkleDAG(
-  node: CRDTChangeNode<Uint8Array>,
-): iCRDTChangeNode {
-  const change = node.change ? Base64.fromUint8Array(node.change) : undefined;
-  if (node.children !== undefined && node.children !== crdtChangeNodeDeferred) {
-    const children: { [hash: string]: iCRDTChangeNode } = {};
-    for (const [hash, child] of Object.entries(node.children)) {
-      children[hash] = serializeUint8ArrayInMerkleDAG(child);
-    }
-    return {
-      ...node,
-      change,
-      children,
-    };
-  } else {
-    return {
-      ...node,
-      change,
-      children: node.children,
-    };
-  }
-}
-
-function deserializeUint8ArrayInMerkleDAG(
-  node: iCRDTChangeNode,
-): CRDTChangeNode<Uint8Array> {
-  const change = node.change ? Base64.toUint8Array(node.change) : undefined;
-  if (node.children !== undefined && node.children !== crdtChangeNodeDeferred) {
-    const children: { [hash: string]: CRDTChangeNode<Uint8Array> } = {};
-    for (const [hash, child] of Object.entries(node.children)) {
-      children[hash] = deserializeUint8ArrayInMerkleDAG(child);
-    }
-    return {
-      ...node,
-      change,
-      children,
-    };
-  } else {
-    return {
-      ...node,
-      change,
-      children: node.children,
-    };
-  }
-}
+// Binary data is stored as a base64 string for JSON serialization.
+// Base64 has only ~33% payload expansion and is the standard encoding for
+// binary data in JSON, so this is an acceptable trade-off.
+type iCRDTChangeNode = CRDTChangeNodeWire<string>;
 
 export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
   serializeChanges(changes: Uint8Array): Uint8Array {
@@ -128,7 +76,8 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
       this.serialize({
         ...message,
         changes:
-          message.changes && serializeUint8ArrayInMerkleDAG(message.changes),
+          message.changes &&
+          serializeChangeNodeForJSON(message.changes, Base64.fromUint8Array),
         keychainChanges:
           message.keychainChanges &&
           Base64.fromUint8Array(message.keychainChanges),
@@ -164,7 +113,10 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
       ...deserialized,
       changes:
         deserialized.changes &&
-        deserializeUint8ArrayInMerkleDAG(deserialized.changes),
+        deserializeChangeNodeFromJSON(
+          deserialized.changes,
+          Base64.toUint8Array,
+        ),
       keychainChanges: deserialized.keychainChanges
         ? Base64.toUint8Array(deserialized.keychainChanges)
         : undefined,

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -6,6 +6,7 @@ import {
   CRDTChangeNodeWire,
   CRDTProvider,
   CRDTSyncMessage,
+  describeValue,
   deserializeChangeNodeFromJSON,
   JSONSerializer,
   Keychain,
@@ -98,13 +99,9 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
     // `AutomergeJSONSerializer.deserializeSyncMessage`.
     if (typeof decoded !== 'object' || decoded === null || Array.isArray(decoded)) {
       throw new Error(
-        `Invalid sync message: expected a plain object (got ${
-          decoded === null
-            ? 'null'
-            : Array.isArray(decoded)
-              ? 'array'
-              : typeof decoded
-        })`,
+        `Invalid sync message: expected a plain object (got ${describeValue(
+          decoded,
+        )})`,
       );
     }
     const raw = decoded as {
@@ -121,19 +118,23 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
     // consumers that key documents by string ID.
     if (typeof raw.documentId !== 'string') {
       throw new Error(
-        `Invalid sync message: 'documentId' must be a string (got ${
-          raw.documentId === null ? 'null' : typeof raw.documentId
-        })`,
+        `Invalid sync message: 'documentId' must be a string (got ${describeValue(
+          raw.documentId,
+        )})`,
       );
     }
     if (raw.changeId !== undefined && typeof raw.changeId !== 'string') {
       throw new Error(
-        `Invalid sync message: 'changeId' must be a string when present (got ${typeof raw.changeId})`,
+        `Invalid sync message: 'changeId' must be a string when present (got ${describeValue(
+          raw.changeId,
+        )})`,
       );
     }
     if (raw.signature !== undefined && typeof raw.signature !== 'string') {
       throw new Error(
-        `Invalid sync message: 'signature' must be a string when present (got ${typeof raw.signature})`,
+        `Invalid sync message: 'signature' must be a string when present (got ${describeValue(
+          raw.signature,
+        )})`,
       );
     }
     // Decode snapshot base64 fields back to Uint8Array.
@@ -150,13 +151,9 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
         Array.isArray(raw.snapshot)
       ) {
         throw new Error(
-          `Invalid sync message: 'snapshot' must be an object when present (got ${
-            raw.snapshot === null
-              ? 'null'
-              : Array.isArray(raw.snapshot)
-                ? 'array'
-                : typeof raw.snapshot
-          })`,
+          `Invalid sync message: 'snapshot' must be an object when present (got ${describeValue(
+            raw.snapshot,
+          )})`,
         );
       }
       snapshot = { ...(raw.snapshot as Record<string, unknown>) };
@@ -171,7 +168,9 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
     if (raw.keychainChanges !== undefined) {
       if (typeof raw.keychainChanges !== 'string') {
         throw new Error(
-          `Invalid sync message: 'keychainChanges' must be a string when present (got ${typeof raw.keychainChanges})`,
+          `Invalid sync message: 'keychainChanges' must be a string when present (got ${describeValue(
+            raw.keychainChanges,
+          )})`,
         );
       }
       keychainChanges = Base64.toUint8Array(raw.keychainChanges);

--- a/packages/collabswarm-yjs/src/yjs-provider.test.ts
+++ b/packages/collabswarm-yjs/src/yjs-provider.test.ts
@@ -587,6 +587,41 @@ describe('YjsJSONSerializer', () => {
     );
   });
 
+  // Regression: a truthy guard (`if (raw.snapshot)`) silently dropped
+  // defined-but-falsy snapshot values rather than rejecting the malformed
+  // payload. The fix routes any non-`undefined` value through the validator
+  // so peers can't bypass it by sending `snapshot: null/0/""`.
+  test('deserializeSyncMessage rejects "snapshot: null" (validation bypass regression)', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc', snapshot: null });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'snapshot' must be an object when present.*got null/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects "snapshot: 0"', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc', snapshot: 0 });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'snapshot' must be an object when present.*got number/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects "snapshot: \\"\\"" (empty string)', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc', snapshot: '' });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'snapshot' must be an object when present.*got string/,
+    );
+  });
+
+  test('deserializeSyncMessage accepts omitted "snapshot" field', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc' });
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.snapshot).toBeUndefined();
+  });
+
   // Regression: prior to the upfront object guard, top-level non-object
   // payloads (null/array/primitive) threw a bare `TypeError: Cannot read
   // properties of null` instead of a descriptive error. Mirrors the

--- a/packages/collabswarm-yjs/src/yjs-provider.test.ts
+++ b/packages/collabswarm-yjs/src/yjs-provider.test.ts
@@ -478,4 +478,43 @@ describe('YjsJSONSerializer', () => {
     expect(deserialized.changes).toBeUndefined();
     expect(deserialized.keychainChanges).toBeUndefined();
   });
+
+  // Build a sync-message Uint8Array wire payload directly from a JS object,
+  // bypassing `serializeSyncMessage`'s type-safety so we can test that
+  // `deserializeSyncMessage` rejects every defined-but-malformed shape of
+  // `changes` rather than silently passing the falsy value through.
+  function buildWire(obj: unknown): Uint8Array {
+    return new TextEncoder().encode(JSON.stringify(obj));
+  }
+
+  test('deserializeSyncMessage rejects "changes: null" (validation bypass regression)', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc', changes: null });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /expected a plain object.*got null/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects "changes: 0"', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc', changes: 0 });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /expected a plain object.*got number/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects "changes: \\"\\"" (empty string)', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc', changes: '' });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /expected a plain object.*got string/,
+    );
+  });
+
+  test('deserializeSyncMessage accepts omitted "changes" field', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc' });
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.changes).toBeUndefined();
+  });
 });

--- a/packages/collabswarm-yjs/src/yjs-provider.test.ts
+++ b/packages/collabswarm-yjs/src/yjs-provider.test.ts
@@ -517,4 +517,118 @@ describe('YjsJSONSerializer', () => {
     const deserialized = serializer.deserializeSyncMessage(wire);
     expect(deserialized.changes).toBeUndefined();
   });
+
+  // Regression: prior to validating `documentId`, a malformed peer payload
+  // missing the field (or sending a non-string value) would propagate
+  // `documentId: undefined`/non-string downstream and violate the required
+  // field contract of `CRDTSyncMessage`. The fix rejects the payload with a
+  // descriptive error attributable back to the peer.
+  test('deserializeSyncMessage rejects payload missing documentId', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ changeId: 'c1' });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'documentId' must be a string.*got undefined/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects payload with non-string documentId (number)', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 42 });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'documentId' must be a string.*got number/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects payload with null documentId', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: null });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'documentId' must be a string.*got null/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects payload with object documentId', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: { id: 'doc' } });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'documentId' must be a string.*got object/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects non-string changeId', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc', changeId: 7 });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'changeId' must be a string when present.*got number/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects non-string signature', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc', signature: 7 });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'signature' must be a string when present.*got number/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects non-string keychainChanges', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc', keychainChanges: [1, 2, 3] });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'keychainChanges' must be a string when present.*got object/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects array snapshot', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({ documentId: 'doc', snapshot: [1, 2, 3] });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*'snapshot' must be an object when present.*got array/,
+    );
+  });
+
+  // Regression: prior to the upfront object guard, top-level non-object
+  // payloads (null/array/primitive) threw a bare `TypeError: Cannot read
+  // properties of null` instead of a descriptive error. Mirrors the
+  // equivalent automerge guard.
+  test('deserializeSyncMessage rejects a top-level JSON null payload', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire(null);
+    expect(() => serializer.deserializeSyncMessage(wire)).not.toThrow(
+      TypeError,
+    );
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*expected a plain object.*got null/,
+    );
+  });
+
+  test('deserializeSyncMessage rejects a top-level JSON array payload', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire([1, 2, 3]);
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /Invalid sync message.*expected a plain object.*got array/,
+    );
+  });
+
+  // Regression: prior to building the returned object explicitly, the
+  // deserializer spread `...deserialized` straight onto the result. A
+  // malicious peer could append junk keys and they would leak through to
+  // downstream consumers. The fix only propagates fields declared on
+  // `CRDTSyncMessage`.
+  test('deserializeSyncMessage strips peer-supplied junk keys', () => {
+    const serializer = new YjsJSONSerializer();
+    const wire = buildWire({
+      documentId: 'doc',
+      changeId: 'cid',
+      somethingExtra: 'evil',
+      anotherJunkField: { nested: true },
+      __evilNonProtoKey: 'still-junk',
+    });
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.documentId).toBe('doc');
+    expect(deserialized.changeId).toBe('cid');
+    expect((deserialized as Record<string, unknown>).somethingExtra).toBeUndefined();
+    expect((deserialized as Record<string, unknown>).anotherJunkField).toBeUndefined();
+    expect((deserialized as Record<string, unknown>).__evilNonProtoKey).toBeUndefined();
+  });
 });

--- a/packages/collabswarm-yjs/src/yjs-provider.test.ts
+++ b/packages/collabswarm-yjs/src/yjs-provider.test.ts
@@ -575,7 +575,7 @@ describe('YjsJSONSerializer', () => {
     const serializer = new YjsJSONSerializer();
     const wire = buildWire({ documentId: 'doc', keychainChanges: [1, 2, 3] });
     expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
-      /Invalid sync message.*'keychainChanges' must be a string when present.*got object/,
+      /Invalid sync message.*'keychainChanges' must be a string when present.*got array/,
     );
   });
 

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -36,6 +36,11 @@ import {
   crdtChangeNodeDeferred,
 } from './crdt-change-node';
 import {
+  CRDTChangeNodeWire,
+  serializeChangeNodeForJSON,
+  deserializeChangeNodeFromJSON,
+} from './merkle-dag-serialization';
+import {
   EPOCH_ID_LENGTH,
   GCM_NONCE_LENGTH,
   EPOCH_SECRET_INFO,
@@ -107,6 +112,9 @@ export {
   CRDTChangeNodeDeferred,
   CRDTChangeNode,
   crdtChangeNodeDeferred,
+  CRDTChangeNodeWire,
+  serializeChangeNodeForJSON,
+  deserializeChangeNodeFromJSON,
   CRDTSyncMessage,
   CRDTProvider,
   ChangesSerializer,

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -37,6 +37,7 @@ import {
 } from './crdt-change-node';
 import {
   CRDTChangeNodeWire,
+  describeValue,
   serializeChangeNodeForJSON,
   deserializeChangeNodeFromJSON,
 } from './merkle-dag-serialization';
@@ -113,6 +114,7 @@ export {
   CRDTChangeNode,
   crdtChangeNodeDeferred,
   CRDTChangeNodeWire,
+  describeValue,
   serializeChangeNodeForJSON,
   deserializeChangeNodeFromJSON,
   CRDTSyncMessage,

--- a/packages/collabswarm/src/merkle-dag-serialization.test.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  CRDTChangeNode,
+  crdtChangeNodeDeferred,
+} from './crdt-change-node';
+import {
+  CRDTChangeNodeWire,
+  deserializeChangeNodeFromJSON,
+  serializeChangeNodeForJSON,
+} from './merkle-dag-serialization';
+
+// --- Test encoders -------------------------------------------------------
+
+// Hex codec: keeps tests dependency-free while exercising the same shape as
+// the base64 codec used by the real providers.
+function hexEncode(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function hexDecode(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) {
+    throw new Error('hex string must have even length');
+  }
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+const encodeBytes = (b: Uint8Array): string => hexEncode(b);
+const decodeBytes = (s: string): Uint8Array => hexDecode(s);
+
+const encodeBytesArray = (bs: Uint8Array[]): string[] =>
+  bs.map((b) => hexEncode(b));
+const decodeBytesArray = (ss: string[]): Uint8Array[] =>
+  ss.map((s) => hexDecode(s));
+
+function expectBytesEqual(actual: Uint8Array, expected: Uint8Array): void {
+  expect(Array.from(actual)).toEqual(Array.from(expected));
+}
+
+function expectBytesArrayEqual(
+  actual: Uint8Array[],
+  expected: Uint8Array[],
+): void {
+  expect(actual.length).toBe(expected.length);
+  for (let i = 0; i < actual.length; i++) {
+    expectBytesEqual(actual[i], expected[i]);
+  }
+}
+
+// --- Tests ---------------------------------------------------------------
+
+describe('serializeChangeNodeForJSON / deserializeChangeNodeFromJSON', () => {
+  test('round-trips a leaf-only Uint8Array node (no children)', () => {
+    const original: CRDTChangeNode<Uint8Array> = {
+      kind: 'document',
+      change: new Uint8Array([1, 2, 3, 4]),
+    };
+
+    const wire = serializeChangeNodeForJSON(original, encodeBytes);
+    expect(wire.kind).toBe('document');
+    expect(wire.change).toBe('01020304');
+    expect(wire.children).toBeUndefined();
+
+    const restored = deserializeChangeNodeFromJSON(wire, decodeBytes);
+    expect(restored.kind).toBe('document');
+    expect(restored.change).toBeDefined();
+    expectBytesEqual(restored.change as Uint8Array, original.change as Uint8Array);
+    expect(restored.children).toBeUndefined();
+  });
+
+  test('round-trips a leaf-only Uint8Array[] node (mirrors automerge)', () => {
+    const original: CRDTChangeNode<Uint8Array[]> = {
+      kind: 'writer',
+      keyID: 'key-1',
+      change: [new Uint8Array([5, 6]), new Uint8Array([7, 8, 9])],
+    };
+
+    const wire = serializeChangeNodeForJSON(original, encodeBytesArray);
+    expect(wire.kind).toBe('writer');
+    expect(wire.keyID).toBe('key-1');
+    expect(wire.change).toEqual(['0506', '070809']);
+
+    const restored = deserializeChangeNodeFromJSON(wire, decodeBytesArray);
+    expect(restored.kind).toBe('writer');
+    expect(restored.keyID).toBe('key-1');
+    expectBytesArrayEqual(
+      restored.change as Uint8Array[],
+      original.change as Uint8Array[],
+    );
+  });
+
+  test('preserves an empty tree where change is undefined and children is undefined', () => {
+    const original: CRDTChangeNode<Uint8Array> = { kind: 'reader' };
+
+    const wire = serializeChangeNodeForJSON(original, encodeBytes);
+    expect(wire).toEqual({ kind: 'reader', change: undefined, children: undefined });
+
+    const restored = deserializeChangeNodeFromJSON(wire, decodeBytes);
+    expect(restored.kind).toBe('reader');
+    expect(restored.change).toBeUndefined();
+    expect(restored.children).toBeUndefined();
+  });
+
+  test('round-trips a multi-level tree with multiple children at each level (Uint8Array)', () => {
+    const original: CRDTChangeNode<Uint8Array> = {
+      kind: 'document',
+      change: new Uint8Array([0xaa]),
+      children: {
+        h1: {
+          kind: 'document',
+          change: new Uint8Array([0xbb, 0xcc]),
+          children: {
+            h1a: {
+              kind: 'writer',
+              keyID: 'k-1',
+              change: new Uint8Array([0x01]),
+            },
+            h1b: {
+              kind: 'reader',
+              change: new Uint8Array([0x02]),
+            },
+          },
+        },
+        h2: {
+          kind: 'document',
+          change: new Uint8Array([0xdd]),
+          children: {
+            h2a: {
+              kind: 'document',
+              change: new Uint8Array([0x03, 0x04, 0x05]),
+            },
+          },
+        },
+        h3: {
+          kind: 'writer',
+          change: new Uint8Array([]),
+        },
+      },
+    };
+
+    const wire = serializeChangeNodeForJSON(original, encodeBytes);
+
+    // Wire form must be plain-JSON-safe: round-trip through JSON.
+    const json = JSON.stringify(wire);
+    const reparsed = JSON.parse(json) as CRDTChangeNodeWire<string>;
+
+    const restored = deserializeChangeNodeFromJSON(reparsed, decodeBytes);
+
+    expect(restored.kind).toBe('document');
+    expectBytesEqual(restored.change as Uint8Array, new Uint8Array([0xaa]));
+
+    // children should be present and structurally identical.
+    expect(restored.children).not.toBe(crdtChangeNodeDeferred);
+    expect(restored.children).toBeDefined();
+    const children = restored.children as Record<
+      string,
+      CRDTChangeNode<Uint8Array>
+    >;
+    expect(Object.keys(children).sort()).toEqual(['h1', 'h2', 'h3']);
+
+    expectBytesEqual(
+      children.h1.change as Uint8Array,
+      new Uint8Array([0xbb, 0xcc]),
+    );
+    const h1Children = children.h1.children as Record<
+      string,
+      CRDTChangeNode<Uint8Array>
+    >;
+    expect(Object.keys(h1Children).sort()).toEqual(['h1a', 'h1b']);
+    expect(h1Children.h1a.kind).toBe('writer');
+    expect(h1Children.h1a.keyID).toBe('k-1');
+    expectBytesEqual(h1Children.h1a.change as Uint8Array, new Uint8Array([0x01]));
+    expect(h1Children.h1b.kind).toBe('reader');
+    expectBytesEqual(h1Children.h1b.change as Uint8Array, new Uint8Array([0x02]));
+
+    const h2Children = children.h2.children as Record<
+      string,
+      CRDTChangeNode<Uint8Array>
+    >;
+    expect(Object.keys(h2Children)).toEqual(['h2a']);
+    expectBytesEqual(
+      h2Children.h2a.change as Uint8Array,
+      new Uint8Array([0x03, 0x04, 0x05]),
+    );
+
+    expect(children.h3.kind).toBe('writer');
+    expectBytesEqual(children.h3.change as Uint8Array, new Uint8Array([]));
+    expect(children.h3.children).toBeUndefined();
+  });
+
+  test('round-trips a multi-level tree with Uint8Array[] leaves (mirrors automerge)', () => {
+    const original: CRDTChangeNode<Uint8Array[]> = {
+      kind: 'document',
+      change: [new Uint8Array([1])],
+      children: {
+        a: {
+          kind: 'writer',
+          change: [new Uint8Array([2]), new Uint8Array([3, 4])],
+          children: {
+            'a.1': {
+              kind: 'reader',
+              keyID: 'reader-key',
+              change: [new Uint8Array([5, 6, 7])],
+            },
+          },
+        },
+        b: {
+          kind: 'document',
+          change: [],
+        },
+      },
+    };
+
+    const wire = serializeChangeNodeForJSON(original, encodeBytesArray);
+    const restored = deserializeChangeNodeFromJSON(wire, decodeBytesArray);
+
+    expectBytesArrayEqual(
+      restored.change as Uint8Array[],
+      original.change as Uint8Array[],
+    );
+    const children = restored.children as Record<
+      string,
+      CRDTChangeNode<Uint8Array[]>
+    >;
+    expectBytesArrayEqual(
+      children.a.change as Uint8Array[],
+      [new Uint8Array([2]), new Uint8Array([3, 4])],
+    );
+    const aChildren = children.a.children as Record<
+      string,
+      CRDTChangeNode<Uint8Array[]>
+    >;
+    expect(aChildren['a.1'].keyID).toBe('reader-key');
+    expectBytesArrayEqual(
+      aChildren['a.1'].change as Uint8Array[],
+      [new Uint8Array([5, 6, 7])],
+    );
+    // Empty array leaves must round-trip as empty arrays (not undefined).
+    expect(children.b.change).toEqual([]);
+  });
+
+  test('preserves crdtChangeNodeDeferred children sentinel through round-trip', () => {
+    const original: CRDTChangeNode<Uint8Array> = {
+      kind: 'document',
+      change: new Uint8Array([9]),
+      children: crdtChangeNodeDeferred,
+    };
+
+    const wire = serializeChangeNodeForJSON(original, encodeBytes);
+    expect(wire.children).toBe(crdtChangeNodeDeferred);
+
+    const restored = deserializeChangeNodeFromJSON(wire, decodeBytes);
+    expect(restored.children).toBe(crdtChangeNodeDeferred);
+    expectBytesEqual(restored.change as Uint8Array, new Uint8Array([9]));
+  });
+
+  test('encoder is not invoked for nodes whose change is undefined', () => {
+    const original: CRDTChangeNode<Uint8Array> = {
+      kind: 'document',
+      children: {
+        only: {
+          kind: 'writer',
+          change: new Uint8Array([42]),
+        },
+      },
+    };
+
+    let calls = 0;
+    const wire = serializeChangeNodeForJSON(original, (b) => {
+      calls++;
+      return hexEncode(b);
+    });
+    expect(calls).toBe(1);
+    expect(wire.change).toBeUndefined();
+    const wireChildren = wire.children as Record<
+      string,
+      CRDTChangeNodeWire<string>
+    >;
+    expect(wireChildren.only.change).toBe('2a');
+
+    let decCalls = 0;
+    const restored = deserializeChangeNodeFromJSON(wire, (s) => {
+      decCalls++;
+      return hexDecode(s);
+    });
+    expect(decCalls).toBe(1);
+    expect(restored.change).toBeUndefined();
+    const restoredChildren = restored.children as Record<
+      string,
+      CRDTChangeNode<Uint8Array>
+    >;
+    expectBytesEqual(
+      restoredChildren.only.change as Uint8Array,
+      new Uint8Array([42]),
+    );
+  });
+});

--- a/packages/collabswarm/src/merkle-dag-serialization.test.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.test.ts
@@ -434,6 +434,88 @@ describe('serializeChangeNodeForJSON / deserializeChangeNodeFromJSON', () => {
         /"kind" must be one of.*got "hacker"/,
       );
     });
+
+    test('throws when "keyID" is a number', () => {
+      // Regression: prior to keyID validation a peer could send
+      // `keyID: 123` and the value would flow through `...node` into the
+      // typed `CRDTChangeNode`, silently violating the `keyID?: string`
+      // contract.
+      const malformed = {
+        kind: 'writer',
+        keyID: 123,
+        change: '01',
+      } as unknown as CRDTChangeNodeWire<string>;
+      expect(() => deserializeChangeNodeFromJSON(malformed, decodeBytes)).toThrow(
+        /"keyID" must be a string when present.*got number/,
+      );
+    });
+
+    test('throws when "keyID" is null', () => {
+      const malformed = {
+        kind: 'writer',
+        keyID: null,
+        change: '01',
+      } as unknown as CRDTChangeNodeWire<string>;
+      expect(() => deserializeChangeNodeFromJSON(malformed, decodeBytes)).toThrow(
+        /"keyID" must be a string when present.*got null/,
+      );
+    });
+
+    test('throws when "keyID" is an object', () => {
+      const malformed = {
+        kind: 'writer',
+        keyID: { evil: true },
+        change: '01',
+      } as unknown as CRDTChangeNodeWire<string>;
+      expect(() => deserializeChangeNodeFromJSON(malformed, decodeBytes)).toThrow(
+        /"keyID" must be a string when present.*got object/,
+      );
+    });
+
+    test('throws when a nested child has an invalid "keyID"', () => {
+      const malformed = JSON.parse(
+        '{"kind":"document","change":"01","children":' +
+          '{"h1":{"kind":"writer","keyID":42,"change":"02"}}}',
+      ) as CRDTChangeNodeWire<string>;
+      expect(() => deserializeChangeNodeFromJSON(malformed, decodeBytes)).toThrow(
+        /"keyID" must be a string when present.*got number/,
+      );
+    });
+
+    test('accepts omitted "keyID" (optional field)', () => {
+      const node: CRDTChangeNodeWire<string> = { kind: 'document', change: '01' };
+      const restored = deserializeChangeNodeFromJSON(node, decodeBytes);
+      expect(restored.keyID).toBeUndefined();
+      // Explicit construction must not set `keyID` as an own property when
+      // omitted; consumers iterating own keys should not see it.
+      expect(Object.prototype.hasOwnProperty.call(restored, 'keyID')).toBe(false);
+    });
+
+    test('accepts a string "keyID"', () => {
+      const node: CRDTChangeNodeWire<string> = {
+        kind: 'writer',
+        keyID: 'k-1',
+        change: '01',
+      };
+      const restored = deserializeChangeNodeFromJSON(node, decodeBytes);
+      expect(restored.keyID).toBe('k-1');
+    });
+
+    test('strips unknown extra wire properties via explicit construction', () => {
+      // Regression: `...node` spread would silently propagate peer-supplied
+      // extras (e.g. a forged `signature` field) into our typed
+      // `CRDTChangeNode`. Explicit construction keeps the in-memory shape
+      // tight to the documented type.
+      const malformed = JSON.parse(
+        '{"kind":"document","change":"01","attackerField":"surprise",' +
+          '"__proto__":{"hijack":true}}',
+      ) as CRDTChangeNodeWire<string>;
+      const restored = deserializeChangeNodeFromJSON(malformed, decodeBytes);
+      expect(Object.keys(restored).sort()).toEqual(['change', 'kind']);
+      expect(
+        (restored as unknown as { attackerField?: unknown }).attackerField,
+      ).toBeUndefined();
+    });
   });
 
   test('encoder is not invoked for nodes whose change is undefined', () => {

--- a/packages/collabswarm/src/merkle-dag-serialization.test.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.test.ts
@@ -318,6 +318,48 @@ describe('serializeChangeNodeForJSON / deserializeChangeNodeFromJSON', () => {
   });
 
   describe('deserialize input validation (untrusted wire shapes)', () => {
+    test('throws with a descriptive Error (not TypeError) when node is null', () => {
+      // Regression: prior to the upfront guard this read `node.kind` first
+      // and threw `TypeError: Cannot read properties of null`, which is a
+      // trivial DoS vector if a peer puts `null` in a `changes` field.
+      const malformed = null as unknown as CRDTChangeNodeWire<string>;
+      const call = () => deserializeChangeNodeFromJSON(malformed, decodeBytes);
+      expect(call).toThrow(Error);
+      expect(call).not.toThrow(TypeError);
+      expect(call).toThrow(/expected a plain object.*got null/);
+    });
+
+    test('throws a descriptive Error when node is the number 0', () => {
+      const malformed = 0 as unknown as CRDTChangeNodeWire<string>;
+      const call = () => deserializeChangeNodeFromJSON(malformed, decodeBytes);
+      expect(call).toThrow(Error);
+      expect(call).not.toThrow(TypeError);
+      expect(call).toThrow(/expected a plain object.*got number/);
+    });
+
+    test('throws a descriptive Error when node is an empty string', () => {
+      const malformed = '' as unknown as CRDTChangeNodeWire<string>;
+      const call = () => deserializeChangeNodeFromJSON(malformed, decodeBytes);
+      expect(call).toThrow(Error);
+      expect(call).not.toThrow(TypeError);
+      expect(call).toThrow(/expected a plain object.*got string/);
+    });
+
+    test('throws a descriptive Error when node is an array', () => {
+      const malformed = [1, 2, 3] as unknown as CRDTChangeNodeWire<string>;
+      expect(() =>
+        deserializeChangeNodeFromJSON(malformed, decodeBytes),
+      ).toThrow(/expected a plain object.*got array/);
+    });
+
+    test('throws a descriptive Error when node is undefined', () => {
+      const malformed = undefined as unknown as CRDTChangeNodeWire<string>;
+      const call = () => deserializeChangeNodeFromJSON(malformed, decodeBytes);
+      expect(call).toThrow(Error);
+      expect(call).not.toThrow(TypeError);
+      expect(call).toThrow(/expected a plain object.*got undefined/);
+    });
+
     test('throws when "kind" is missing', () => {
       // Simulate a peer message that omits `kind` entirely. Cast through
       // unknown because the field is required by the type, but malformed

--- a/packages/collabswarm/src/merkle-dag-serialization.test.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.test.ts
@@ -317,6 +317,83 @@ describe('serializeChangeNodeForJSON / deserializeChangeNodeFromJSON', () => {
     ).toBeNull();
   });
 
+  describe('deserialize input validation (untrusted wire shapes)', () => {
+    test('throws when "kind" is missing', () => {
+      // Simulate a peer message that omits `kind` entirely. Cast through
+      // unknown because the field is required by the type, but malformed
+      // JSON has no such guarantee at runtime.
+      const malformed = { change: '01' } as unknown as CRDTChangeNodeWire<string>;
+      expect(() => deserializeChangeNodeFromJSON(malformed, decodeBytes)).toThrow(
+        /"kind" must be one of/,
+      );
+    });
+
+    test('throws when "kind" is an unknown string', () => {
+      const malformed: CRDTChangeNodeWire<string> = {
+        kind: 'evil' as unknown as 'document',
+        change: '01',
+      };
+      expect(() => deserializeChangeNodeFromJSON(malformed, decodeBytes)).toThrow(
+        /"kind" must be one of.*got "evil"/,
+      );
+    });
+
+    test('throws when "kind" is the wrong type (e.g. a number)', () => {
+      const malformed = {
+        kind: 7,
+        change: '01',
+      } as unknown as CRDTChangeNodeWire<string>;
+      expect(() => deserializeChangeNodeFromJSON(malformed, decodeBytes)).toThrow(
+        /"kind" must be one of/,
+      );
+    });
+
+    test('accepts all three documented kinds: document, writer, reader', () => {
+      for (const kind of ['document', 'writer', 'reader'] as const) {
+        const node: CRDTChangeNodeWire<string> = { kind, change: '01' };
+        const restored = deserializeChangeNodeFromJSON(node, decodeBytes);
+        expect(restored.kind).toBe(kind);
+      }
+    });
+
+    test('throws when a child node is null', () => {
+      const malformed = JSON.parse(
+        '{"kind":"document","change":"01","children":{"h1":null}}',
+      ) as CRDTChangeNodeWire<string>;
+      expect(() => deserializeChangeNodeFromJSON(malformed, decodeBytes)).toThrow(
+        /child at key "h1" must be a plain object.*got null/,
+      );
+    });
+
+    test('throws when a child node is an array', () => {
+      const malformed = JSON.parse(
+        '{"kind":"document","change":"01","children":{"h1":[1,2]}}',
+      ) as CRDTChangeNodeWire<string>;
+      expect(() => deserializeChangeNodeFromJSON(malformed, decodeBytes)).toThrow(
+        /child at key "h1" must be a plain object.*got array/,
+      );
+    });
+
+    test('throws when a child node is a primitive (string)', () => {
+      const malformed = JSON.parse(
+        '{"kind":"document","change":"01","children":{"h1":"not-an-object"}}',
+      ) as CRDTChangeNodeWire<string>;
+      expect(() => deserializeChangeNodeFromJSON(malformed, decodeBytes)).toThrow(
+        /child at key "h1" must be a plain object.*got string/,
+      );
+    });
+
+    test('throws when a nested child has an invalid "kind"', () => {
+      const malformed = JSON.parse(
+        '{"kind":"document","change":"01","children":' +
+          '{"h1":{"kind":"hacker","change":"02"}}}',
+      ) as CRDTChangeNodeWire<string>;
+      expect(() => deserializeChangeNodeFromJSON(malformed, decodeBytes)).toThrow(
+        /"kind" must be one of.*got "hacker"/,
+      );
+    });
+  });
+
   test('encoder is not invoked for nodes whose change is undefined', () => {
     const original: CRDTChangeNode<Uint8Array> = {
       kind: 'document',

--- a/packages/collabswarm/src/merkle-dag-serialization.test.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.test.ts
@@ -257,6 +257,66 @@ describe('serializeChangeNodeForJSON / deserializeChangeNodeFromJSON', () => {
     expectBytesEqual(restored.change as Uint8Array, new Uint8Array([9]));
   });
 
+  test('children maps use a null prototype to resist prototype pollution', () => {
+    // A peer could send `__proto__` / `constructor` as hash keys. The
+    // resulting `children` dictionaries must not alter `Object.prototype`
+    // and must expose those keys as plain own properties rather than as
+    // inherited members.
+    const polluted: CRDTChangeNodeWire<string> = {
+      kind: 'document',
+      change: '01',
+      children: JSON.parse(
+        '{"__proto__":{"kind":"writer","change":"02"},' +
+          '"constructor":{"kind":"reader","change":"03"}}',
+      ) as { [hash: string]: CRDTChangeNodeWire<string> },
+    };
+
+    const restored = deserializeChangeNodeFromJSON(polluted, decodeBytes);
+
+    // `Object.prototype` must remain pristine.
+    expect(
+      Object.prototype.hasOwnProperty.call(Object.prototype, 'polluted'),
+    ).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+
+    expect(restored.children).toBeDefined();
+    expect(restored.children).not.toBe(crdtChangeNodeDeferred);
+    const children = restored.children as Record<
+      string,
+      CRDTChangeNode<Uint8Array>
+    >;
+    // Null-prototype dictionary: no inherited members.
+    expect(Object.getPrototypeOf(children)).toBeNull();
+    // Special-cased keys round-trip as own properties.
+    expect(Object.keys(children).sort()).toEqual(['__proto__', 'constructor']);
+    expect(children['__proto__'].kind).toBe('writer');
+    expectBytesEqual(
+      children['__proto__'].change as Uint8Array,
+      new Uint8Array([0x02]),
+    );
+    expect(children['constructor'].kind).toBe('reader');
+    expectBytesEqual(
+      children['constructor'].change as Uint8Array,
+      new Uint8Array([0x03]),
+    );
+
+    // The serializer side likewise produces a null-prototype map.
+    const original: CRDTChangeNode<Uint8Array> = {
+      kind: 'document',
+      children: {
+        h1: { kind: 'writer', change: new Uint8Array([1]) },
+      },
+    };
+    const wire = serializeChangeNodeForJSON(original, encodeBytes);
+    expect(wire.children).toBeDefined();
+    expect(wire.children).not.toBe(crdtChangeNodeDeferred);
+    expect(
+      Object.getPrototypeOf(
+        wire.children as Record<string, CRDTChangeNodeWire<string>>,
+      ),
+    ).toBeNull();
+  });
+
   test('encoder is not invoked for nodes whose change is undefined', () => {
     const original: CRDTChangeNode<Uint8Array> = {
       kind: 'document',

--- a/packages/collabswarm/src/merkle-dag-serialization.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.ts
@@ -90,6 +90,18 @@ export function deserializeChangeNodeFromJSON<TIn, TOut>(
 ): CRDTChangeNode<TOut> {
   const change = node.change !== undefined ? decodeLeaf(node.change) : undefined;
   if (node.children !== undefined && node.children !== crdtChangeNodeDeferred) {
+    // Wire input is untrusted: validate the children shape before iterating,
+    // since `Object.entries(null)` / non-object inputs throw a `TypeError`
+    // that's hard to attribute back to a malformed peer message.
+    if (
+      typeof node.children !== 'object' ||
+      node.children === null ||
+      Array.isArray(node.children)
+    ) {
+      throw new Error(
+        'Invalid merkle-dag node: "children" must be an object keyed by hash',
+      );
+    }
     // Null-prototype dictionary: peer-supplied JSON keys like `__proto__`
     // or `constructor` cannot pollute `Object.prototype` or shadow
     // inherited members on the resulting children map.

--- a/packages/collabswarm/src/merkle-dag-serialization.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.ts
@@ -34,6 +34,27 @@ function isValidChangeNodeKind(value: unknown): value is CRDTChangeNodeKind {
 }
 
 /**
+ * Human-readable label for an unknown value's runtime type, used in wire
+ * validation error messages.
+ *
+ * `typeof` alone reports `'object'` for both `null` and arrays, which
+ * obscures common malformed-peer cases. This helper distinguishes those:
+ * - `null`           -> `'null'`
+ * - any array        -> `'array'`
+ * - anything else    -> raw `typeof` result (`'object'`, `'string'`,
+ *                      `'number'`, `'boolean'`, `'undefined'`, etc.)
+ *
+ * Use in validation error strings whenever a field's expected type is not
+ * already enforced to be a primitive, so error attribution back to the peer
+ * is unambiguous.
+ */
+export function describeValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+/**
  * Wire-shape mirror of `CRDTChangeNode<T>` used during JSON serialization.
  *
  * The `kind` / `keyID` / `children` shape is preserved exactly; only the
@@ -130,9 +151,9 @@ export function deserializeChangeNodeFromJSON<TIn, TOut>(
   // peer crashes the deserializer by supplying `changes: null`.
   if (typeof node !== 'object' || node === null || Array.isArray(node)) {
     throw new Error(
-      `Invalid merkle-dag node: expected a plain object (got ${
-        node === null ? 'null' : Array.isArray(node) ? 'array' : typeof node
-      })`,
+      `Invalid merkle-dag node: expected a plain object (got ${describeValue(
+        node,
+      )})`,
     );
   }
   // Wire input is untrusted: a malformed peer message can omit or supply a
@@ -154,9 +175,9 @@ export function deserializeChangeNodeFromJSON<TIn, TOut>(
   // violate the `CRDTChangeNode.keyID?: string` contract.
   if (node.keyID !== undefined && typeof node.keyID !== 'string') {
     throw new Error(
-      `Invalid merkle-dag node: "keyID" must be a string when present (got ${
-        node.keyID === null ? 'null' : typeof node.keyID
-      })`,
+      `Invalid merkle-dag node: "keyID" must be a string when present (got ${describeValue(
+        node.keyID,
+      )})`,
     );
   }
   const change = node.change !== undefined ? decodeLeaf(node.change) : undefined;
@@ -191,9 +212,7 @@ export function deserializeChangeNodeFromJSON<TIn, TOut>(
         throw new Error(
           `Invalid merkle-dag node: child at key ${JSON.stringify(
             hash,
-          )} must be a plain object (got ${
-            child === null ? 'null' : Array.isArray(child) ? 'array' : typeof child
-          })`,
+          )} must be a plain object (got ${describeValue(child)})`,
         );
       }
       children[hash] = deserializeChangeNodeFromJSON(

--- a/packages/collabswarm/src/merkle-dag-serialization.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.ts
@@ -9,14 +9,22 @@ import {
 } from './crdt-change-node';
 
 // Allow-list of `kind` discriminants accepted from peer wire messages.
-// Kept in sync with `CRDTChangeNodeKind` via the type assertion below so a
-// new kind added to the union will fail to compile here until the set is
-// updated.
-const VALID_CHANGE_NODE_KINDS: ReadonlySet<CRDTChangeNodeKind> = new Set([
-  crdtDocumentChangeNode,
-  crdtWriterChangeNode,
-  crdtReaderChangeNode,
-]);
+//
+// The allow-list is derived from an exhaustive `Record<CRDTChangeNodeKind,
+// true>` so that adding a new variant to the `CRDTChangeNodeKind` union will
+// be a compile-time error here until the corresponding entry is added: TS
+// requires every key of the union to be present in the record literal.
+// Using a `ReadonlySet` alone would not give that guarantee -- a strict
+// subset of the union is assignable to `ReadonlySet<CRDTChangeNodeKind>`
+// without error.
+const VALID_CHANGE_NODE_KIND_RECORD: Record<CRDTChangeNodeKind, true> = {
+  [crdtDocumentChangeNode]: true,
+  [crdtWriterChangeNode]: true,
+  [crdtReaderChangeNode]: true,
+};
+const VALID_CHANGE_NODE_KINDS: ReadonlySet<CRDTChangeNodeKind> = new Set(
+  Object.keys(VALID_CHANGE_NODE_KIND_RECORD) as CRDTChangeNodeKind[],
+);
 
 function isValidChangeNodeKind(value: unknown): value is CRDTChangeNodeKind {
   return (
@@ -96,11 +104,12 @@ export function serializeChangeNodeForJSON<TIn, TOut>(
  * Wire input is treated as untrusted: the reconstructed `children` map uses a
  * null prototype so peer-supplied hash keys (e.g. `__proto__`,
  * `constructor`) cannot pollute `Object.prototype` or shadow inherited
- * members. The shape of the node itself is also validated: `kind` must be a
- * known {@link CRDTChangeNodeKind} discriminant, and each entry in
- * `children` must be a plain object. A malformed peer message throws a
- * descriptive `Error` rather than silently passing the bad value through
- * via spread.
+ * members. The shape of the node itself is also validated up front: `node`
+ * must be a non-null, non-array object; `kind` must be a known
+ * {@link CRDTChangeNodeKind} discriminant; and each entry in `children`
+ * must be a plain object. A malformed peer message throws a descriptive
+ * `Error` rather than a bare `TypeError` from property access on `null` /
+ * non-object input, which would otherwise be a trivial DoS vector.
  *
  * @typeParam TIn  Wire leaf payload type (e.g. `string` or `string[]`).
  * @typeParam TOut Decoded leaf payload type (e.g. `Uint8Array` or
@@ -113,6 +122,19 @@ export function deserializeChangeNodeFromJSON<TIn, TOut>(
   node: CRDTChangeNodeWire<TIn>,
   decodeLeaf: (leaf: TIn) => TOut,
 ): CRDTChangeNode<TOut> {
+  // Wire input is untrusted: a malformed peer can send `null`, an array, or
+  // a primitive in place of a node object. Reading `node.kind` on those
+  // values would throw a bare `TypeError` (`Cannot read properties of null`)
+  // that is hard to attribute back to the peer; reject up front with a
+  // descriptive error instead. This also denies a trivial DoS path where a
+  // peer crashes the deserializer by supplying `changes: null`.
+  if (typeof node !== 'object' || node === null || Array.isArray(node)) {
+    throw new Error(
+      `Invalid merkle-dag node: expected a plain object (got ${
+        node === null ? 'null' : Array.isArray(node) ? 'array' : typeof node
+      })`,
+    );
+  }
   // Wire input is untrusted: a malformed peer message can omit or supply a
   // non-string `kind`. Reject up front so downstream consumers can rely on
   // the discriminant being one of the documented `CRDTChangeNodeKind`s

--- a/packages/collabswarm/src/merkle-dag-serialization.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.ts
@@ -43,7 +43,11 @@ export function serializeChangeNodeForJSON<TIn, TOut>(
 ): CRDTChangeNodeWire<TOut> {
   const change = node.change !== undefined ? encodeLeaf(node.change) : undefined;
   if (node.children !== undefined && node.children !== crdtChangeNodeDeferred) {
-    const children: { [hash: string]: CRDTChangeNodeWire<TOut> } = {};
+    // Use a null-prototype dictionary so that hash keys coming from peer
+    // wire messages (e.g. `__proto__`, `constructor`) cannot mutate the
+    // shared `Object.prototype` or otherwise alter lookup semantics.
+    const children: { [hash: string]: CRDTChangeNodeWire<TOut> } =
+      Object.create(null);
     for (const [hash, child] of Object.entries(node.children)) {
       children[hash] = serializeChangeNodeForJSON(child, encodeLeaf);
     }
@@ -68,6 +72,11 @@ export function serializeChangeNodeForJSON<TIn, TOut>(
  * Preserves `crdtChangeNodeDeferred` children verbatim, matching the
  * serializer.
  *
+ * Wire input is treated as untrusted: the reconstructed `children` map uses a
+ * null prototype so peer-supplied hash keys (e.g. `__proto__`,
+ * `constructor`) cannot pollute `Object.prototype` or shadow inherited
+ * members.
+ *
  * @typeParam TIn  Wire leaf payload type (e.g. `string` or `string[]`).
  * @typeParam TOut Decoded leaf payload type (e.g. `Uint8Array` or
  *                 `Uint8Array[]`).
@@ -81,7 +90,11 @@ export function deserializeChangeNodeFromJSON<TIn, TOut>(
 ): CRDTChangeNode<TOut> {
   const change = node.change !== undefined ? decodeLeaf(node.change) : undefined;
   if (node.children !== undefined && node.children !== crdtChangeNodeDeferred) {
-    const children: { [hash: string]: CRDTChangeNode<TOut> } = {};
+    // Null-prototype dictionary: peer-supplied JSON keys like `__proto__`
+    // or `constructor` cannot pollute `Object.prototype` or shadow
+    // inherited members on the resulting children map.
+    const children: { [hash: string]: CRDTChangeNode<TOut> } =
+      Object.create(null);
     for (const [hash, child] of Object.entries(node.children)) {
       children[hash] = deserializeChangeNodeFromJSON(child, decodeLeaf);
     }

--- a/packages/collabswarm/src/merkle-dag-serialization.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.ts
@@ -1,8 +1,29 @@
 import {
   CRDTChangeNode,
   CRDTChangeNodeDeferred,
+  CRDTChangeNodeKind,
   crdtChangeNodeDeferred,
+  crdtDocumentChangeNode,
+  crdtReaderChangeNode,
+  crdtWriterChangeNode,
 } from './crdt-change-node';
+
+// Allow-list of `kind` discriminants accepted from peer wire messages.
+// Kept in sync with `CRDTChangeNodeKind` via the type assertion below so a
+// new kind added to the union will fail to compile here until the set is
+// updated.
+const VALID_CHANGE_NODE_KINDS: ReadonlySet<CRDTChangeNodeKind> = new Set([
+  crdtDocumentChangeNode,
+  crdtWriterChangeNode,
+  crdtReaderChangeNode,
+]);
+
+function isValidChangeNodeKind(value: unknown): value is CRDTChangeNodeKind {
+  return (
+    typeof value === 'string' &&
+    VALID_CHANGE_NODE_KINDS.has(value as CRDTChangeNodeKind)
+  );
+}
 
 /**
  * Wire-shape mirror of `CRDTChangeNode<T>` used during JSON serialization.
@@ -75,7 +96,11 @@ export function serializeChangeNodeForJSON<TIn, TOut>(
  * Wire input is treated as untrusted: the reconstructed `children` map uses a
  * null prototype so peer-supplied hash keys (e.g. `__proto__`,
  * `constructor`) cannot pollute `Object.prototype` or shadow inherited
- * members.
+ * members. The shape of the node itself is also validated: `kind` must be a
+ * known {@link CRDTChangeNodeKind} discriminant, and each entry in
+ * `children` must be a plain object. A malformed peer message throws a
+ * descriptive `Error` rather than silently passing the bad value through
+ * via spread.
  *
  * @typeParam TIn  Wire leaf payload type (e.g. `string` or `string[]`).
  * @typeParam TOut Decoded leaf payload type (e.g. `Uint8Array` or
@@ -88,6 +113,19 @@ export function deserializeChangeNodeFromJSON<TIn, TOut>(
   node: CRDTChangeNodeWire<TIn>,
   decodeLeaf: (leaf: TIn) => TOut,
 ): CRDTChangeNode<TOut> {
+  // Wire input is untrusted: a malformed peer message can omit or supply a
+  // non-string `kind`. Reject up front so downstream consumers can rely on
+  // the discriminant being one of the documented `CRDTChangeNodeKind`s
+  // rather than silently propagating an invalid value via `...node`.
+  if (!isValidChangeNodeKind(node.kind)) {
+    throw new Error(
+      `Invalid merkle-dag node: "kind" must be one of ${Array.from(
+        VALID_CHANGE_NODE_KINDS,
+      )
+        .map((k) => JSON.stringify(k))
+        .join(', ')} (got ${JSON.stringify(node.kind)})`,
+    );
+  }
   const change = node.change !== undefined ? decodeLeaf(node.change) : undefined;
   if (node.children !== undefined && node.children !== crdtChangeNodeDeferred) {
     // Wire input is untrusted: validate the children shape before iterating,
@@ -108,7 +146,27 @@ export function deserializeChangeNodeFromJSON<TIn, TOut>(
     const children: { [hash: string]: CRDTChangeNode<TOut> } =
       Object.create(null);
     for (const [hash, child] of Object.entries(node.children)) {
-      children[hash] = deserializeChangeNodeFromJSON(child, decodeLeaf);
+      // Each child must itself be a plain object (not null, not an array,
+      // not a primitive) before we recurse -- otherwise the recursive call
+      // would fail deep in the stack with a less helpful error and might
+      // partially construct a children map.
+      if (
+        typeof child !== 'object' ||
+        child === null ||
+        Array.isArray(child)
+      ) {
+        throw new Error(
+          `Invalid merkle-dag node: child at key ${JSON.stringify(
+            hash,
+          )} must be a plain object (got ${
+            child === null ? 'null' : Array.isArray(child) ? 'array' : typeof child
+          })`,
+        );
+      }
+      children[hash] = deserializeChangeNodeFromJSON(
+        child as CRDTChangeNodeWire<TIn>,
+        decodeLeaf,
+      );
     }
     return {
       ...node,

--- a/packages/collabswarm/src/merkle-dag-serialization.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.ts
@@ -1,0 +1,99 @@
+import {
+  CRDTChangeNode,
+  CRDTChangeNodeDeferred,
+  crdtChangeNodeDeferred,
+} from './crdt-change-node';
+
+/**
+ * Wire-shape mirror of `CRDTChangeNode<T>` used during JSON serialization.
+ *
+ * The `kind` / `keyID` / `children` shape is preserved exactly; only the
+ * `change` payload at each leaf is rewritten to a JSON-friendly type by the
+ * caller-provided encoder.
+ */
+export type CRDTChangeNodeWire<TOut> = {
+  kind: CRDTChangeNode<unknown>['kind'];
+  keyID?: string;
+  change?: TOut;
+  children?: { [hash: string]: CRDTChangeNodeWire<TOut> } | CRDTChangeNodeDeferred;
+};
+
+/**
+ * Recursively serialize a `CRDTChangeNode` tree by transforming each node's
+ * `change` payload via the provided encoder, preserving the `kind`, `keyID`,
+ * and `children` structure for round-tripping through JSON.
+ *
+ * A `children` value equal to `crdtChangeNodeDeferred` (i.e. `false`) is
+ * preserved verbatim so deferred subtrees survive the round-trip.
+ *
+ * The output is intentionally byte-identical (modulo the leaf encoding) to
+ * the input shape so peers running this code interoperate with peers using
+ * the prior per-provider helpers.
+ *
+ * @typeParam TIn  Input leaf payload type (e.g. `Uint8Array` or
+ *                 `Uint8Array[]`).
+ * @typeParam TOut Output leaf payload type (e.g. `string` or `string[]`).
+ * @param node      The change node tree to serialize.
+ * @param encodeLeaf Function that maps an input leaf payload to its
+ *                  JSON-serializable representation.
+ */
+export function serializeChangeNodeForJSON<TIn, TOut>(
+  node: CRDTChangeNode<TIn>,
+  encodeLeaf: (leaf: TIn) => TOut,
+): CRDTChangeNodeWire<TOut> {
+  const change = node.change !== undefined ? encodeLeaf(node.change) : undefined;
+  if (node.children !== undefined && node.children !== crdtChangeNodeDeferred) {
+    const children: { [hash: string]: CRDTChangeNodeWire<TOut> } = {};
+    for (const [hash, child] of Object.entries(node.children)) {
+      children[hash] = serializeChangeNodeForJSON(child, encodeLeaf);
+    }
+    return {
+      ...node,
+      change,
+      children,
+    };
+  }
+  return {
+    ...node,
+    change,
+    children: node.children,
+  };
+}
+
+/**
+ * Inverse of {@link serializeChangeNodeForJSON}: recursively reconstruct a
+ * `CRDTChangeNode` tree from its JSON-friendly wire form, decoding each
+ * node's `change` payload via the provided decoder.
+ *
+ * Preserves `crdtChangeNodeDeferred` children verbatim, matching the
+ * serializer.
+ *
+ * @typeParam TIn  Wire leaf payload type (e.g. `string` or `string[]`).
+ * @typeParam TOut Decoded leaf payload type (e.g. `Uint8Array` or
+ *                 `Uint8Array[]`).
+ * @param node       The wire-form change node tree to deserialize.
+ * @param decodeLeaf Function that maps a wire leaf payload back to its
+ *                   in-memory representation.
+ */
+export function deserializeChangeNodeFromJSON<TIn, TOut>(
+  node: CRDTChangeNodeWire<TIn>,
+  decodeLeaf: (leaf: TIn) => TOut,
+): CRDTChangeNode<TOut> {
+  const change = node.change !== undefined ? decodeLeaf(node.change) : undefined;
+  if (node.children !== undefined && node.children !== crdtChangeNodeDeferred) {
+    const children: { [hash: string]: CRDTChangeNode<TOut> } = {};
+    for (const [hash, child] of Object.entries(node.children)) {
+      children[hash] = deserializeChangeNodeFromJSON(child, decodeLeaf);
+    }
+    return {
+      ...node,
+      change,
+      children,
+    };
+  }
+  return {
+    ...node,
+    change,
+    children: node.children,
+  };
+}

--- a/packages/collabswarm/src/merkle-dag-serialization.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.ts
@@ -148,6 +148,17 @@ export function deserializeChangeNodeFromJSON<TIn, TOut>(
         .join(', ')} (got ${JSON.stringify(node.kind)})`,
     );
   }
+  // Wire input is untrusted: a peer can send `keyID: 123` / object / null
+  // in place of the documented `keyID?: string`. Reject any non-string value
+  // (when present) so we don't silently propagate it via `...node` and
+  // violate the `CRDTChangeNode.keyID?: string` contract.
+  if (node.keyID !== undefined && typeof node.keyID !== 'string') {
+    throw new Error(
+      `Invalid merkle-dag node: "keyID" must be a string when present (got ${
+        node.keyID === null ? 'null' : typeof node.keyID
+      })`,
+    );
+  }
   const change = node.change !== undefined ? decodeLeaf(node.change) : undefined;
   if (node.children !== undefined && node.children !== crdtChangeNodeDeferred) {
     // Wire input is untrusted: validate the children shape before iterating,
@@ -190,15 +201,32 @@ export function deserializeChangeNodeFromJSON<TIn, TOut>(
         decodeLeaf,
       );
     }
-    return {
-      ...node,
-      change,
-      children,
-    };
+    // Construct the output node explicitly rather than spreading `...node`.
+    // The wire input is untrusted, so spreading would silently propagate any
+    // extra peer-supplied properties into our typed `CRDTChangeNode<TOut>`,
+    // including under field names we may add in the future. Listing each
+    // field by name keeps the in-memory shape tight to the documented type.
+    const result: CRDTChangeNode<TOut> = { kind: node.kind, children };
+    if (node.keyID !== undefined) {
+      result.keyID = node.keyID;
+    }
+    if (change !== undefined) {
+      result.change = change;
+    }
+    return result;
   }
-  return {
-    ...node,
-    change,
-    children: node.children,
-  };
+  // Same explicit-construction rationale as above; here `children` is either
+  // `undefined` or the `crdtChangeNodeDeferred` sentinel, both of which are
+  // preserved verbatim.
+  const result: CRDTChangeNode<TOut> = { kind: node.kind };
+  if (node.keyID !== undefined) {
+    result.keyID = node.keyID;
+  }
+  if (change !== undefined) {
+    result.change = change;
+  }
+  if (node.children !== undefined) {
+    result.children = node.children;
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary
- The yjs and automerge providers each carried near-identical recursive helpers for shuttling `CRDTChangeNode` trees through JSON sync messages -- one for `Uint8Array` leaves, one for `Uint8Array[]` leaves. Only the leaf encoder differed; the `kind` / `keyID` / `children` traversal was duplicated.
- This PR introduces a single generic pair, `serializeChangeNodeForJSON` / `deserializeChangeNodeFromJSON`, plus a shared `CRDTChangeNodeWire<T>` type, in the core `@collabswarm/collabswarm` package. The helpers take caller-supplied encode/decode callbacks for the leaf payload.
- Both providers now delegate to the shared helpers. Base64 stays in the provider call site since that is where it is actually applied.

## Why
- Single source of truth for the wire-shape traversal -- future fixes (e.g. iteration order, deferred-subtree handling, deeper validation) land in one file instead of two.
- Net reduction of ~76 lines in the provider files; the new helper plus tests adds back well-covered code in the core package.
- Easier for future CRDT backends to plug in -- they only need to supply a leaf encoder/decoder.

## Wire format
Byte-identical to before. Existing peers running the old code interoperate with peers running the new code -- the traversal and leaf encoding are unchanged, only the call site moved.

## Files changed
- `packages/collabswarm/src/merkle-dag-serialization.ts` (new): generic `serializeChangeNodeForJSON` / `deserializeChangeNodeFromJSON` + `CRDTChangeNodeWire` type.
- `packages/collabswarm/src/merkle-dag-serialization.test.ts` (new): round-trip tests for `Uint8Array` and `Uint8Array[]` leaves, empty trees, multi-level trees, the `crdtChangeNodeDeferred` sentinel, and undefined-change nodes.
- `packages/collabswarm/src/index.ts`: re-export the new helpers and wire type.
- `packages/collabswarm-yjs/src/collabswarm-yjs.ts`: drop local `serializeUint8ArrayInMerkleDAG` / `deserializeUint8ArrayInMerkleDAG`; call shared helpers passing `Base64.fromUint8Array` / `Base64.toUint8Array`.
- `packages/collabswarm-automerge/src/collabswarm-automerge.ts`: drop local `serializeBinaryChangesInMerkleDAG` / `deserializeBinaryChangesInMerkleDAG`; call shared helpers passing the existing `serializeBinaryChanges` / `deserializeBinaryChanges` array codecs.

## Test plan
- [x] `yarn workspace @collabswarm/collabswarm tsc` -- clean.
- [x] `yarn workspace @collabswarm/collabswarm test` -- 317/317 passing, including the 7 new round-trip tests.
- [x] `yarn workspace @collabswarm/collabswarm-yjs tsc` -- clean.
- [x] `yarn workspace @collabswarm/collabswarm-yjs test` -- 39/39 passing.
- [x] `yarn workspace @collabswarm/collabswarm-automerge tsc` -- clean.
- [x] `yarn workspace @collabswarm/collabswarm-automerge test` -- 24/24 passing.
- [x] `grep` confirms zero remaining references to the deleted per-provider helpers across `packages/`, `examples/`, `e2e/`, `relay-server/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of sync messages to reject malformed payloads and enforce strict field type checking, improving data integrity and error reporting.
  * Hardened deserialization logic to strip untrusted keys and prevent prototype pollution attacks.
  * Added comprehensive input validation for JSON payloads, rejecting non-object structures with clearer error messages.

* **New Features**
  * Improved change node serialization/deserialization with dedicated JSON wire format utilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/swarmbase/swarmbase/pull/263)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->