### PR TITLE
Move yjs and @automerge/automerge to peerDependencies in their provider packages

### DIFF
--- a/examples/browser-test/package.json
+++ b/examples/browser-test/package.json
@@ -2,6 +2,7 @@
   "name": "@collabswarm/browser-test",
   "private": true,
   "dependencies": {
+    "@automerge/automerge": "^3.2.4",
     "@collabswarm/collabswarm": "workspace:packages/collabswarm",
     "@collabswarm/collabswarm-automerge": "workspace:packages/collabswarm-automerge",
     "@collabswarm/collabswarm-redux": "workspace:packages/collabswarm-redux",

--- a/examples/password-manager/package.json
+++ b/examples/password-manager/package.json
@@ -25,7 +25,8 @@
     "react-scripts": "^5.0.1",
     "typescript": "^5.9.3",
     "uuid": "^10.0.0",
-    "web-vitals": "^4.2.3"
+    "web-vitals": "^4.2.3",
+    "yjs": "^13.6.30"
   },
   "type": "module",
   "devDependencies": {

--- a/examples/wiki-swarm/package.json
+++ b/examples/wiki-swarm/package.json
@@ -2,6 +2,7 @@
   "name": "@collabswarm/wiki-swarm",
   "private": true,
   "dependencies": {
+    "@automerge/automerge": "^3.2.4",
     "@collabswarm/collabswarm": "workspace:packages/collabswarm",
     "@collabswarm/collabswarm-automerge": "workspace:packages/collabswarm-automerge",
     "@collabswarm/collabswarm-redux": "workspace:packages/collabswarm-redux",

--- a/packages/collabswarm-automerge/package.json
+++ b/packages/collabswarm-automerge/package.json
@@ -25,6 +25,7 @@
   "author": "allegrormc@gmail.com",
   "license": "ISC",
   "devDependencies": {
+    "@automerge/automerge": "^3.2.4",
     "@peculiar/webcrypto": "^1.4.6",
     "@types/node": "^22.7.5",
     "@types/uuid": "^10",
@@ -35,9 +36,11 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@automerge/automerge": "^3.2.4",
     "@collabswarm/collabswarm": "workspace:packages/collabswarm",
     "uuid": "^10.0.0"
+  },
+  "peerDependencies": {
+    "@automerge/automerge": "^3.0.0"
   },
   "gitHead": "5d48e475ac53ef5920423d3a22a4e19201e607a1",
   "publishConfig": {

--- a/packages/collabswarm-automerge/package.json
+++ b/packages/collabswarm-automerge/package.json
@@ -40,7 +40,7 @@
     "uuid": "^10.0.0"
   },
   "peerDependencies": {
-    "@automerge/automerge": "^3.0.0"
+    "@automerge/automerge": "^3.2.4"
   },
   "gitHead": "5d48e475ac53ef5920423d3a22a4e19201e607a1",
   "publishConfig": {

--- a/packages/collabswarm-yjs/package.json
+++ b/packages/collabswarm-yjs/package.json
@@ -31,11 +31,14 @@
     "jest": "^29.2.5",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.1.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "yjs": "^13.6.30"
   },
   "dependencies": {
-    "@collabswarm/collabswarm": "workspace:packages/collabswarm",
-    "yjs": "^13.6.30"
+    "@collabswarm/collabswarm": "workspace:packages/collabswarm"
+  },
+  "peerDependencies": {
+    "yjs": "^13.0.0"
   },
   "gitHead": "5d48e475ac53ef5920423d3a22a4e19201e607a1",
   "publishConfig": {

--- a/packages/collabswarm-yjs/package.json
+++ b/packages/collabswarm-yjs/package.json
@@ -38,7 +38,7 @@
     "@collabswarm/collabswarm": "workspace:packages/collabswarm"
   },
   "peerDependencies": {
-    "yjs": "^13.0.0"
+    "yjs": "^13.6.30"
   },
   "gitHead": "5d48e475ac53ef5920423d3a22a4e19201e607a1",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,7 +1913,7 @@ __metadata:
     typescript: "npm:^5.9.3"
     uuid: "npm:^10.0.0"
   peerDependencies:
-    "@automerge/automerge": ^3.0.0
+    "@automerge/automerge": ^3.2.4
   bin:
     collabswarm-automerge-d: dist/bin/collabswarm-automerge-d.js
   languageName: unknown
@@ -1993,7 +1993,7 @@ __metadata:
     typescript: "npm:^5.9.3"
     yjs: "npm:^13.6.30"
   peerDependencies:
-    yjs: ^13.0.0
+    yjs: ^13.6.30
   bin:
     collabswarm-yjs-d: dist/bin/collabswarm-yjs-d.js
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,6 +1869,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@collabswarm/browser-test@workspace:examples/browser-test"
   dependencies:
+    "@automerge/automerge": "npm:^3.2.4"
     "@collabswarm/collabswarm": "workspace:packages/collabswarm"
     "@collabswarm/collabswarm-automerge": "workspace:packages/collabswarm-automerge"
     "@collabswarm/collabswarm-redux": "workspace:packages/collabswarm-redux"
@@ -1911,6 +1912,8 @@ __metadata:
     ts-node: "npm:^10.1.0"
     typescript: "npm:^5.9.3"
     uuid: "npm:^10.0.0"
+  peerDependencies:
+    "@automerge/automerge": ^3.0.0
   bin:
     collabswarm-automerge-d: dist/bin/collabswarm-automerge-d.js
   languageName: unknown
@@ -1989,6 +1992,8 @@ __metadata:
     ts-node: "npm:^10.1.0"
     typescript: "npm:^5.9.3"
     yjs: "npm:^13.6.30"
+  peerDependencies:
+    yjs: ^13.0.0
   bin:
     collabswarm-yjs-d: dist/bin/collabswarm-yjs-d.js
   languageName: unknown
@@ -2072,6 +2077,7 @@ __metadata:
     typescript: "npm:^5.9.3"
     uuid: "npm:^10.0.0"
     web-vitals: "npm:^4.2.3"
+    yjs: "npm:^13.6.30"
   languageName: unknown
   linkType: soft
 
@@ -2079,6 +2085,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@collabswarm/wiki-swarm@workspace:examples/wiki-swarm"
   dependencies:
+    "@automerge/automerge": "npm:^3.2.4"
     "@collabswarm/collabswarm": "workspace:packages/collabswarm"
     "@collabswarm/collabswarm-automerge": "workspace:packages/collabswarm-automerge"
     "@collabswarm/collabswarm-redux": "workspace:packages/collabswarm-redux"


### PR DESCRIPTION
## Summary

- `@collabswarm/collabswarm-automerge` was declaring `@automerge/automerge` as a direct `dependency`, and `@collabswarm/collabswarm-yjs` was declaring `yjs` as a direct `dependency`. This caused a dual-instance hazard: if a downstream consumer installs a different version of the CRDT lib, the package manager may resolve two separate copies. Two distinct module instances mean different class identities — `instanceof` checks fail and document interop silently breaks.
- The correct pattern is `peerDependencies` (consumer chooses and owns the version) + `devDependencies` (so in-repo tests can still run). This matches the existing pattern used by `collabswarm-redux` for `redux`/`redux-thunk`.

## Consumer packages updated to pin CRDT lib directly

These packages were relying on the transitive dependency through the provider package and now explicitly declare the CRDT lib in their own `dependencies`:

- `examples/wiki-swarm` — added `@automerge/automerge: ^3.2.4`
- `examples/browser-test` — added `@automerge/automerge: ^3.2.4`
- `examples/password-manager` — added `yjs: ^13.6.30`

## Downstream API change

This is a downstream-visible change: consumers of `@collabswarm/collabswarm-automerge` or `@collabswarm/collabswarm-yjs` **must now install `@automerge/automerge` or `yjs` explicitly** in their own project. The CRDT lib will no longer arrive transitively.

## Verification

- `yarn workspace @collabswarm/collabswarm-automerge tsc` — passes (24 tests pass)
- `yarn workspace @collabswarm/collabswarm-automerge test` — 24/24 tests pass
- `yarn workspace @collabswarm/collabswarm-yjs tsc` — passes
- `yarn workspace @collabswarm/collabswarm-yjs test` — 39/39 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated dependency configurations across example applications and core packages
* Reorganized @automerge/automerge and yjs as peer dependencies to improve version compatibility
* Added @automerge/automerge support to additional example projects
* Extended yjs support to password-manager example
* Standardized library dependency versions across the project

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/swarmbase/swarmbase/pull/264)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->