### PR TITLE
Add WS-4 phase 1: ACL chain-of-trust verification (#186)

### DIFF
--- a/packages/collabswarm/src/acl-chain.test.ts
+++ b/packages/collabswarm/src/acl-chain.test.ts
@@ -1,0 +1,761 @@
+import { describe, expect, test, beforeAll, jest } from '@jest/globals';
+
+import {
+  ACLChain,
+  ACLChainOps,
+  ACLEntry,
+  ACLState,
+  canonicalEntryPayload,
+  computeEntryHash,
+} from './acl-chain';
+import { SubtleCrypto } from './auth-subtlecrypto';
+
+// ---------------------------------------------------------------------------
+// Fixtures and helpers
+// ---------------------------------------------------------------------------
+
+const auth = new SubtleCrypto();
+
+/**
+ * Generate an ECDSA P-384 keypair using the same algorithm as the SubtleCrypto
+ * auth provider's default. Each test gets fresh keys so identities don't
+ * leak across tests.
+ */
+async function genKeyPair(): Promise<{
+  publicKey: CryptoKey;
+  privateKey: CryptoKey;
+}> {
+  const pair = await crypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-384' },
+    true,
+    ['sign', 'verify'],
+  );
+  return { publicKey: pair.publicKey, privateKey: pair.privateKey };
+}
+
+/**
+ * Canonical raw encoding of an ECDSA public key. Stable across imports.
+ */
+async function serializePublicKey(key: CryptoKey): Promise<Uint8Array> {
+  return new Uint8Array(await crypto.subtle.exportKey('raw', key));
+}
+
+// ---------------------------------------------------------------------------
+// In-memory ACL adapter
+//
+// The chain is generic over the change format; for tests we use a tiny
+// JSON-encoded "add" / "remove" change vocabulary. Each change carries a
+// list of public-key hashes to grant or revoke writer status.
+// ---------------------------------------------------------------------------
+
+interface AclChange {
+  op: 'add' | 'remove';
+  /** Hex-encoded raw public keys. */
+  keys: string[];
+}
+
+function serializeChange(c: AclChange): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(c));
+}
+
+function toHex(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    s += bytes[i].toString(16).padStart(2, '0');
+  }
+  return s;
+}
+
+class TestAclState implements ACLState<AclChange, CryptoKey> {
+  // Brand from the interface; we satisfy it structurally without storing it.
+  readonly _aclStateBrand?: never;
+  /** Hex-encoded raw public keys of current writers. */
+  readonly writers: Set<string>;
+  constructor(writers: ReadonlySet<string> = new Set()) {
+    this.writers = new Set(writers);
+  }
+  clone(): TestAclState {
+    return new TestAclState(this.writers);
+  }
+}
+
+const testOps: ACLChainOps<AclChange, CryptoKey> = {
+  emptyState(): TestAclState {
+    return new TestAclState();
+  },
+  async applyChange(state, change): Promise<TestAclState> {
+    const s = (state as TestAclState).clone();
+    if (change.op === 'add') {
+      for (const k of change.keys) s.writers.add(k);
+    } else {
+      for (const k of change.keys) s.writers.delete(k);
+    }
+    return s;
+  },
+  async isWriter(state, publicKey): Promise<boolean> {
+    const bytes = await serializePublicKey(publicKey);
+    return (state as TestAclState).writers.has(toHex(bytes));
+  },
+};
+
+interface TestIdentity {
+  publicKey: CryptoKey;
+  privateKey: CryptoKey;
+  hashHex: string;
+}
+
+async function makeIdentity(): Promise<TestIdentity> {
+  const { publicKey, privateKey } = await genKeyPair();
+  const hashHex = toHex(await serializePublicKey(publicKey));
+  return { publicKey, privateKey, hashHex };
+}
+
+function makeChain(
+  genesisAuthorizedKeys: CryptoKey[],
+): ACLChain<AclChange, CryptoKey, CryptoKey> {
+  return new ACLChain<AclChange, CryptoKey, CryptoKey>(
+    {
+      auth,
+      serializeKey: serializePublicKey,
+      ops: testOps,
+      genesisAuthorizedKeys,
+    },
+    serializeChange,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Some operations are intentionally slow (P-384 keygen, signature verify).
+// Generous timeout keeps CI green on slower machines.
+jest.setTimeout(30_000);
+
+let alice: TestIdentity;
+let bob: TestIdentity;
+let carol: TestIdentity;
+let eve: TestIdentity;
+
+beforeAll(async () => {
+  alice = await makeIdentity();
+  bob = await makeIdentity();
+  carol = await makeIdentity();
+  eve = await makeIdentity();
+});
+
+describe('canonical encoding', () => {
+  test('changes in any field change the hash', async () => {
+    const base: Omit<ACLEntry<AclChange>, 'signature'> = {
+      sequenceNumber: 0,
+      timestamp: 1000,
+      parentHash: undefined,
+      change: { op: 'add', keys: [bob.hashHex] },
+      signerKeyHash: new Uint8Array([1, 2, 3]),
+    };
+
+    const h0 = toHex(await computeEntryHash(base, serializeChange));
+
+    // Bump sequenceNumber
+    const h1 = toHex(
+      await computeEntryHash({ ...base, sequenceNumber: 1 }, serializeChange),
+    );
+    expect(h1).not.toBe(h0);
+
+    // Bump timestamp
+    const h2 = toHex(
+      await computeEntryHash({ ...base, timestamp: 1001 }, serializeChange),
+    );
+    expect(h2).not.toBe(h0);
+
+    // Different change content
+    const h3 = toHex(
+      await computeEntryHash(
+        { ...base, change: { op: 'add', keys: [carol.hashHex] } },
+        serializeChange,
+      ),
+    );
+    expect(h3).not.toBe(h0);
+
+    // Different signer
+    const h4 = toHex(
+      await computeEntryHash(
+        { ...base, signerKeyHash: new Uint8Array([9, 9, 9]) },
+        serializeChange,
+      ),
+    );
+    expect(h4).not.toBe(h0);
+  });
+
+  test('length-prefixed encoding prevents boundary ambiguity', async () => {
+    // Two entries that, without length prefixing, would have the same
+    // concatenated representation:
+    //   signerKeyHash=[1,2], change=bytes("3")
+    //   signerKeyHash=[1,2,3], change=bytes("")
+    // Both produce bytes [1,2,3] if you forget the length prefixes.
+    const a: Omit<ACLEntry<AclChange>, 'signature'> = {
+      sequenceNumber: 0,
+      timestamp: 0,
+      change: { op: 'add', keys: [] }, // serializes to '{"op":"add","keys":[]}'
+      signerKeyHash: new Uint8Array([1, 2]),
+    };
+    const b: Omit<ACLEntry<AclChange>, 'signature'> = {
+      sequenceNumber: 0,
+      timestamp: 0,
+      change: { op: 'add', keys: [] },
+      signerKeyHash: new Uint8Array([1, 2, 3]),
+    };
+    const ha = canonicalEntryPayload(a, serializeChange);
+    const hb = canonicalEntryPayload(b, serializeChange);
+    expect(toHex(ha)).not.toBe(toHex(hb));
+  });
+});
+
+describe('legitimate chain', () => {
+  test('genesis member can author the first entry and bootstrap themselves', async () => {
+    const chain = makeChain([alice.publicKey]);
+
+    const entry = await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    expect(chain.length).toBe(1);
+    expect(entry.sequenceNumber).toBe(0);
+    expect(entry.parentHash).toBeUndefined();
+    expect(chain.headHash).toBeDefined();
+    expect(await testOps.isWriter(chain.state!, alice.publicKey)).toBe(true);
+  });
+
+  test('writer can add a second writer, who can then author', async () => {
+    const chain = makeChain([alice.publicKey]);
+
+    // Alice (genesis) adds herself.
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    // Alice adds Bob.
+    await chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    // Bob (now a writer) adds Carol.
+    await chain.authorAndAppend(
+      { op: 'add', keys: [carol.hashHex] },
+      bob.publicKey,
+      bob.privateKey,
+    );
+
+    expect(chain.length).toBe(3);
+    expect(await testOps.isWriter(chain.state!, alice.publicKey)).toBe(true);
+    expect(await testOps.isWriter(chain.state!, bob.publicKey)).toBe(true);
+    expect(await testOps.isWriter(chain.state!, carol.publicKey)).toBe(true);
+  });
+
+  test('chain heads link properly via parentHash', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const e0 = await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    const e1 = await chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    expect(e0.parentHash).toBeUndefined();
+    const e0Hash = await computeEntryHash(e0, serializeChange);
+    expect(e1.parentHash).toBeDefined();
+    expect(toHex(e1.parentHash!)).toBe(toHex(e0Hash));
+  });
+});
+
+describe('rejection: unauthorized signer', () => {
+  test('non-genesis key cannot author the genesis entry', async () => {
+    const chain = makeChain([alice.publicKey]);
+
+    // Eve tries to start a chain even though she's not in the genesis set.
+    // authorAndAppend throws because the entry would be rejected.
+    await expect(
+      chain.authorAndAppend(
+        { op: 'add', keys: [eve.hashHex] },
+        eve.publicKey,
+        eve.privateKey,
+      ),
+    ).rejects.toThrow(/unauthorized-signer/);
+
+    expect(chain.length).toBe(0);
+  });
+
+  test('non-writer cannot author a non-genesis entry', async () => {
+    const chain = makeChain([alice.publicKey]);
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    await expect(
+      chain.authorAndAppend(
+        { op: 'add', keys: [eve.hashHex] },
+        eve.publicKey,
+        eve.privateKey,
+      ),
+    ).rejects.toThrow(/unauthorized-signer/);
+  });
+
+  test('removed writer cannot replay a pre-removal style change', async () => {
+    // Threat model:
+    //   - Bob is a legitimate writer for a while.
+    //   - Alice removes Bob.
+    //   - Bob, having held his private key the whole time, signs a *new*
+    //     entry as if he were still a writer, with a parentHash that
+    //     correctly points at the current head (he can read the chain).
+    //   - The chain MUST reject this: Bob is no longer a writer.
+    const chain = makeChain([alice.publicKey]);
+
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    await chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    // Bob legitimately authors something while he's still a writer.
+    await chain.authorAndAppend(
+      { op: 'add', keys: [carol.hashHex] },
+      bob.publicKey,
+      bob.privateKey,
+    );
+    // Alice removes Bob.
+    await chain.authorAndAppend(
+      { op: 'remove', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    expect(await testOps.isWriter(chain.state!, bob.publicKey)).toBe(false);
+
+    // Bob crafts a fresh entry now that points at the current head.
+    const head = chain.headHash;
+    const seq = chain.length;
+    const payload = {
+      sequenceNumber: seq,
+      timestamp: Date.now(),
+      parentHash: head,
+      change: { op: 'add' as const, keys: [eve.hashHex] },
+      signerKeyHash: await serializePublicKey(bob.publicKey),
+    };
+    const encoded = canonicalEntryPayload(payload, serializeChange);
+    const signature = await auth.sign(encoded, bob.privateKey);
+    const evilEntry: ACLEntry<AclChange> = { ...payload, signature };
+
+    const result = await chain.ingestEntry(evilEntry, bob.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('unauthorized-signer');
+    }
+    expect(chain.length).toBe(4); // unchanged
+  });
+
+  test('replay of a removed writer\'s *historical* entry against a fresh chain fails', async () => {
+    // Different threat: a former writer captured an entry they previously
+    // authored (signature was valid at the time) and tries to feed it back
+    // into a new node that is bootstrapping from a snapshot in which they
+    // are no longer a writer. The chain must reject based on the current
+    // state, not the historical state.
+    const chain = makeChain([alice.publicKey]);
+
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    await chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    const bobsLegitEntry = await chain.authorAndAppend(
+      { op: 'add', keys: [carol.hashHex] },
+      bob.publicKey,
+      bob.privateKey,
+    );
+    await chain.authorAndAppend(
+      { op: 'remove', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    // Now simulate a new node receiving the FIRST TWO entries (genesis +
+    // bob added) and then immediately being fed bob's "legit" entry as if
+    // out-of-order. The new node accepts genesis + add(bob) (because
+    // sequence still lines up), then bob's entry should still be accepted
+    // *if its sequenceNumber matches*. So this case is actually a legit
+    // replay -- we test it elsewhere. Here we test the more interesting
+    // case: feeding the entry with the WRONG sequence number gets rejected
+    // for sequence-out-of-order, even though Bob *was* a valid writer.
+    const fresh = makeChain([alice.publicKey]);
+    await fresh.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    // Skip the "add Bob" entry to simulate trying to inject Bob's entry
+    // out of order.
+    const result = await fresh.ingestEntry(bobsLegitEntry, bob.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Either parent-hash-mismatch or sequence-out-of-order is acceptable
+      // -- both are valid rejections. Just make sure it didn't slip through.
+      expect(['parent-hash-mismatch', 'sequence-out-of-order']).toContain(
+        result.reason,
+      );
+    }
+  });
+});
+
+describe('rejection: tampering and replay', () => {
+  test('flipping a single byte in the change invalidates the signature', async () => {
+    // Build a chain, snapshot its entries, then construct a fresh chain
+    // by replaying the *first* entry verbatim (so the head hashes match)
+    // and try to ingest a tampered version of the *second* entry.
+    const chain = makeChain([alice.publicKey]);
+    const e0 = await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    const e1 = await chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    // Replay e0 verbatim into a fresh chain so the heads line up.
+    const fresh = makeChain([alice.publicKey]);
+    const r0 = await fresh.ingestEntry(e0, alice.publicKey);
+    expect(r0.ok).toBe(true);
+
+    // Tamper: switch the add target from bob to eve while keeping the
+    // signature unchanged. Signature was over the bob-add payload, so it
+    // must no longer verify.
+    const tampered: ACLEntry<AclChange> = {
+      ...e1,
+      change: { op: 'add', keys: [eve.hashHex] },
+    };
+    const result = await fresh.ingestEntry(tampered, alice.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('bad-signature');
+  });
+
+  test('substituting a different signer for the same payload is rejected', async () => {
+    const chain = makeChain([alice.publicKey]);
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    const entry = await chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    const fresh = makeChain([alice.publicKey]);
+    await fresh.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    // Caller claims Eve signed, but the signerKeyHash inside the entry
+    // says Alice -- mismatch caught before we even try to verify.
+    const result = await fresh.ingestEntry(entry, eve.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('unknown-signer-key');
+  });
+
+  test('exact duplicate ingest is rejected', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const e0 = await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    // Try to ingest the same entry again -- sequence number is now 1, so
+    // this is caught as sequence-out-of-order before we hit the duplicate
+    // check, but the chain MUST reject it either way. We check that the
+    // chain length stays at 1.
+    const result = await chain.ingestEntry(e0, alice.publicKey);
+    expect(result.ok).toBe(false);
+    expect(chain.length).toBe(1);
+  });
+
+  test('fork attempt: two entries with the same parent are not both accepted', async () => {
+    // Build a chain to a fork point.
+    const chain = makeChain([alice.publicKey]);
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    await chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    const forkPoint = chain.headHash;
+    const forkSeq = chain.length;
+
+    // Build entry A: alice adds carol.
+    const payloadA = {
+      sequenceNumber: forkSeq,
+      timestamp: 1000,
+      parentHash: forkPoint,
+      change: { op: 'add' as const, keys: [carol.hashHex] },
+      signerKeyHash: await serializePublicKey(alice.publicKey),
+    };
+    const sigA = await auth.sign(
+      canonicalEntryPayload(payloadA, serializeChange),
+      alice.privateKey,
+    );
+    const entryA: ACLEntry<AclChange> = { ...payloadA, signature: sigA };
+
+    // Build entry B: bob adds eve. Same parent, same seq, different content.
+    const payloadB = {
+      sequenceNumber: forkSeq,
+      timestamp: 1001,
+      parentHash: forkPoint,
+      change: { op: 'add' as const, keys: [eve.hashHex] },
+      signerKeyHash: await serializePublicKey(bob.publicKey),
+    };
+    const sigB = await auth.sign(
+      canonicalEntryPayload(payloadB, serializeChange),
+      bob.privateKey,
+    );
+    const entryB: ACLEntry<AclChange> = { ...payloadB, signature: sigB };
+
+    // First one in wins.
+    const rA = await chain.ingestEntry(entryA, alice.publicKey);
+    expect(rA.ok).toBe(true);
+    expect(await testOps.isWriter(chain.state!, carol.publicKey)).toBe(true);
+
+    // Second one is rejected: its parentHash no longer matches the head.
+    const rB = await chain.ingestEntry(entryB, bob.publicKey);
+    expect(rB.ok).toBe(false);
+    if (!rB.ok) {
+      expect(['parent-hash-mismatch', 'sequence-out-of-order']).toContain(
+        rB.reason,
+      );
+    }
+    expect(await testOps.isWriter(chain.state!, eve.publicKey)).toBe(false);
+  });
+
+  test('mid-chain malicious insertion is rejected', async () => {
+    // Attacker wants to splice an entry into the middle of an existing
+    // chain. Even if the entry's content is plausible, its parentHash
+    // points to a non-head position so the chain rejects it.
+    const chain = makeChain([alice.publicKey]);
+
+    const e0 = await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    await chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    await chain.authorAndAppend(
+      { op: 'add', keys: [carol.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    // Construct a malicious entry whose parentHash points at e0 (the
+    // genesis), not the current head. Even with a valid signature from
+    // Alice, this must be rejected.
+    const e0Hash = await computeEntryHash(e0, serializeChange);
+    const payload = {
+      sequenceNumber: chain.length,
+      timestamp: 9999,
+      parentHash: e0Hash,
+      change: { op: 'add' as const, keys: [eve.hashHex] },
+      signerKeyHash: await serializePublicKey(alice.publicKey),
+    };
+    const signature = await auth.sign(
+      canonicalEntryPayload(payload, serializeChange),
+      alice.privateKey,
+    );
+    const evil: ACLEntry<AclChange> = { ...payload, signature };
+    const result = await chain.ingestEntry(evil, alice.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('parent-hash-mismatch');
+  });
+
+  test('sequence number that skips ahead is rejected', async () => {
+    const chain = makeChain([alice.publicKey]);
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    const head = chain.headHash;
+    const payload = {
+      sequenceNumber: 5, // chain expects 1
+      timestamp: 1000,
+      parentHash: head,
+      change: { op: 'add' as const, keys: [bob.hashHex] },
+      signerKeyHash: await serializePublicKey(alice.publicKey),
+    };
+    const signature = await auth.sign(
+      canonicalEntryPayload(payload, serializeChange),
+      alice.privateKey,
+    );
+    const result = await chain.ingestEntry(
+      { ...payload, signature },
+      alice.publicKey,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('sequence-out-of-order');
+  });
+});
+
+describe('replay() snapshot loading', () => {
+  test('round-trips a legitimate chain into a fresh ACLChain instance', async () => {
+    const chain = makeChain([alice.publicKey]);
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    await chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    await chain.authorAndAppend(
+      { op: 'add', keys: [carol.hashHex] },
+      bob.publicKey,
+      bob.privateKey,
+    );
+
+    const entries = chain.entries();
+
+    // Build a resolver that can recover each public key from its hash --
+    // in production this would consult a directory or a separate keystore.
+    const byHash = new Map<string, CryptoKey>([
+      [alice.hashHex, alice.publicKey],
+      [bob.hashHex, bob.publicKey],
+      [carol.hashHex, carol.publicKey],
+    ]);
+
+    const fresh = makeChain([alice.publicKey]);
+    const result = await fresh.replay(entries, async (hash) =>
+      byHash.get(toHex(hash)),
+    );
+    expect(result.ok).toBe(true);
+    expect(fresh.length).toBe(3);
+    expect(await testOps.isWriter(fresh.state!, alice.publicKey)).toBe(true);
+    expect(await testOps.isWriter(fresh.state!, bob.publicKey)).toBe(true);
+    expect(await testOps.isWriter(fresh.state!, carol.publicKey)).toBe(true);
+  });
+
+  test('replay rejects a chain with a hostile entry spliced in', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const e0 = await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    const e1 = await chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    // Build an Eve-authored entry that *looks* like it would extend the
+    // chain, but Eve has never been a writer.
+    const headAfterE1 = await computeEntryHash(e1, serializeChange);
+    const payload = {
+      sequenceNumber: 2,
+      timestamp: 5000,
+      parentHash: headAfterE1,
+      change: { op: 'add' as const, keys: [eve.hashHex] },
+      signerKeyHash: await serializePublicKey(eve.publicKey),
+    };
+    const signature = await auth.sign(
+      canonicalEntryPayload(payload, serializeChange),
+      eve.privateKey,
+    );
+    const eveEntry: ACLEntry<AclChange> = { ...payload, signature };
+
+    const byHash = new Map<string, CryptoKey>([
+      [alice.hashHex, alice.publicKey],
+      [bob.hashHex, bob.publicKey],
+      [eve.hashHex, eve.publicKey],
+    ]);
+
+    const fresh = makeChain([alice.publicKey]);
+    const result = await fresh.replay([e0, e1, eveEntry], async (hash) =>
+      byHash.get(toHex(hash)),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('unauthorized-signer');
+      expect(result.index).toBe(2);
+    }
+    // After a failed replay, the chain holds the partial-but-valid prefix
+    // so callers can inspect it for diagnostics.
+    expect(fresh.length).toBe(2);
+  });
+
+  test('replay rejects when resolveKey cannot map a signerKeyHash', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const e0 = await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    const fresh = makeChain([alice.publicKey]);
+    const result = await fresh.replay([e0], async () => undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('unknown-signer-key');
+      expect(result.index).toBe(0);
+    }
+  });
+});
+
+describe('headHash behavior', () => {
+  test('headHash returns a copy that callers cannot mutate', async () => {
+    const chain = makeChain([alice.publicKey]);
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    const head1 = chain.headHash!;
+    head1[0] ^= 0xff; // mutate the returned buffer
+    const head2 = chain.headHash!;
+
+    // The chain's internal head should not have been affected.
+    expect(toHex(head1)).not.toBe(toHex(head2));
+  });
+});

--- a/packages/collabswarm/src/acl-chain.test.ts
+++ b/packages/collabswarm/src/acl-chain.test.ts
@@ -367,12 +367,12 @@ describe('rejection: unauthorized signer', () => {
     expect(chain.length).toBe(4); // unchanged
   });
 
-  test('replay of a removed writer\'s *historical* entry against a fresh chain fails', async () => {
-    // Different threat: a former writer captured an entry they previously
-    // authored (signature was valid at the time) and tries to feed it back
-    // into a new node that is bootstrapping from a snapshot in which they
-    // are no longer a writer. The chain must reject based on the current
-    // state, not the historical state.
+  test('out-of-order injection of a historical entry into a fresh chain fails', async () => {
+    // Threat model: a former writer (or any attacker who has observed past
+    // entries) tries to inject a previously-valid entry into a fresh chain
+    // at the wrong position. Even though the signature was valid at the
+    // time, the chain must reject it because either the parent hash or
+    // the sequence number no longer line up.
     const chain = makeChain([alice.publicKey]);
 
     await chain.authorAndAppend(
@@ -757,5 +757,134 @@ describe('headHash behavior', () => {
 
     // The chain's internal head should not have been affected.
     expect(toHex(head1)).not.toBe(toHex(head2));
+  });
+});
+
+describe('malformed entry rejection', () => {
+  // These tests cover entries that may arrive over the network with
+  // entirely wrong shapes. The chain must surface them as structured
+  // 'malformed-entry' results rather than throwing, since a hostile peer
+  // could otherwise DoS the local node with a single forged entry.
+  test('non-Uint8Array signature is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const broken = {
+      sequenceNumber: 0,
+      timestamp: 0,
+      parentHash: undefined,
+      change: { op: 'add' as const, keys: [alice.hashHex] },
+      signerKeyHash: await serializePublicKey(alice.publicKey),
+      signature: 'not bytes' as unknown as Uint8Array,
+    } as ACLEntry<AclChange>;
+    const result = await chain.ingestEntry(broken, alice.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('malformed-entry');
+  });
+
+  test('non-integer sequenceNumber is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const broken = {
+      sequenceNumber: 1.5 as unknown as number,
+      timestamp: 0,
+      parentHash: undefined,
+      change: { op: 'add' as const, keys: [alice.hashHex] },
+      signerKeyHash: await serializePublicKey(alice.publicKey),
+      signature: new Uint8Array([1, 2, 3]),
+    } as ACLEntry<AclChange>;
+    const result = await chain.ingestEntry(broken, alice.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('malformed-entry');
+  });
+
+  test('non-Uint8Array signerKeyHash is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const broken = {
+      sequenceNumber: 0,
+      timestamp: 0,
+      parentHash: undefined,
+      change: { op: 'add' as const, keys: [alice.hashHex] },
+      signerKeyHash: 'not bytes' as unknown as Uint8Array,
+      signature: new Uint8Array([1, 2, 3]),
+    } as ACLEntry<AclChange>;
+    const result = await chain.ingestEntry(broken, alice.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('malformed-entry');
+  });
+
+  test('null entry is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const result = await chain.ingestEntry(
+      null as unknown as ACLEntry<AclChange>,
+      alice.publicKey,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('malformed-entry');
+  });
+});
+
+describe('concurrent mutation safety', () => {
+  // The chain serializes mutating calls via an internal queue so two
+  // overlapping appends cannot both capture the same `_entries.length`
+  // and corrupt sequence numbers / parent links.
+  test('two concurrent authorAndAppend calls produce a well-formed chain', async () => {
+    const chain = makeChain([alice.publicKey]);
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    // Fire two appends without awaiting in between -- they would race if
+    // the chain didn't serialize internally.
+    const [a, b] = await Promise.all([
+      chain.authorAndAppend(
+        { op: 'add', keys: [bob.hashHex] },
+        alice.publicKey,
+        alice.privateKey,
+      ),
+      chain.authorAndAppend(
+        { op: 'add', keys: [carol.hashHex] },
+        alice.publicKey,
+        alice.privateKey,
+      ),
+    ]);
+
+    expect(chain.length).toBe(3);
+    // Sequence numbers must be contiguous and parent hashes must link.
+    expect(a.sequenceNumber).not.toBe(b.sequenceNumber);
+    const seqs = [a.sequenceNumber, b.sequenceNumber].sort();
+    expect(seqs).toEqual([1, 2]);
+    // The later entry must point at the earlier entry's hash, not at the
+    // pre-mutation head.
+    const entries = chain.entries();
+    expect(entries[2].parentHash).toBeDefined();
+    expect(entries[2].sequenceNumber).toBe(2);
+    expect(entries[1].sequenceNumber).toBe(1);
+  });
+
+  test('failure in one queued mutation does not poison subsequent ones', async () => {
+    const chain = makeChain([alice.publicKey]);
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    // Eve is not authorized, so this authorAndAppend rejects.
+    const failing = chain.authorAndAppend(
+      { op: 'add', keys: [eve.hashHex] },
+      eve.publicKey,
+      eve.privateKey,
+    );
+    // Fire a legitimate append immediately so it enqueues behind the
+    // failing one.
+    const succeeding = chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    await expect(failing).rejects.toThrow();
+    await expect(succeeding).resolves.toBeDefined();
+    expect(chain.length).toBe(2);
   });
 });

--- a/packages/collabswarm/src/acl-chain.test.ts
+++ b/packages/collabswarm/src/acl-chain.test.ts
@@ -903,6 +903,80 @@ describe('malformed entry rejection', () => {
       expect(result.message).toMatch(/timestamp/);
     }
   });
+
+  // `canonicalEntryPayload` encodes `sequenceNumber` as an unsigned 32-bit
+  // integer. Values >0xFFFFFFFF would silently wrap via `>>> 0`, letting a
+  // hostile peer manufacture two *different* sequence numbers that share
+  // identical canonical bytes (and therefore identical signatures and
+  // hashes). Anything outside [0, 0xFFFFFFFF] must be rejected up front.
+  async function brokenSequenceEntry(
+    sequenceNumber: number,
+  ): Promise<ACLEntry<AclChange>> {
+    return {
+      sequenceNumber,
+      timestamp: 0,
+      parentHash: undefined,
+      change: { op: 'add' as const, keys: [alice.hashHex] },
+      signerKeyId: await serializePublicKey(alice.publicKey),
+      signature: new Uint8Array([1, 2, 3]),
+    } as ACLEntry<AclChange>;
+  }
+
+  test('sequenceNumber > 0xFFFFFFFF is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const result = await chain.ingestEntry(
+      await brokenSequenceEntry(0x100000000),
+      alice.publicKey,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/sequenceNumber/);
+    }
+  });
+
+  test('sequenceNumber up to 0xFFFFFFFF passes shape validation', async () => {
+    // The shape check itself must accept the maximum permissible value.
+    // The chain's own sequence check will then reject it because the
+    // chain is empty (expects sequenceNumber=0), but with
+    // sequence-out-of-order rather than malformed-entry. This confirms
+    // we draw the bound at exactly 2^32-1.
+    const chain = makeChain([alice.publicKey]);
+    const result = await chain.ingestEntry(
+      await brokenSequenceEntry(0xffffffff),
+      alice.publicKey,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).not.toBe('malformed-entry');
+    }
+  });
+
+  test('negative sequenceNumber is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const result = await chain.ingestEntry(
+      await brokenSequenceEntry(-1),
+      alice.publicKey,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/sequenceNumber/);
+    }
+  });
+
+  test('sequenceNumber beyond MAX_SAFE_INTEGER is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const result = await chain.ingestEntry(
+      await brokenSequenceEntry(Number.MAX_SAFE_INTEGER + 1),
+      alice.publicKey,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/sequenceNumber/);
+    }
+  });
 });
 
 describe('concurrent mutation safety', () => {

--- a/packages/collabswarm/src/acl-chain.test.ts
+++ b/packages/collabswarm/src/acl-chain.test.ts
@@ -18,8 +18,9 @@ const auth = new SubtleCrypto();
 
 /**
  * Generate an ECDSA P-384 keypair using the same algorithm as the SubtleCrypto
- * auth provider's default. Each test gets fresh keys so identities don't
- * leak across tests.
+ * auth provider's default. The suite-level identities (`alice`, `bob`, etc.)
+ * are generated once in `beforeAll`; tests that need additional isolated
+ * identities (e.g., to model an unknown peer) call this helper inline.
  */
 async function genKeyPair(): Promise<{
   publicKey: CryptoKey;

--- a/packages/collabswarm/src/acl-chain.test.ts
+++ b/packages/collabswarm/src/acl-chain.test.ts
@@ -741,6 +741,42 @@ describe('replay() snapshot loading', () => {
       expect(result.index).toBe(0);
     }
   });
+
+  test('replay validates full entry shape before invoking resolveKey', async () => {
+    // Regression: a hostile snapshot must not be able to force `resolveKey`
+    // to do expensive work (e.g. a directory lookup keyed by the supplied
+    // bytestring) by supplying an absurdly large `signerKeyId`. The full
+    // `validateEntryShape` check -- which enforces MAX_SIGNER_KEY_BYTES --
+    // must run *before* resolveKey is called.
+    const hostile = {
+      sequenceNumber: 0,
+      timestamp: 0,
+      parentHash: undefined,
+      change: { op: 'add' as const, keys: [alice.hashHex] },
+      // 1 MiB key id -- well above MAX_SIGNER_KEY_BYTES (256).
+      signerKeyId: new Uint8Array(1 << 20),
+      signature: new Uint8Array(64),
+    } as ACLEntry<AclChange>;
+
+    let resolveCalls = 0;
+    const fresh = makeChain([alice.publicKey]);
+    const result = await fresh.replay([hostile], async (id) => {
+      resolveCalls += 1;
+      // Touch the supplied bytes so a real implementation's cost would
+      // scale with `id.byteLength`. We must never get here.
+      void id.byteLength;
+      return undefined;
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.index).toBe(0);
+      expect(result.message).toMatch(/signerKeyId has an implausible length/);
+    }
+    expect(resolveCalls).toBe(0);
+    expect(fresh.length).toBe(0);
+  });
 });
 
 describe('headHash behavior', () => {
@@ -1064,12 +1100,12 @@ describe('oversized change rejection', () => {
   test('change larger than 1 MiB is rejected as malformed-entry', async () => {
     const chain = makeChain([alice.publicKey]);
     // Build a change whose serialized JSON exceeds MAX_CHANGE_BYTES (1 MiB).
-    // The keys array is included in the JSON encoding, so 1.1M single-char
-    // entries comfortably overshoots the limit while keeping the
-    // in-memory representation reasonable.
+    // A single ~1.1 MiB key string is cheap to construct (one allocation),
+    // serializes to JSON ~1 MiB without allocating millions of array elements,
+    // and comfortably overshoots the 1 MiB limit.
     const huge: AclChange = {
       op: 'add',
-      keys: Array.from({ length: 1_100_000 }, () => 'a'),
+      keys: ['a'.repeat(1_100_000)],
     };
     const payload = {
       sequenceNumber: 0,

--- a/packages/collabswarm/src/acl-chain.test.ts
+++ b/packages/collabswarm/src/acl-chain.test.ts
@@ -1177,6 +1177,57 @@ describe('oversized change rejection', () => {
     }
   });
 
+  test('Uint8Array change is rejected before serializeChange is even called', async () => {
+    // Thread A (Copilot follow-up): when `entry.change` is itself a
+    // `Uint8Array` (the common case for byte-oriented CRDTs like Yjs),
+    // the chain must size-gate it *before* `_serializeChange` runs --
+    // otherwise the (potentially identity) serializer has already
+    // allocated/copied a multi-megabyte buffer by the time the
+    // post-serialize check fires.
+    const OVERSIZED = (1 << 20) + 1; // MAX_CHANGE_BYTES + 1
+    let calls = 0;
+    const spy = (c: Uint8Array): Uint8Array => {
+      calls += 1;
+      return c;
+    };
+    const chain = new ACLChain<Uint8Array, CryptoKey, CryptoKey>(
+      {
+        auth,
+        serializeKey: serializePublicKey,
+        // The chain is generic in `ChangesType` and the chain ops only
+        // touch `applyChange`/`isWriter`; we never feed an oversized
+        // entry past the size gate so the ops are not exercised here.
+        ops: {
+          emptyState: () => new TestAclState() as unknown as ACLState<Uint8Array, CryptoKey>,
+          applyChange: async (s) => s,
+          isWriter: async () => true,
+        } as ACLChainOps<Uint8Array, CryptoKey>,
+        genesisAuthorizedKeys: [alice.publicKey],
+      },
+      spy,
+    );
+
+    const entry: ACLEntry<Uint8Array> = {
+      sequenceNumber: 0,
+      timestamp: 0,
+      parentHash: undefined,
+      // The Uint8Array is itself oversized; the pre-serialize gate must
+      // reject this before `spy` is ever invoked.
+      change: new Uint8Array(OVERSIZED),
+      signerKeyId: await serializePublicKey(alice.publicKey),
+      signature: new Uint8Array([1, 2, 3]),
+    };
+
+    const result = await chain.ingestEntry(entry, alice.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/change exceeds maximum size/);
+    }
+    // The pre-serialize gate fired -- `_serializeChange` was never called.
+    expect(calls).toBe(0);
+  });
+
   test('serializeChange returning a non-Uint8Array is rejected', async () => {
     // Defensive: if a custom adapter returns garbage we surface
     // malformed-entry rather than crashing later when assembling the

--- a/packages/collabswarm/src/acl-chain.test.ts
+++ b/packages/collabswarm/src/acl-chain.test.ts
@@ -151,7 +151,7 @@ describe('canonical encoding', () => {
       timestamp: 1000,
       parentHash: undefined,
       change: { op: 'add', keys: [bob.hashHex] },
-      signerKeyHash: new Uint8Array([1, 2, 3]),
+      signerKeyId: new Uint8Array([1, 2, 3]),
     };
 
     const h0 = toHex(await computeEntryHash(base, serializeChange));
@@ -180,7 +180,7 @@ describe('canonical encoding', () => {
     // Different signer
     const h4 = toHex(
       await computeEntryHash(
-        { ...base, signerKeyHash: new Uint8Array([9, 9, 9]) },
+        { ...base, signerKeyId: new Uint8Array([9, 9, 9]) },
         serializeChange,
       ),
     );
@@ -190,20 +190,20 @@ describe('canonical encoding', () => {
   test('length-prefixed encoding prevents boundary ambiguity', async () => {
     // Two entries that, without length prefixing, would have the same
     // concatenated representation:
-    //   signerKeyHash=[1,2], change=bytes("3")
-    //   signerKeyHash=[1,2,3], change=bytes("")
+    //   signerKeyId=[1,2], change=bytes("3")
+    //   signerKeyId=[1,2,3], change=bytes("")
     // Both produce bytes [1,2,3] if you forget the length prefixes.
     const a: Omit<ACLEntry<AclChange>, 'signature'> = {
       sequenceNumber: 0,
       timestamp: 0,
       change: { op: 'add', keys: [] }, // serializes to '{"op":"add","keys":[]}'
-      signerKeyHash: new Uint8Array([1, 2]),
+      signerKeyId: new Uint8Array([1, 2]),
     };
     const b: Omit<ACLEntry<AclChange>, 'signature'> = {
       sequenceNumber: 0,
       timestamp: 0,
       change: { op: 'add', keys: [] },
-      signerKeyHash: new Uint8Array([1, 2, 3]),
+      signerKeyId: new Uint8Array([1, 2, 3]),
     };
     const ha = canonicalEntryPayload(a, serializeChange);
     const hb = canonicalEntryPayload(b, serializeChange);
@@ -353,7 +353,7 @@ describe('rejection: unauthorized signer', () => {
       timestamp: Date.now(),
       parentHash: head,
       change: { op: 'add' as const, keys: [eve.hashHex] },
-      signerKeyHash: await serializePublicKey(bob.publicKey),
+      signerKeyId: await serializePublicKey(bob.publicKey),
     };
     const encoded = canonicalEntryPayload(payload, serializeChange);
     const signature = await auth.sign(encoded, bob.privateKey);
@@ -478,7 +478,7 @@ describe('rejection: tampering and replay', () => {
       alice.privateKey,
     );
 
-    // Caller claims Eve signed, but the signerKeyHash inside the entry
+    // Caller claims Eve signed, but the signerKeyId inside the entry
     // says Alice -- mismatch caught before we even try to verify.
     const result = await fresh.ingestEntry(entry, eve.publicKey);
     expect(result.ok).toBe(false);
@@ -525,7 +525,7 @@ describe('rejection: tampering and replay', () => {
       timestamp: 1000,
       parentHash: forkPoint,
       change: { op: 'add' as const, keys: [carol.hashHex] },
-      signerKeyHash: await serializePublicKey(alice.publicKey),
+      signerKeyId: await serializePublicKey(alice.publicKey),
     };
     const sigA = await auth.sign(
       canonicalEntryPayload(payloadA, serializeChange),
@@ -539,7 +539,7 @@ describe('rejection: tampering and replay', () => {
       timestamp: 1001,
       parentHash: forkPoint,
       change: { op: 'add' as const, keys: [eve.hashHex] },
-      signerKeyHash: await serializePublicKey(bob.publicKey),
+      signerKeyId: await serializePublicKey(bob.publicKey),
     };
     const sigB = await auth.sign(
       canonicalEntryPayload(payloadB, serializeChange),
@@ -594,7 +594,7 @@ describe('rejection: tampering and replay', () => {
       timestamp: 9999,
       parentHash: e0Hash,
       change: { op: 'add' as const, keys: [eve.hashHex] },
-      signerKeyHash: await serializePublicKey(alice.publicKey),
+      signerKeyId: await serializePublicKey(alice.publicKey),
     };
     const signature = await auth.sign(
       canonicalEntryPayload(payload, serializeChange),
@@ -620,7 +620,7 @@ describe('rejection: tampering and replay', () => {
       timestamp: 1000,
       parentHash: head,
       change: { op: 'add' as const, keys: [bob.hashHex] },
-      signerKeyHash: await serializePublicKey(alice.publicKey),
+      signerKeyId: await serializePublicKey(alice.publicKey),
     };
     const signature = await auth.sign(
       canonicalEntryPayload(payload, serializeChange),
@@ -696,7 +696,7 @@ describe('replay() snapshot loading', () => {
       timestamp: 5000,
       parentHash: headAfterE1,
       change: { op: 'add' as const, keys: [eve.hashHex] },
-      signerKeyHash: await serializePublicKey(eve.publicKey),
+      signerKeyId: await serializePublicKey(eve.publicKey),
     };
     const signature = await auth.sign(
       canonicalEntryPayload(payload, serializeChange),
@@ -724,7 +724,7 @@ describe('replay() snapshot loading', () => {
     expect(fresh.length).toBe(2);
   });
 
-  test('replay rejects when resolveKey cannot map a signerKeyHash', async () => {
+  test('replay rejects when resolveKey cannot map a signerKeyId', async () => {
     const chain = makeChain([alice.publicKey]);
     const e0 = await chain.authorAndAppend(
       { op: 'add', keys: [alice.hashHex] },
@@ -772,7 +772,7 @@ describe('malformed entry rejection', () => {
       timestamp: 0,
       parentHash: undefined,
       change: { op: 'add' as const, keys: [alice.hashHex] },
-      signerKeyHash: await serializePublicKey(alice.publicKey),
+      signerKeyId: await serializePublicKey(alice.publicKey),
       signature: 'not bytes' as unknown as Uint8Array,
     } as ACLEntry<AclChange>;
     const result = await chain.ingestEntry(broken, alice.publicKey);
@@ -787,7 +787,7 @@ describe('malformed entry rejection', () => {
       timestamp: 0,
       parentHash: undefined,
       change: { op: 'add' as const, keys: [alice.hashHex] },
-      signerKeyHash: await serializePublicKey(alice.publicKey),
+      signerKeyId: await serializePublicKey(alice.publicKey),
       signature: new Uint8Array([1, 2, 3]),
     } as ACLEntry<AclChange>;
     const result = await chain.ingestEntry(broken, alice.publicKey);
@@ -795,14 +795,14 @@ describe('malformed entry rejection', () => {
     if (!result.ok) expect(result.reason).toBe('malformed-entry');
   });
 
-  test('non-Uint8Array signerKeyHash is rejected without throwing', async () => {
+  test('non-Uint8Array signerKeyId is rejected without throwing', async () => {
     const chain = makeChain([alice.publicKey]);
     const broken = {
       sequenceNumber: 0,
       timestamp: 0,
       parentHash: undefined,
       change: { op: 'add' as const, keys: [alice.hashHex] },
-      signerKeyHash: 'not bytes' as unknown as Uint8Array,
+      signerKeyId: 'not bytes' as unknown as Uint8Array,
       signature: new Uint8Array([1, 2, 3]),
     } as ACLEntry<AclChange>;
     const result = await chain.ingestEntry(broken, alice.publicKey);
@@ -818,6 +818,89 @@ describe('malformed entry rejection', () => {
     );
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe('malformed-entry');
+  });
+
+  // `canonicalEntryPayload` encodes `timestamp` as two unsigned 32-bit
+  // halves; fractional, negative, NaN, and Infinity values would silently
+  // corrupt the encoding (and let an attacker manufacture distinct
+  // timestamps that share canonical bytes). All such values must be
+  // rejected up front as 'malformed-entry'.
+  async function brokenTimestampEntry(
+    timestamp: number,
+  ): Promise<ACLEntry<AclChange>> {
+    return {
+      sequenceNumber: 0,
+      timestamp,
+      parentHash: undefined,
+      change: { op: 'add' as const, keys: [alice.hashHex] },
+      signerKeyId: await serializePublicKey(alice.publicKey),
+      signature: new Uint8Array([1, 2, 3]),
+    } as ACLEntry<AclChange>;
+  }
+
+  test('fractional timestamp is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const result = await chain.ingestEntry(
+      await brokenTimestampEntry(1.5),
+      alice.publicKey,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/timestamp/);
+    }
+  });
+
+  test('negative timestamp is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const result = await chain.ingestEntry(
+      await brokenTimestampEntry(-1),
+      alice.publicKey,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/timestamp/);
+    }
+  });
+
+  test('NaN timestamp is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const result = await chain.ingestEntry(
+      await brokenTimestampEntry(Number.NaN),
+      alice.publicKey,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/timestamp/);
+    }
+  });
+
+  test('Infinity timestamp is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const result = await chain.ingestEntry(
+      await brokenTimestampEntry(Number.POSITIVE_INFINITY),
+      alice.publicKey,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/timestamp/);
+    }
+  });
+
+  test('timestamp beyond MAX_SAFE_INTEGER is rejected without throwing', async () => {
+    const chain = makeChain([alice.publicKey]);
+    const result = await chain.ingestEntry(
+      await brokenTimestampEntry(Number.MAX_SAFE_INTEGER + 1),
+      alice.publicKey,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/timestamp/);
+    }
   });
 });
 

--- a/packages/collabswarm/src/acl-chain.test.ts
+++ b/packages/collabswarm/src/acl-chain.test.ts
@@ -1046,3 +1046,311 @@ describe('concurrent mutation safety', () => {
     expect(chain.length).toBe(2);
   });
 });
+
+describe('oversized change rejection', () => {
+  // Thread A (CodeRabbit): the size gate must run *before* the full
+  // header+payload buffer is assembled, so a hostile peer cannot force a
+  // multi-megabyte allocation on the hot path by sending an oversized
+  // `change`.
+  //
+  // We exercise the gate two ways:
+  //   1. End-to-end: a change whose serialization exceeds MAX_CHANGE_BYTES
+  //      (1 MiB) is rejected as 'malformed-entry'.
+  //   2. Allocation order: we instrument the chain's `serializeChange`
+  //      callback so it returns an oversized buffer, then assert that
+  //      ingestion rejects without ever calling our spy a second time --
+  //      proving the rejection happened before any redundant work.
+
+  test('change larger than 1 MiB is rejected as malformed-entry', async () => {
+    const chain = makeChain([alice.publicKey]);
+    // Build a change whose serialized JSON exceeds MAX_CHANGE_BYTES (1 MiB).
+    // The keys array is included in the JSON encoding, so 1.1M single-char
+    // entries comfortably overshoots the limit while keeping the
+    // in-memory representation reasonable.
+    const huge: AclChange = {
+      op: 'add',
+      keys: Array.from({ length: 1_100_000 }, () => 'a'),
+    };
+    const payload = {
+      sequenceNumber: 0,
+      timestamp: 0,
+      parentHash: undefined,
+      change: huge,
+      signerKeyId: await serializePublicKey(alice.publicKey),
+    };
+    const encoded = canonicalEntryPayload(payload, serializeChange);
+    const signature = await auth.sign(encoded, alice.privateKey);
+    const entry: ACLEntry<AclChange> = { ...payload, signature };
+
+    const result = await chain.ingestEntry(entry, alice.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/serialized change exceeds maximum size/);
+    }
+    expect(chain.length).toBe(0);
+  });
+
+  test('size gate runs before full payload assembly (allocation order)', async () => {
+    // Use a chain whose `serializeChange` returns an oversized buffer on
+    // every call, and confirm that ingestion bails out *immediately* after
+    // the first serialization -- i.e. we do not proceed to assemble the
+    // header+payload buffer (which would have been roughly twice the
+    // change size on top of the change bytes themselves).
+    const OVERSIZED = (1 << 20) + 1; // MAX_CHANGE_BYTES + 1
+    let calls = 0;
+    let largestAllocation = 0;
+    const spy = (_c: AclChange): Uint8Array => {
+      calls += 1;
+      const bytes = new Uint8Array(OVERSIZED);
+      largestAllocation = Math.max(largestAllocation, bytes.byteLength);
+      return bytes;
+    };
+    const chain = new ACLChain<AclChange, CryptoKey, CryptoKey>(
+      {
+        auth,
+        serializeKey: serializePublicKey,
+        ops: testOps,
+        genesisAuthorizedKeys: [alice.publicKey],
+      },
+      spy,
+    );
+
+    const entry: ACLEntry<AclChange> = {
+      sequenceNumber: 0,
+      timestamp: 0,
+      parentHash: undefined,
+      change: { op: 'add', keys: [alice.hashHex] },
+      signerKeyId: await serializePublicKey(alice.publicKey),
+      signature: new Uint8Array([1, 2, 3]),
+    };
+
+    const result = await chain.ingestEntry(entry, alice.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/serialized change exceeds maximum size/);
+    }
+    // Exactly one serialization happened -- the gate fired before
+    // `canonicalEntryPayloadFromBytes` could re-walk or re-serialize.
+    expect(calls).toBe(1);
+    // And the largest allocation observed during ingestion was the
+    // change-bytes buffer itself, not the larger header+payload buffer
+    // (which would be header (24) + parent (0) + signerKey (~97) +
+    // changeBytes -- visibly bigger than just changeBytes).
+    expect(largestAllocation).toBe(OVERSIZED);
+  });
+
+  test('change at exactly 1 MiB still passes the size gate', async () => {
+    // The bound is inclusive (> MAX_CHANGE_BYTES is rejected, ==
+    // MAX_CHANGE_BYTES is allowed) so confirm the boundary is correct.
+    // We use a spy serializer that returns a buffer of exactly
+    // MAX_CHANGE_BYTES bytes; the entry will then fail signature
+    // verification (the signature is junk) rather than malformed-entry.
+    const exactly = (_c: AclChange): Uint8Array =>
+      new Uint8Array(1 << 20); // MAX_CHANGE_BYTES
+    const chain = new ACLChain<AclChange, CryptoKey, CryptoKey>(
+      {
+        auth,
+        serializeKey: serializePublicKey,
+        ops: testOps,
+        genesisAuthorizedKeys: [alice.publicKey],
+      },
+      exactly,
+    );
+
+    const entry: ACLEntry<AclChange> = {
+      sequenceNumber: 0,
+      timestamp: 0,
+      parentHash: undefined,
+      change: { op: 'add', keys: [alice.hashHex] },
+      signerKeyId: await serializePublicKey(alice.publicKey),
+      signature: new Uint8Array(96), // wrong length for ECDSA P-384 sig is fine
+    };
+
+    const result = await chain.ingestEntry(entry, alice.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Must NOT be the size gate; size is within bounds.
+      expect(result.message).not.toMatch(/serialized change exceeds/);
+      expect(result.reason).toBe('bad-signature');
+    }
+  });
+
+  test('serializeChange returning a non-Uint8Array is rejected', async () => {
+    // Defensive: if a custom adapter returns garbage we surface
+    // malformed-entry rather than crashing later when assembling the
+    // canonical payload.
+    const bogus = (_c: AclChange): Uint8Array =>
+      'not bytes' as unknown as Uint8Array;
+    const chain = new ACLChain<AclChange, CryptoKey, CryptoKey>(
+      {
+        auth,
+        serializeKey: serializePublicKey,
+        ops: testOps,
+        genesisAuthorizedKeys: [alice.publicKey],
+      },
+      bogus,
+    );
+
+    const entry: ACLEntry<AclChange> = {
+      sequenceNumber: 0,
+      timestamp: 0,
+      parentHash: undefined,
+      change: { op: 'add', keys: [alice.hashHex] },
+      signerKeyId: await serializePublicKey(alice.publicKey),
+      signature: new Uint8Array([1, 2, 3]),
+    };
+    const result = await chain.ingestEntry(entry, alice.publicKey);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('malformed-entry');
+      expect(result.message).toMatch(/serializeChange/);
+    }
+  });
+});
+
+describe('ingested entries are snapshot, not aliased', () => {
+  // Thread B (CodeRabbit): the chain must not store the caller-owned entry
+  // object directly. Mutating the entry after ingestion (or after
+  // authorAndAppend returns) used to leak straight into `_entries` and
+  // could corrupt parent-hash links, signature verification on replay,
+  // and the chain's audit log.
+
+  test('mutating entry returned by authorAndAppend does not corrupt the chain', async () => {
+    const chain = makeChain([alice.publicKey]);
+
+    const entry = await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    // Snapshot the chain's view of this entry's bytes BEFORE we mutate
+    // the caller's copy.
+    const beforeSig = new Uint8Array(chain.entries()[0].signature);
+    const beforeSigner = new Uint8Array(chain.entries()[0].signerKeyId);
+
+    // Mutate every byte field the caller can reach on their reference.
+    entry.signature.fill(0);
+    entry.signerKeyId.fill(0);
+
+    // The chain's stored entry must be unaffected.
+    const stored = chain.entries()[0];
+    expect(Array.from(stored.signature)).toEqual(Array.from(beforeSig));
+    expect(Array.from(stored.signerKeyId)).toEqual(Array.from(beforeSigner));
+    // Sanity: the caller's view really did mutate -- otherwise the test
+    // is vacuous.
+    expect(entry.signature.every((b) => b === 0)).toBe(true);
+  });
+
+  test('mutating entry passed to ingestEntry does not corrupt the chain', async () => {
+    // Author an entry on one chain, then ingest it onto a fresh chain
+    // and mutate the caller-owned reference. The fresh chain's stored
+    // copy must remain intact.
+    const sourceChain = makeChain([alice.publicKey]);
+    const e0 = await sourceChain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+
+    const targetChain = makeChain([alice.publicKey]);
+    const result = await targetChain.ingestEntry(e0, alice.publicKey);
+    expect(result.ok).toBe(true);
+
+    const storedBefore = targetChain.entries()[0];
+    const sigBefore = new Uint8Array(storedBefore.signature);
+    const keyBefore = new Uint8Array(storedBefore.signerKeyId);
+
+    // Now corrupt the caller's reference.
+    e0.signature.fill(0xff);
+    e0.signerKeyId.fill(0xff);
+    if (e0.parentHash) e0.parentHash.fill(0xff);
+
+    const storedAfter = targetChain.entries()[0];
+    expect(Array.from(storedAfter.signature)).toEqual(Array.from(sigBefore));
+    expect(Array.from(storedAfter.signerKeyId)).toEqual(Array.from(keyBefore));
+  });
+
+  test('mutating parentHash on a caller-owned entry does not break chain linkage', async () => {
+    // The parentHash on entry #1 forms the chain's hash-linked backbone.
+    // If the caller mutates entry.parentHash after ingestion, computing
+    // headHash via `_entryHashes` and replay() through computeEntryHash
+    // would otherwise disagree on what was actually appended.
+    const chain = makeChain([alice.publicKey]);
+    await chain.authorAndAppend(
+      { op: 'add', keys: [alice.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    const e1 = await chain.authorAndAppend(
+      { op: 'add', keys: [bob.hashHex] },
+      alice.publicKey,
+      alice.privateKey,
+    );
+    expect(e1.parentHash).toBeDefined();
+
+    const storedParentBefore = new Uint8Array(chain.entries()[1].parentHash!);
+
+    // Mutate the caller-owned parentHash on the returned entry.
+    e1.parentHash!.fill(0);
+
+    // Chain's snapshot remains intact.
+    const storedParentAfter = chain.entries()[1].parentHash!;
+    expect(Array.from(storedParentAfter)).toEqual(
+      Array.from(storedParentBefore),
+    );
+
+    // And the hash from headHash() still verifies against the stored
+    // entry via computeEntryHash.
+    const recomputed = await computeEntryHash(
+      chain.entries()[1],
+      serializeChange,
+    );
+    expect(toHex(chain.headHash!)).toBe(toHex(recomputed));
+  });
+
+  test('snapshot does not alias caller buffers for the change field when it is Uint8Array', async () => {
+    // Special case: some CRDT adapters use a `Uint8Array` for the change
+    // type itself. The chain's snapshot must clone that byte buffer too.
+    interface BytesAclChange extends Uint8Array {}
+    const bytesSerialize = (c: BytesAclChange): Uint8Array =>
+      new Uint8Array(c);
+    const bytesOps: ACLChainOps<BytesAclChange, CryptoKey> = {
+      emptyState: () => new TestAclState() as unknown as ACLState<BytesAclChange, CryptoKey>,
+      applyChange: async (state) => state,
+      isWriter: async () => true,
+    };
+    const chain = new ACLChain<BytesAclChange, CryptoKey, CryptoKey>(
+      {
+        auth,
+        serializeKey: serializePublicKey,
+        ops: bytesOps,
+        genesisAuthorizedKeys: [alice.publicKey],
+      },
+      bytesSerialize,
+    );
+
+    const callerChange = new Uint8Array([1, 2, 3, 4]) as BytesAclChange;
+    const payload = {
+      sequenceNumber: 0,
+      timestamp: 0,
+      parentHash: undefined,
+      change: callerChange,
+      signerKeyId: await serializePublicKey(alice.publicKey),
+    };
+    const encoded = canonicalEntryPayload(payload, bytesSerialize);
+    const signature = await auth.sign(encoded, alice.privateKey);
+    const entry: ACLEntry<BytesAclChange> = { ...payload, signature };
+
+    const result = await chain.ingestEntry(entry, alice.publicKey);
+    expect(result.ok).toBe(true);
+
+    // Mutate the caller's view of the change bytes.
+    callerChange.fill(0xff);
+
+    const stored = chain.entries()[0].change as unknown as Uint8Array;
+    expect(Array.from(stored)).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/packages/collabswarm/src/acl-chain.ts
+++ b/packages/collabswarm/src/acl-chain.ts
@@ -558,6 +558,10 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
    *   error and indicates a misuse of the API, not a network attack.
    *   Network-supplied entries should be passed through {@link ingestEntry}
    *   instead, which returns a structured error rather than throwing.
+   *   Errors from {@link ACLChainConfig.serializeKey} (e.g. unsupported key
+   *   types) and from {@link ACLChainConfig.auth}'s `sign` method (e.g.
+   *   WebCrypto failures, key/algorithm incompatibility, hardware backend
+   *   errors) also propagate as a rejected promise.
    */
   async authorAndAppend(
     change: ChangesType,

--- a/packages/collabswarm/src/acl-chain.ts
+++ b/packages/collabswarm/src/acl-chain.ts
@@ -208,8 +208,18 @@ export interface ACLChainConfig<ChangesType, PrivateKey, PublicKey> {
  * Compute the canonical hash of an {@link ACLEntry}.
  *
  * Hashes only the entry's payload fields (everything except the signature),
- * so the hash is stable for use as a {@link ACLEntry.parentHash} and as a
- * dedup key.
+ * so the hash is stable across signers and serialization round-trips. The
+ * resulting digest is used in two places:
+ *
+ * - As the value embedded in the next entry's {@link ACLEntry.parentHash}
+ *   field, forming the chain's hash-linked backbone.
+ * - As an element of {@link ACLChain}'s internal `_entryHashes` array, which
+ *   tracks the most recent entry's hash so the next append can stamp the
+ *   correct `parentHash`.
+ *
+ * Note: this hash is *not* used as a deduplication key. `_ingestEntryInternal`
+ * deliberately does not deduplicate by hash — sequence-number and
+ * parent-hash checks enforce chain integrity instead.
  *
  * The encoding is length-prefixed to avoid ambiguity between adjacent
  * variable-length fields:
@@ -829,6 +839,15 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
    * Runs under the mutation queue, so concurrent `ingestEntry` /
    * `authorAndAppend` / `replay` calls observe a consistent chain
    * throughout the replay.
+   *
+   * Partial-success contract: `replay()` first resets `_entries`,
+   * `_entryHashes`, and `_state`, then ingests the supplied entries in
+   * order. If verification fails at entry `i`, the method returns early
+   * with that failure result and the chain is left containing the valid
+   * prefix `entries[0..i-1]` along with the corresponding `_state`. The
+   * prior chain contents are *not* restored. Callers who need transactional
+   * "all-or-nothing" semantics should snapshot the chain before calling
+   * `replay()` and decide what to do based on the returned result.
    *
    * @param entries The full chain to verify. Each entry's signer key must
    *   be resolvable via `resolveKey(signerKeyId)`. If `resolveKey`

--- a/packages/collabswarm/src/acl-chain.ts
+++ b/packages/collabswarm/src/acl-chain.ts
@@ -241,10 +241,7 @@ export async function computeEntryHash<ChangesType>(
   serializeChange: (change: ChangesType) => Uint8Array,
 ): Promise<Uint8Array> {
   const payload = canonicalEntryPayload(entry, serializeChange);
-  const hash = await crypto.subtle.digest(
-    'SHA-256',
-    payload.buffer.slice(payload.byteOffset, payload.byteOffset + payload.byteLength) as ArrayBuffer,
-  );
+  const hash = await crypto.subtle.digest('SHA-256', payload as BufferSource);
   return new Uint8Array(hash);
 }
 
@@ -815,13 +812,7 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
       };
     }
     try {
-      const digest = await crypto.subtle.digest(
-        'SHA-256',
-        payloadBytes.buffer.slice(
-          payloadBytes.byteOffset,
-          payloadBytes.byteOffset + payloadBytes.byteLength,
-        ) as ArrayBuffer,
-      );
+      const digest = await crypto.subtle.digest('SHA-256', payloadBytes as BufferSource);
       entryHash = new Uint8Array(digest);
     } catch (err) {
       return {

--- a/packages/collabswarm/src/acl-chain.ts
+++ b/packages/collabswarm/src/acl-chain.ts
@@ -158,13 +158,12 @@ export type ACLChainVerifyError =
   | 'parent-hash-mismatch'
   | 'sequence-out-of-order'
   | 'unknown-signer-key'
-  | 'duplicate-entry'
   | 'malformed-entry';
 
 /**
- * Result returned by {@link ACLChain.verifyChain} and the various append
- * paths. `ok: false` results carry both a structured reason and a human
- * readable message for logging.
+ * Result returned by {@link ACLChain.replay}, {@link ACLChain.ingestEntry},
+ * and {@link ACLChain.authorAndAppend}. `ok: false` results carry both a
+ * structured reason and a human readable message for logging.
  */
 export type ACLChainVerifyResult =
   | { ok: true }
@@ -313,25 +312,22 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
 }
 
 /**
- * Hex-encode a Uint8Array. Used for set keys when comparing identifiers.
+ * Upper bound on byte length accepted for `parentHash`. Sized generously
+ * above SHA-256's 32-byte digest so the cap rejects only obviously
+ * malformed peer input. Network-supplied entries with unreasonably large
+ * `parentHash` buffers would otherwise force large allocations during
+ * hashing.
  */
-function toHex(bytes: Uint8Array): string {
-  let s = '';
-  for (let i = 0; i < bytes.byteLength; i++) {
-    s += bytes[i].toString(16).padStart(2, '0');
-  }
-  return s;
-}
+const MAX_PARENT_HASH_BYTES = 64;
 
 /**
- * Upper bound on byte length accepted for hash- or key-bytes fields
- * (`parentHash`, `signerKeyId`). Sized generously above SHA-256's 32-byte
- * digest and the canonical ECDSA P-384 public-key serialization so the
- * cap rejects only obviously malformed peer input. Network-supplied
- * entries with unreasonably large byte arrays here would otherwise force
- * large allocations during hashing.
+ * Upper bound on byte length accepted for `signerKeyId`. Sized above the
+ * canonical ECDSA P-384 raw public-key serialization (~97 bytes) and SPKI
+ * encoding (~120 bytes) with headroom for alternate algorithms a future
+ * `AuthProvider` might use. Anything substantially larger than a couple
+ * hundred bytes is hostile input.
  */
-const MAX_HASH_BYTES = 64;
+const MAX_SIGNER_KEY_BYTES = 256;
 
 /**
  * Upper bound on the serialized change payload accepted from the network.
@@ -354,13 +350,18 @@ function validateEntryShape<ChangesType>(
   if (entry === null || typeof entry !== 'object') {
     return 'entry is not an object';
   }
+  // `sequenceNumber` is encoded as an unsigned 32-bit integer in
+  // `canonicalEntryPayload`. Values >2^32-1 would silently wrap via the
+  // `>>> 0` cast and let a hostile peer manufacture two *different*
+  // sequence numbers that produce identical canonical bytes (and
+  // therefore identical signatures and hashes). Cap at 0xFFFFFFFF.
   if (
     typeof entry.sequenceNumber !== 'number' ||
     !Number.isInteger(entry.sequenceNumber) ||
     entry.sequenceNumber < 0 ||
-    entry.sequenceNumber > Number.MAX_SAFE_INTEGER
+    entry.sequenceNumber > 0xffffffff
   ) {
-    return 'sequenceNumber is not a non-negative safe integer';
+    return 'sequenceNumber is not an unsigned 32-bit integer';
   }
   // `timestamp` is encoded as two unsigned 32-bit halves in
   // `canonicalEntryPayload`. Fractional values would be silently truncated
@@ -381,7 +382,7 @@ function validateEntryShape<ChangesType>(
   }
   if (
     entry.signerKeyId.byteLength === 0 ||
-    entry.signerKeyId.byteLength > MAX_HASH_BYTES * 4
+    entry.signerKeyId.byteLength > MAX_SIGNER_KEY_BYTES
   ) {
     // Public key encodings are a couple hundred bytes at most; reject
     // anything wildly out of range.
@@ -399,7 +400,7 @@ function validateEntryShape<ChangesType>(
     }
     if (
       entry.parentHash.byteLength === 0 ||
-      entry.parentHash.byteLength > MAX_HASH_BYTES
+      entry.parentHash.byteLength > MAX_PARENT_HASH_BYTES
     ) {
       return 'parentHash has an implausible length';
     }
@@ -438,12 +439,6 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
    * `null` while the chain is still empty.
    */
   private _state: ACLState<ChangesType, PublicKey> | null = null;
-
-  /**
-   * Set of entry hashes (hex) seen so far. Used to reject exact duplicates
-   * up front, before doing the more expensive signature work.
-   */
-  private readonly _seenHashes = new Set<string>();
 
   /** Serializer used both for the change payload and for the AuthProvider. */
   private readonly _serializeChange: (change: ChangesType) => Uint8Array;
@@ -682,10 +677,17 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
       }
     }
 
-    // 4. Reject exact duplicates before doing expensive signature work.
-    //    `serializeChange` runs over the (still opaque) change here; if it
-    //    throws on hostile input we surface it as a structured error
-    //    rather than letting the exception escape.
+    // 4. Canonical-encode and hash the payload. Bound the size up front so
+    //    a hostile peer cannot force a large allocation via an oversized
+    //    `change`. `serializeChange` runs over the (still opaque) change
+    //    here; if it throws on hostile input we surface it as a structured
+    //    error rather than letting the exception escape.
+    //
+    //    We do not separately deduplicate by hash: any two entries with the
+    //    same canonical payload would necessarily share a `sequenceNumber`,
+    //    and the sequence check in step 2 already requires
+    //    `entry.sequenceNumber === this._entries.length`. A re-ingested
+    //    entry therefore can never reach this point with a matching hash.
     let entryHash: Uint8Array;
     let payloadBytes: Uint8Array;
     try {
@@ -721,15 +723,6 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
         ok: false,
         reason: 'malformed-entry',
         message: `failed to hash entry payload: ${(err as Error).message}`,
-        index,
-      };
-    }
-    const entryHashHex = toHex(entryHash);
-    if (this._seenHashes.has(entryHashHex)) {
-      return {
-        ok: false,
-        reason: 'duplicate-entry',
-        message: 'entry with this hash has already been ingested',
         index,
       };
     }
@@ -821,7 +814,6 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
     this._state = newState;
     this._entries.push(entry);
     this._entryHashes.push(entryHash);
-    this._seenHashes.add(entryHashHex);
 
     return { ok: true };
   }
@@ -852,7 +844,6 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
       // scratch" primitive without constructing a new chain.
       this._entries.length = 0;
       this._entryHashes.length = 0;
-      this._seenHashes.clear();
       this._state = null;
 
       for (let i = 0; i < entries.length; i++) {

--- a/packages/collabswarm/src/acl-chain.ts
+++ b/packages/collabswarm/src/acl-chain.ts
@@ -132,7 +132,8 @@ export interface ACLEntry<ChangesType> {
    * Stable canonical serialization of the signer's public key
    * (see {@link SerializePublicKey}). The chain uses this for fast
    * identity comparisons; the actual public key for signature verification
-   * is supplied separately at {@link ACLChain.append} time.
+   * is supplied separately at {@link ACLChain.authorAndAppend} /
+   * {@link ACLChain.ingestEntry} time.
    */
   signerKeyHash: Uint8Array;
 
@@ -237,7 +238,9 @@ export async function computeEntryHash<ChangesType>(
 /**
  * Canonical byte encoding of an {@link ACLEntry}'s payload (everything
  * the signature covers). Exported for tests; callers should usually go
- * through {@link ACLChain.append}.
+ * through {@link ACLChain.authorAndAppend} (when authoring new entries)
+ * or {@link ACLChain.ingestEntry} (when verifying entries received from
+ * peers), both of which handle canonical encoding internally.
  */
 export function canonicalEntryPayload<ChangesType>(
   entry: Omit<ACLEntry<ChangesType>, 'signature'>,
@@ -313,6 +316,83 @@ function toHex(bytes: Uint8Array): string {
 }
 
 /**
+ * SHA-256 byte length, used to bound the size of `parentHash` and
+ * `signerKeyHash` fields. Network-supplied entries with unreasonably large
+ * byte arrays here would otherwise force large allocations during hashing.
+ */
+const MAX_HASH_BYTES = 64;
+
+/**
+ * Upper bound on the serialized change payload accepted from the network.
+ * 1 MiB is well above any realistic ACL diff but small enough that a
+ * hostile peer cannot exhaust memory with a single forged entry.
+ */
+const MAX_CHANGE_BYTES = 1 << 20;
+
+/**
+ * Structural runtime check for a network-supplied {@link ACLEntry}.
+ *
+ * Returns `null` if the entry is well-formed enough to attempt signature
+ * verification, or a human-readable reason string otherwise. Callers
+ * should treat any non-null result as a `malformed-entry` rejection --
+ * do not throw, since the entry may have been delivered by a hostile peer.
+ */
+function validateEntryShape<ChangesType>(
+  entry: ACLEntry<ChangesType>,
+): string | null {
+  if (entry === null || typeof entry !== 'object') {
+    return 'entry is not an object';
+  }
+  if (
+    typeof entry.sequenceNumber !== 'number' ||
+    !Number.isInteger(entry.sequenceNumber) ||
+    entry.sequenceNumber < 0 ||
+    entry.sequenceNumber > Number.MAX_SAFE_INTEGER
+  ) {
+    return 'sequenceNumber is not a non-negative safe integer';
+  }
+  if (
+    typeof entry.timestamp !== 'number' ||
+    !Number.isFinite(entry.timestamp)
+  ) {
+    return 'timestamp is not a finite number';
+  }
+  if (!(entry.signerKeyHash instanceof Uint8Array)) {
+    return 'signerKeyHash is not a Uint8Array';
+  }
+  if (
+    entry.signerKeyHash.byteLength === 0 ||
+    entry.signerKeyHash.byteLength > MAX_HASH_BYTES * 4
+  ) {
+    // Public key encodings are a couple hundred bytes at most; reject
+    // anything wildly out of range.
+    return 'signerKeyHash has an implausible length';
+  }
+  if (!(entry.signature instanceof Uint8Array)) {
+    return 'signature is not a Uint8Array';
+  }
+  if (entry.signature.byteLength === 0 || entry.signature.byteLength > 1024) {
+    return 'signature has an implausible length';
+  }
+  if (entry.parentHash !== undefined) {
+    if (!(entry.parentHash instanceof Uint8Array)) {
+      return 'parentHash is not a Uint8Array';
+    }
+    if (
+      entry.parentHash.byteLength === 0 ||
+      entry.parentHash.byteLength > MAX_HASH_BYTES
+    ) {
+      return 'parentHash has an implausible length';
+    }
+  }
+  // `change` is opaque to the chain; we cannot validate its internal
+  // structure here. The caller-supplied `serializeChange` is responsible
+  // for producing a byte buffer or throwing, and we bound the resulting
+  // size below in ingestEntry().
+  return null;
+}
+
+/**
  * An append-only, hash-linked log of signed ACL changes.
  *
  * Each entry is verified before being applied:
@@ -348,6 +428,16 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
 
   /** Serializer used both for the change payload and for the AuthProvider. */
   private readonly _serializeChange: (change: ChangesType) => Uint8Array;
+
+  /**
+   * Tail of the mutation queue. Mutating methods (`ingestEntry`,
+   * `authorAndAppend`, `replay`) chain onto this promise so they run
+   * serially even if invoked concurrently. Without this, two overlapping
+   * `ingestEntry` calls could both capture the same `_entries.length`,
+   * pass their checks against the same prior state, and then both append --
+   * silently corrupting sequence numbers and parent-hash links.
+   */
+  private _mutationQueue: Promise<unknown> = Promise.resolve();
 
   constructor(
     private readonly _config: ACLChainConfig<ChangesType, PrivateKey, PublicKey>,
@@ -390,12 +480,33 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
   }
 
   /**
+   * Serialize the given task against the mutation queue.
+   *
+   * Returns a promise that resolves with the task's result once all prior
+   * queued tasks have settled. The queue catches and discards errors so
+   * one failing task does not poison the queue for subsequent ones.
+   */
+  private _runExclusive<T>(task: () => Promise<T>): Promise<T> {
+    const next = this._mutationQueue.then(task, task);
+    // Swallow the result so the next task isn't poisoned by a rejection.
+    this._mutationQueue = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  }
+
+  /**
    * Build, sign, and append a new entry authored by `signerKey`.
    *
    * The signer must currently be authorized (a writer in the chain's
    * current state, or in `genesisAuthorizedKeys` for the genesis entry).
    * On success the entry is verified, applied to the chain's internal
    * state, and returned for transmission to peers.
+   *
+   * Concurrent `authorAndAppend` / {@link ingestEntry} calls are
+   * serialized via an internal queue, so each call sees a consistent
+   * `_entries.length`, head hash, and ACL state during its checks.
    *
    * @throws Error if the signer is not authorized -- this is a programmer
    *   error and indicates a misuse of the API, not a network attack.
@@ -408,30 +519,32 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
     signerPrivateKey: PrivateKey,
     timestamp: number = Date.now(),
   ): Promise<ACLEntry<ChangesType>> {
-    const signerKeyHash = await this._config.serializeKey(signerPublicKey);
+    return this._runExclusive(async () => {
+      const signerKeyHash = await this._config.serializeKey(signerPublicKey);
 
-    const payload: Omit<ACLEntry<ChangesType>, 'signature'> = {
-      sequenceNumber: this._entries.length,
-      timestamp,
-      parentHash: this.headHash,
-      change,
-      signerKeyHash,
-    };
+      const payload: Omit<ACLEntry<ChangesType>, 'signature'> = {
+        sequenceNumber: this._entries.length,
+        timestamp,
+        parentHash: this.headHash,
+        change,
+        signerKeyHash,
+      };
 
-    const encoded = canonicalEntryPayload(payload, this._serializeChange);
-    const signature = await this._config.auth.sign(encoded, signerPrivateKey);
+      const encoded = canonicalEntryPayload(payload, this._serializeChange);
+      const signature = await this._config.auth.sign(encoded, signerPrivateKey);
 
-    const entry: ACLEntry<ChangesType> = { ...payload, signature };
+      const entry: ACLEntry<ChangesType> = { ...payload, signature };
 
-    const result = await this.ingestEntry(entry, signerPublicKey);
-    if (!result.ok) {
-      // Author tried to append an entry they're not allowed to author.
-      // This is a programmer error, not a hostile-input case.
-      throw new Error(
-        `ACLChain.authorAndAppend: refusing to append entry: ${result.reason}: ${result.message}`,
-      );
-    }
-    return entry;
+      const result = await this._ingestEntryInternal(entry, signerPublicKey);
+      if (!result.ok) {
+        // Author tried to append an entry they're not allowed to author.
+        // This is a programmer error, not a hostile-input case.
+        throw new Error(
+          `ACLChain.authorAndAppend: refusing to append entry: ${result.reason}: ${result.message}`,
+        );
+      }
+      return entry;
+    });
   }
 
   /**
@@ -439,7 +552,13 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
    *
    * Returns a structured result rather than throwing so callers can log
    * and discard malicious or stale entries without unwinding their own
-   * control flow.
+   * control flow. Malformed runtime data (wrong field types, oversized
+   * byte buffers, exceptions thrown by `serializeKey`/`serializeChange`)
+   * is surfaced as a `'malformed-entry'` result rather than propagating
+   * as an exception, so a single hostile entry cannot DoS the caller.
+   *
+   * Concurrent invocations are serialized via an internal queue so each
+   * call observes a consistent prior chain state.
    *
    * @param entry The signed entry to apply.
    * @param signerPublicKey The public key that the caller claims signed
@@ -451,11 +570,49 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
     entry: ACLEntry<ChangesType>,
     signerPublicKey: PublicKey,
   ): Promise<ACLChainVerifyResult> {
+    return this._runExclusive(() =>
+      this._ingestEntryInternal(entry, signerPublicKey),
+    );
+  }
+
+  /**
+   * Implementation of {@link ingestEntry} that assumes the caller already
+   * holds the mutation queue. Do not call this directly from outside the
+   * class.
+   */
+  private async _ingestEntryInternal(
+    entry: ACLEntry<ChangesType>,
+    signerPublicKey: PublicKey,
+  ): Promise<ACLChainVerifyResult> {
     const index = this._entries.length;
+
+    // 0. Structural validation. Network-supplied entries may have entirely
+    //    wrong shapes (missing fields, wrong types, oversized buffers);
+    //    catch these up front so subsequent steps can rely on field types
+    //    and we never throw on hostile input.
+    const shapeError = validateEntryShape(entry);
+    if (shapeError !== null) {
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: shapeError,
+        index,
+      };
+    }
 
     // 1. Caller-supplied key must match the hash in the entry.
     const declared = entry.signerKeyHash;
-    const actual = await this._config.serializeKey(signerPublicKey);
+    let actual: Uint8Array;
+    try {
+      actual = await this._config.serializeKey(signerPublicKey);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: `serializeKey threw on supplied public key: ${(err as Error).message}`,
+        index,
+      };
+    }
     if (!bytesEqual(declared, actual)) {
       return {
         ok: false,
@@ -507,7 +664,47 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
     }
 
     // 4. Reject exact duplicates before doing expensive signature work.
-    const entryHash = await computeEntryHash(entry, this._serializeChange);
+    //    `serializeChange` runs over the (still opaque) change here; if it
+    //    throws on hostile input we surface it as a structured error
+    //    rather than letting the exception escape.
+    let entryHash: Uint8Array;
+    let payloadBytes: Uint8Array;
+    try {
+      payloadBytes = canonicalEntryPayload(entry, this._serializeChange);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: `failed to canonically encode entry: ${(err as Error).message}`,
+        index,
+      };
+    }
+    if (payloadBytes.byteLength > MAX_CHANGE_BYTES + 1024) {
+      // 1 KiB slack for the fixed header + parent/signer fields.
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: `encoded entry payload exceeds maximum size (${payloadBytes.byteLength} > ${MAX_CHANGE_BYTES + 1024} bytes)`,
+        index,
+      };
+    }
+    try {
+      const digest = await crypto.subtle.digest(
+        'SHA-256',
+        payloadBytes.buffer.slice(
+          payloadBytes.byteOffset,
+          payloadBytes.byteOffset + payloadBytes.byteLength,
+        ) as ArrayBuffer,
+      );
+      entryHash = new Uint8Array(digest);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: `failed to hash entry payload: ${(err as Error).message}`,
+        index,
+      };
+    }
     const entryHashHex = toHex(entryHash);
     if (this._seenHashes.has(entryHashHex)) {
       return {
@@ -519,7 +716,6 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
     }
 
     // 5. Signature must verify against the canonical payload.
-    const payloadBytes = canonicalEntryPayload(entry, this._serializeChange);
     let signatureOk: boolean;
     try {
       signatureOk = await this._config.auth.verify(
@@ -547,12 +743,34 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
     // 6. Authorization: signer must be a writer in the state *before* this
     //    entry. For the genesis entry, the bootstrap set defines who can
     //    sign.
-    const priorState = this._state ?? this._config.ops.emptyState();
+    let priorState: ACLState<ChangesType, PublicKey>;
+    try {
+      priorState = this._state ?? this._config.ops.emptyState();
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: `ops.emptyState threw: ${(err as Error).message}`,
+        index,
+      };
+    }
     let authorized: boolean;
-    if (this._entries.length === 0) {
-      authorized = await this._isInBootstrapSet(signerPublicKey);
-    } else {
-      authorized = await this._config.ops.isWriter(priorState, signerPublicKey);
+    try {
+      if (this._entries.length === 0) {
+        authorized = await this._isInBootstrapSet(signerPublicKey);
+      } else {
+        authorized = await this._config.ops.isWriter(
+          priorState,
+          signerPublicKey,
+        );
+      }
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: `authorization check threw: ${(err as Error).message}`,
+        index,
+      };
     }
     if (!authorized) {
       return {
@@ -566,8 +784,21 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
       };
     }
 
-    // 7. All checks passed -- apply the change and commit.
-    const newState = await this._config.ops.applyChange(priorState, entry.change);
+    // 7. All checks passed -- apply the change and commit. If applyChange
+    //    throws (e.g. malformed change semantics that slipped past the
+    //    signature check because the signer happened to also be malicious),
+    //    surface as malformed-entry so chain state is not partially updated.
+    let newState: ACLState<ChangesType, PublicKey>;
+    try {
+      newState = await this._config.ops.applyChange(priorState, entry.change);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: `ops.applyChange threw: ${(err as Error).message}`,
+        index,
+      };
+    }
     this._state = newState;
     this._entries.push(entry);
     this._entryHashes.push(entryHash);
@@ -584,6 +815,10 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
    * the chain has the same `state` as if every entry had been ingested
    * individually.
    *
+   * Runs under the mutation queue, so concurrent `ingestEntry` /
+   * `authorAndAppend` / `replay` calls observe a consistent chain
+   * throughout the replay.
+   *
    * @param entries The full chain to verify. Each entry's signer key must
    *   be resolvable via `resolveKey(signerKeyHash)`. If `resolveKey`
    *   returns `undefined`, the entry is rejected with
@@ -593,30 +828,58 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
     entries: ReadonlyArray<ACLEntry<ChangesType>>,
     resolveKey: (signerKeyHash: Uint8Array) => Promise<PublicKey | undefined>,
   ): Promise<ACLChainVerifyResult> {
-    // Reset internal state so callers can use replay() as a "load from
-    // scratch" primitive without constructing a new chain.
-    this._entries.length = 0;
-    this._entryHashes.length = 0;
-    this._seenHashes.clear();
-    this._state = null;
+    return this._runExclusive(async () => {
+      // Reset internal state so callers can use replay() as a "load from
+      // scratch" primitive without constructing a new chain.
+      this._entries.length = 0;
+      this._entryHashes.length = 0;
+      this._seenHashes.clear();
+      this._state = null;
 
-    for (let i = 0; i < entries.length; i++) {
-      const entry = entries[i];
-      const signerKey = await resolveKey(entry.signerKeyHash);
-      if (!signerKey) {
-        return {
-          ok: false,
-          reason: 'unknown-signer-key',
-          message: `no public key available for signerKeyHash at entry ${i}`,
-          index: i,
-        };
+      for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        // Pre-validate shape so resolveKey isn't called with garbage and
+        // a hostile entry can't crash the loop with a TypeError.
+        const shapeError =
+          entry === null || typeof entry !== 'object'
+            ? 'entry is not an object'
+            : !(entry.signerKeyHash instanceof Uint8Array)
+              ? 'signerKeyHash is not a Uint8Array'
+              : null;
+        if (shapeError !== null) {
+          return {
+            ok: false,
+            reason: 'malformed-entry',
+            message: shapeError,
+            index: i,
+          };
+        }
+        let signerKey: PublicKey | undefined;
+        try {
+          signerKey = await resolveKey(entry.signerKeyHash);
+        } catch (err) {
+          return {
+            ok: false,
+            reason: 'unknown-signer-key',
+            message: `resolveKey threw at entry ${i}: ${(err as Error).message}`,
+            index: i,
+          };
+        }
+        if (!signerKey) {
+          return {
+            ok: false,
+            reason: 'unknown-signer-key',
+            message: `no public key available for signerKeyHash at entry ${i}`,
+            index: i,
+          };
+        }
+        const result = await this._ingestEntryInternal(entry, signerKey);
+        if (!result.ok) {
+          return result;
+        }
       }
-      const result = await this.ingestEntry(entry, signerKey);
-      if (!result.ok) {
-        return result;
-      }
-    }
-    return { ok: true };
+      return { ok: true };
+    });
   }
 
   /**

--- a/packages/collabswarm/src/acl-chain.ts
+++ b/packages/collabswarm/src/acl-chain.ts
@@ -324,9 +324,12 @@ function toHex(bytes: Uint8Array): string {
 }
 
 /**
- * SHA-256 byte length, used to bound the size of `parentHash` and
- * `signerKeyId` fields. Network-supplied entries with unreasonably large
- * byte arrays here would otherwise force large allocations during hashing.
+ * Upper bound on byte length accepted for hash- or key-bytes fields
+ * (`parentHash`, `signerKeyId`). Sized generously above SHA-256's 32-byte
+ * digest and the canonical ECDSA P-384 public-key serialization so the
+ * cap rejects only obviously malformed peer input. Network-supplied
+ * entries with unreasonably large byte arrays here would otherwise force
+ * large allocations during hashing.
  */
 const MAX_HASH_BYTES = 64;
 

--- a/packages/collabswarm/src/acl-chain.ts
+++ b/packages/collabswarm/src/acl-chain.ts
@@ -320,9 +320,15 @@ function canonicalEntryPayloadFromBytes<ChangesType>(
 }
 
 /**
- * Constant-time byte equality. Falls back to a fixed-length loop so we don't
- * leak timing information about which byte differs -- relevant since hashes
- * and signatures are compared on the hot path.
+ * Constant-time byte equality for equal-length inputs.
+ *
+ * Returns `false` immediately when the lengths differ -- timing then
+ * reveals only that the lengths differ, which is not secret here:
+ * every call site compares values with publicly-known structural lengths
+ * (canonical serialized public keys, SHA-256 hash digests). When the
+ * lengths *do* match, the comparison runs a fixed-length XOR loop so we
+ * don't leak which byte differs -- relevant since hashes and signature
+ * key ids are compared on the hot path.
  */
 function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
   if (a.byteLength !== b.byteLength) return false;
@@ -980,14 +986,17 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
 
       for (let i = 0; i < entries.length; i++) {
         const entry = entries[i];
-        // Pre-validate shape so resolveKey isn't called with garbage and
-        // a hostile entry can't crash the loop with a TypeError.
-        const shapeError =
-          entry === null || typeof entry !== 'object'
-            ? 'entry is not an object'
-            : !(entry.signerKeyId instanceof Uint8Array)
-              ? 'signerKeyId is not a Uint8Array'
-              : null;
+        // Pre-validate the full entry shape *before* calling resolveKey.
+        // A hostile snapshot could otherwise supply an arbitrarily large
+        // `signerKeyId` and force `resolveKey` (often a lookup keyed by
+        // that bytestring) to perform expensive work or allocate large
+        // amounts of memory. `validateEntryShape` enforces the
+        // `MAX_SIGNER_KEY_BYTES` bound (along with all other field
+        // bounds), so resolveKey only ever sees a key id of plausible
+        // size. `_ingestEntryInternal` re-runs the same check below; the
+        // redundancy is intentional so this entry point is safe even if
+        // resolveKey misbehaves on hostile input.
+        const shapeError = validateEntryShape(entry);
         if (shapeError !== null) {
           return {
             ok: false,

--- a/packages/collabswarm/src/acl-chain.ts
+++ b/packages/collabswarm/src/acl-chain.ts
@@ -259,7 +259,19 @@ export function canonicalEntryPayload<ChangesType>(
   entry: Omit<ACLEntry<ChangesType>, 'signature'>,
   serializeChange: (change: ChangesType) => Uint8Array,
 ): Uint8Array {
-  const changeBytes = serializeChange(entry.change);
+  return canonicalEntryPayloadFromBytes(entry, serializeChange(entry.change));
+}
+
+/**
+ * Internal helper: build the canonical payload from a pre-serialized `change`
+ * byte buffer. Callers on the network ingestion path serialize and size-gate
+ * the change *before* invoking this so an oversized `change` cannot force a
+ * large header+payload allocation on the hot path.
+ */
+function canonicalEntryPayloadFromBytes<ChangesType>(
+  entry: Omit<ACLEntry<ChangesType>, 'signature' | 'change'>,
+  changeBytes: Uint8Array,
+): Uint8Array {
   const parent = entry.parentHash ?? new Uint8Array(0);
   const signerKey = entry.signerKeyId;
 
@@ -496,8 +508,15 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
   /**
    * Snapshot of the chain's entries. Returns a shallow copy so callers
    * can iterate without risk of seeing live mutations from concurrent
-   * appends. The entries themselves are not deeply copied; do not mutate
-   * the returned objects.
+   * appends.
+   *
+   * The entries themselves are the chain's *internal snapshots* of the
+   * originally-ingested entries (see `_ingestEntryInternal`); their byte
+   * fields are private copies that do not alias caller-owned buffers.
+   * They are still not frozen, so do not mutate the returned objects —
+   * doing so would corrupt subsequent reads through `entries()` and
+   * could desynchronize a serialized chain on the wire from this
+   * instance's view.
    */
   entries(): ReadonlyArray<ACLEntry<ChangesType>> {
     return this._entries.slice();
@@ -693,15 +712,48 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
     //    here; if it throws on hostile input we surface it as a structured
     //    error rather than letting the exception escape.
     //
+    //    We serialize the `change` first and size-gate the result *before*
+    //    assembling the full header+payload buffer. Otherwise an oversized
+    //    network `change` would force the larger allocation in
+    //    `canonicalEntryPayloadFromBytes` (header + parent + signer +
+    //    changeBytes) on the hot path before the size check could run.
+    //
     //    We do not separately deduplicate by hash: any two entries with the
     //    same canonical payload would necessarily share a `sequenceNumber`,
     //    and the sequence check in step 2 already requires
     //    `entry.sequenceNumber === this._entries.length`. A re-ingested
     //    entry therefore can never reach this point with a matching hash.
     let entryHash: Uint8Array;
+    let changeBytes: Uint8Array;
+    try {
+      changeBytes = this._serializeChange(entry.change);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: `failed to serialize change: ${(err as Error).message}`,
+        index,
+      };
+    }
+    if (!(changeBytes instanceof Uint8Array)) {
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: 'serializeChange did not return a Uint8Array',
+        index,
+      };
+    }
+    if (changeBytes.byteLength > MAX_CHANGE_BYTES) {
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: `serialized change exceeds maximum size (${changeBytes.byteLength} > ${MAX_CHANGE_BYTES} bytes)`,
+        index,
+      };
+    }
     let payloadBytes: Uint8Array;
     try {
-      payloadBytes = canonicalEntryPayload(entry, this._serializeChange);
+      payloadBytes = canonicalEntryPayloadFromBytes(entry, changeBytes);
     } catch (err) {
       return {
         ok: false,
@@ -711,7 +763,9 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
       };
     }
     if (payloadBytes.byteLength > MAX_CHANGE_BYTES + 1024) {
-      // 1 KiB slack for the fixed header + parent/signer fields.
+      // 1 KiB slack for the fixed header + parent/signer fields. The
+      // `change` byte length was already gated above; this catches a
+      // pathological `parentHash` / `signerKeyId` combination.
       return {
         ok: false,
         reason: 'malformed-entry',
@@ -822,7 +876,31 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
       };
     }
     this._state = newState;
-    this._entries.push(entry);
+    // Store an immutable snapshot rather than the caller-owned entry
+    // reference. `authorAndAppend` returns the entry it just built, and
+    // `ingestEntry` callers also still hold the same object. Mutating it
+    // afterwards -- e.g. flipping a byte in `signature` or `parentHash` --
+    // would otherwise corrupt the chain's recorded state. Deep-copy the
+    // byte fields we own; `change` is opaque (its concrete type belongs
+    // to the CRDT adapter) so we clone it only when it is itself a
+    // `Uint8Array`, otherwise we rely on the spread to at least isolate
+    // the property slot on our entry object from the caller's.
+    const snapshot: ACLEntry<ChangesType> = {
+      ...entry,
+      parentHash:
+        entry.parentHash === undefined
+          ? undefined
+          : new Uint8Array(entry.parentHash),
+      signerKeyId: new Uint8Array(entry.signerKeyId),
+      signature: new Uint8Array(entry.signature),
+      change:
+        entry.change instanceof Uint8Array
+          ? (new Uint8Array(entry.change) as unknown as ChangesType)
+          : entry.change,
+    };
+    this._entries.push(snapshot);
+    // `entryHash` is freshly allocated locally above (from `crypto.subtle`
+    // output), so no defensive copy is needed.
     this._entryHashes.push(entryHash);
 
     return { ok: true };

--- a/packages/collabswarm/src/acl-chain.ts
+++ b/packages/collabswarm/src/acl-chain.ts
@@ -643,7 +643,11 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
       };
     }
 
-    // 1. Caller-supplied key must match the hash in the entry.
+    // 1. Caller-supplied key must match the canonical key bytes in the entry.
+    //    `entry.signerKeyId` holds the canonical serialized public key
+    //    (produced by `serializeKey`); it is *not* a hash. The genuine
+    //    SHA-256 hash field on entries is `parentHash`. Don't confuse the
+    //    two.
     const declared = entry.signerKeyId;
     let actual: Uint8Array;
     try {
@@ -708,21 +712,52 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
 
     // 4. Canonical-encode and hash the payload. Bound the size up front so
     //    a hostile peer cannot force a large allocation via an oversized
-    //    `change`. `serializeChange` runs over the (still opaque) change
-    //    here; if it throws on hostile input we surface it as a structured
-    //    error rather than letting the exception escape.
+    //    `change`.
     //
-    //    We serialize the `change` first and size-gate the result *before*
-    //    assembling the full header+payload buffer. Otherwise an oversized
-    //    network `change` would force the larger allocation in
-    //    `canonicalEntryPayloadFromBytes` (header + parent + signer +
-    //    changeBytes) on the hot path before the size check could run.
+    //    Defense-in-depth, in order:
+    //
+    //    (a) **Pre-serialize gate.** If `entry.change` is itself a
+    //        `Uint8Array` -- which is the common case (e.g. Yjs encodes
+    //        changes as raw bytes and uses an identity serializer) -- we
+    //        check its `byteLength` *before* calling `_serializeChange`.
+    //        This catches the hostile-peer DoS case where an attacker
+    //        delivers a multi-megabyte buffer: we reject without copying
+    //        or re-encoding it. We do NOT inspect non-`Uint8Array` shapes
+    //        here because that would require walking caller-supplied
+    //        structures of unknown cost.
+    //
+    //    (b) **Post-serialize gate.** For opaque `ChangesType` values
+    //        (e.g. Automerge `BinaryChange[]`, or arbitrary JSON payloads
+    //        for the test serializer) we cannot meaningfully size them
+    //        until they have been serialized. The post-serialize check on
+    //        `changeBytes.byteLength` is the second line of defense for
+    //        those shapes: the allocation has already happened, but the
+    //        chain still refuses to assemble the full header+payload
+    //        buffer (~2x the size) and refuses to verify a signature or
+    //        append the entry. This bounds the worst-case allocation at
+    //        roughly one `MAX_CHANGE_BYTES` buffer per ingestion attempt
+    //        rather than two.
+    //
+    //    `serializeChange` runs over the (still opaque) change here; if
+    //    it throws on hostile input we surface it as a structured error
+    //    rather than letting the exception escape.
     //
     //    We do not separately deduplicate by hash: any two entries with the
     //    same canonical payload would necessarily share a `sequenceNumber`,
     //    and the sequence check in step 2 already requires
     //    `entry.sequenceNumber === this._entries.length`. A re-ingested
     //    entry therefore can never reach this point with a matching hash.
+    if (
+      entry.change instanceof Uint8Array &&
+      entry.change.byteLength > MAX_CHANGE_BYTES
+    ) {
+      return {
+        ok: false,
+        reason: 'malformed-entry',
+        message: `change exceeds maximum size (${entry.change.byteLength} > ${MAX_CHANGE_BYTES} bytes)`,
+        index,
+      };
+    }
     let entryHash: Uint8Array;
     let changeBytes: Uint8Array;
     try {

--- a/packages/collabswarm/src/acl-chain.ts
+++ b/packages/collabswarm/src/acl-chain.ts
@@ -1,0 +1,645 @@
+/**
+ * ACL chain-of-trust verification.
+ *
+ * The existing {@link ACL} interface tracks readers and writers but does not
+ * record *who* authorized each ACL change, nor in what order. This makes it
+ * impossible to detect attacks like:
+ *
+ *   - A former writer (removed via `removeWriter`) crafting ACL changes
+ *     that would have been valid before their removal, then replaying them
+ *     to re-grant themselves access.
+ *   - An attacker re-ordering legitimate ACL changes (e.g. applying a
+ *     "remove Alice" change *after* "add Bob" when Alice was supposed to be
+ *     removed first, so Alice never appears as a co-signer for Bob).
+ *   - Injecting a forged change mid-chain that has no path back to a
+ *     genesis-authorized signer.
+ *
+ * {@link ACLChain} solves these problems by maintaining an append-only,
+ * hash-linked log of {@link ACLEntry}s. Each entry is signed by its author
+ * and references the hash of the previous entry. On append, the chain
+ * verifies:
+ *
+ *   1. The entry's signature matches its declared author.
+ *   2. The author was authorized (i.e. a writer) at the *previous* state.
+ *   3. The entry's `parentHash` matches the current head -- so re-ordering,
+ *      forks, and mid-chain insertion are all rejected.
+ *   4. Sequence numbers strictly increase, catching duplicate / replayed
+ *      entries with mutated timestamps.
+ *
+ * The chain is independent of the {@link ACL} implementation (Yjs, Automerge,
+ * etc.). Callers provide an {@link ACLChainOps} adapter that knows how to
+ * (a) apply an ACL change block to a snapshot of state and (b) check whether
+ * a given public key is authorized as a writer in that snapshot. This keeps
+ * the chain decoupled from any specific CRDT.
+ *
+ * This module does not yet wire into the main {@link CollabswarmDocument}
+ * sync path. It is a self-contained building block; a follow-up PR will
+ * integrate it with `_mergeWriters` and the sync message verification path.
+ */
+
+import type { AuthProvider } from './auth-provider';
+
+/**
+ * Canonical serialization of a public key for use as a stable identifier.
+ *
+ * The same key must always produce the same bytes regardless of how it was
+ * imported, so that signers can be compared across instances. For ECDSA P-384
+ * keys, the SPKI or raw uncompressed point encoding both satisfy this.
+ */
+export type SerializePublicKey<PublicKey> = (
+  key: PublicKey,
+) => Promise<Uint8Array>;
+
+/**
+ * Adapter that the chain uses to talk to a concrete {@link ACL} backend.
+ *
+ * The chain is generic over the ACL change block type (`ChangesType`) and
+ * the public key type (`PublicKey`). It does not itself know how to apply
+ * a change block to an ACL state -- it delegates to this adapter.
+ */
+export interface ACLChainOps<ChangesType, PublicKey> {
+  /**
+   * Construct a fresh, empty ACL state snapshot. Used to replay the chain
+   * from genesis when verifying.
+   */
+  emptyState(): ACLState<ChangesType, PublicKey>;
+
+  /**
+   * Apply a change block to a state snapshot, producing a new snapshot.
+   * Must not mutate the input snapshot -- the chain re-uses snapshots
+   * across verification runs.
+   */
+  applyChange(
+    state: ACLState<ChangesType, PublicKey>,
+    change: ChangesType,
+  ): Promise<ACLState<ChangesType, PublicKey>>;
+
+  /**
+   * Whether the given public key is a writer in the given state.
+   */
+  isWriter(
+    state: ACLState<ChangesType, PublicKey>,
+    publicKey: PublicKey,
+  ): Promise<boolean>;
+}
+
+/**
+ * Opaque snapshot of ACL state at some point in the chain.
+ *
+ * Carried by {@link ACLChainOps} between calls. The chain treats this as a
+ * black box; the adapter is free to use whatever representation it likes
+ * (a wrapped {@link ACL} clone, a serialized blob, an immutable structure).
+ */
+export interface ACLState<_ChangesType, _PublicKey> {
+  /** Marker brand to discourage misuse. */
+  readonly _aclStateBrand?: never;
+}
+
+/**
+ * A single signed entry in the ACL chain.
+ *
+ * The signature covers the canonical encoding of the entry's payload
+ * (`change`, `signerKeyHash`, `sequenceNumber`, `timestamp`, `parentHash`).
+ *
+ * @typeParam ChangesType The CRDT change block type produced by the ACL.
+ */
+export interface ACLEntry<ChangesType> {
+  /**
+   * Strictly increasing sequence number. The first entry must have sequence
+   * `0`; each subsequent entry must be `previous.sequenceNumber + 1`.
+   */
+  sequenceNumber: number;
+
+  /**
+   * Author timestamp in Unix milliseconds. Advisory only -- the chain
+   * does not reject entries solely on timestamp, since clocks may drift.
+   * Used to break ties for human-readable audit logs.
+   */
+  timestamp: number;
+
+  /**
+   * Hash of the previous entry, or `undefined` for the genesis entry.
+   * Hash is computed via {@link computeEntryHash}.
+   */
+  parentHash?: Uint8Array;
+
+  /**
+   * The ACL change block authored by the signer. Opaque to the chain.
+   */
+  change: ChangesType;
+
+  /**
+   * Stable canonical serialization of the signer's public key
+   * (see {@link SerializePublicKey}). The chain uses this for fast
+   * identity comparisons; the actual public key for signature verification
+   * is supplied separately at {@link ACLChain.append} time.
+   */
+  signerKeyHash: Uint8Array;
+
+  /**
+   * Signature over the canonical encoding of all fields above.
+   */
+  signature: Uint8Array;
+}
+
+/**
+ * Failure modes that can be reported when verifying or appending an entry.
+ *
+ * Stable string union so callers can switch on the failure reason.
+ */
+export type ACLChainVerifyError =
+  | 'bad-signature'
+  | 'unauthorized-signer'
+  | 'parent-hash-mismatch'
+  | 'sequence-out-of-order'
+  | 'unknown-signer-key'
+  | 'duplicate-entry'
+  | 'malformed-entry';
+
+/**
+ * Result returned by {@link ACLChain.verifyChain} and the various append
+ * paths. `ok: false` results carry both a structured reason and a human
+ * readable message for logging.
+ */
+export type ACLChainVerifyResult =
+  | { ok: true }
+  | { ok: false; reason: ACLChainVerifyError; message: string; index: number };
+
+/**
+ * Configuration for an {@link ACLChain}.
+ */
+export interface ACLChainConfig<ChangesType, PrivateKey, PublicKey> {
+  /**
+   * Auth provider used for sign / verify operations on entries. The chain
+   * uses the same signing primitive as the rest of SwarmDB so applications
+   * do not need to manage a second key.
+   */
+  auth: AuthProvider<PrivateKey, PublicKey, unknown>;
+
+  /**
+   * Serializer that produces a canonical byte representation of a public
+   * key. The same key must always produce the same bytes.
+   */
+  serializeKey: SerializePublicKey<PublicKey>;
+
+  /**
+   * Adapter that knows how to apply ACL changes and check writer authority
+   * for a specific backend (Yjs, Automerge, etc.).
+   */
+  ops: ACLChainOps<ChangesType, PublicKey>;
+
+  /**
+   * Set of public keys authorized to author the *genesis* entry (i.e. the
+   * first change in the chain). Without a bootstrap root, every chain
+   * would be vacuously verifiable.
+   *
+   * In practice this is the set of founding members for the document.
+   * After the genesis entry is applied, subsequent entries are authorized
+   * against the ACL state produced by the chain itself.
+   */
+  genesisAuthorizedKeys: PublicKey[];
+}
+
+/**
+ * Compute the canonical hash of an {@link ACLEntry}.
+ *
+ * Hashes only the entry's payload fields (everything except the signature),
+ * so the hash is stable for use as a {@link ACLEntry.parentHash} and as a
+ * dedup key.
+ *
+ * The encoding is length-prefixed to avoid ambiguity between adjacent
+ * variable-length fields:
+ *
+ * ```text
+ *   u32 BE sequenceNumber
+ *   u64 BE timestamp (only low 53 bits are meaningful in JS)
+ *   u32 BE parentHash.length || parentHash bytes
+ *   u32 BE signerKeyHash.length || signerKeyHash bytes
+ *   u32 BE change.length || change bytes
+ * ```
+ *
+ * @param entry The entry to hash. The `signature` field is ignored.
+ * @param serializeChange Adapter that converts the opaque `ChangesType` into
+ *   a `Uint8Array` for hashing.
+ */
+export async function computeEntryHash<ChangesType>(
+  entry: Omit<ACLEntry<ChangesType>, 'signature'>,
+  serializeChange: (change: ChangesType) => Uint8Array,
+): Promise<Uint8Array> {
+  const payload = canonicalEntryPayload(entry, serializeChange);
+  const hash = await crypto.subtle.digest(
+    'SHA-256',
+    payload.buffer.slice(payload.byteOffset, payload.byteOffset + payload.byteLength) as ArrayBuffer,
+  );
+  return new Uint8Array(hash);
+}
+
+/**
+ * Canonical byte encoding of an {@link ACLEntry}'s payload (everything
+ * the signature covers). Exported for tests; callers should usually go
+ * through {@link ACLChain.append}.
+ */
+export function canonicalEntryPayload<ChangesType>(
+  entry: Omit<ACLEntry<ChangesType>, 'signature'>,
+  serializeChange: (change: ChangesType) => Uint8Array,
+): Uint8Array {
+  const changeBytes = serializeChange(entry.change);
+  const parent = entry.parentHash ?? new Uint8Array(0);
+  const signerKey = entry.signerKeyHash;
+
+  // Header is fixed-size: u32 seq + u64 ts + 3 u32 length prefixes.
+  const headerLen = 4 + 8 + 4 + 4 + 4;
+  const total =
+    headerLen + parent.byteLength + signerKey.byteLength + changeBytes.byteLength;
+
+  const out = new Uint8Array(total);
+  const view = new DataView(out.buffer);
+  let off = 0;
+
+  view.setUint32(off, entry.sequenceNumber >>> 0, false);
+  off += 4;
+
+  // Split timestamp into hi/lo 32-bit halves so we don't lose precision on
+  // values >2^32. JS numbers are safe to 2^53 so this is sufficient.
+  const ts = entry.timestamp;
+  // Math.floor handles negatives and fractional values defensively.
+  const tsHi = Math.floor(ts / 0x100000000);
+  const tsLo = ts >>> 0;
+  view.setUint32(off, tsHi, false);
+  off += 4;
+  view.setUint32(off, tsLo, false);
+  off += 4;
+
+  view.setUint32(off, parent.byteLength >>> 0, false);
+  off += 4;
+  out.set(parent, off);
+  off += parent.byteLength;
+
+  view.setUint32(off, signerKey.byteLength >>> 0, false);
+  off += 4;
+  out.set(signerKey, off);
+  off += signerKey.byteLength;
+
+  view.setUint32(off, changeBytes.byteLength >>> 0, false);
+  off += 4;
+  out.set(changeBytes, off);
+
+  return out;
+}
+
+/**
+ * Constant-time byte equality. Falls back to a fixed-length loop so we don't
+ * leak timing information about which byte differs -- relevant since hashes
+ * and signatures are compared on the hot path.
+ */
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  let diff = 0;
+  for (let i = 0; i < a.byteLength; i++) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}
+
+/**
+ * Hex-encode a Uint8Array. Used for set keys when comparing identifiers.
+ */
+function toHex(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    s += bytes[i].toString(16).padStart(2, '0');
+  }
+  return s;
+}
+
+/**
+ * An append-only, hash-linked log of signed ACL changes.
+ *
+ * Each entry is verified before being applied:
+ *
+ *   1. Its signature must match its declared signer key.
+ *   2. The signer must be a writer in the state immediately *before* this
+ *      entry (or in {@link ACLChainConfig.genesisAuthorizedKeys} for the
+ *      first entry).
+ *   3. Its `parentHash` must match the hash of the current head.
+ *   4. Its `sequenceNumber` must be exactly the prior length.
+ *
+ * Verified entries are appended and the chain's `state` is advanced.
+ *
+ * @typeParam ChangesType The CRDT change block type produced by the ACL.
+ * @typeParam PrivateKey The private key type used by the auth provider.
+ * @typeParam PublicKey The public key type used by the auth provider.
+ */
+export class ACLChain<ChangesType, PrivateKey, PublicKey> {
+  private readonly _entries: ACLEntry<ChangesType>[] = [];
+  private readonly _entryHashes: Uint8Array[] = [];
+
+  /**
+   * Current ACL state, updated incrementally as entries are appended.
+   * `null` while the chain is still empty.
+   */
+  private _state: ACLState<ChangesType, PublicKey> | null = null;
+
+  /**
+   * Set of entry hashes (hex) seen so far. Used to reject exact duplicates
+   * up front, before doing the more expensive signature work.
+   */
+  private readonly _seenHashes = new Set<string>();
+
+  /** Serializer used both for the change payload and for the AuthProvider. */
+  private readonly _serializeChange: (change: ChangesType) => Uint8Array;
+
+  constructor(
+    private readonly _config: ACLChainConfig<ChangesType, PrivateKey, PublicKey>,
+    /**
+     * Adapter for converting an opaque `ChangesType` to bytes for signing
+     * and hashing. Required because the chain has no direct knowledge of
+     * the CRDT change format.
+     */
+    serializeChange: (change: ChangesType) => Uint8Array,
+  ) {
+    this._serializeChange = serializeChange;
+  }
+
+  /**
+   * Number of entries currently in the chain.
+   */
+  get length(): number {
+    return this._entries.length;
+  }
+
+  /**
+   * Hash of the most recently appended entry, or `undefined` if the chain
+   * is empty.
+   *
+   * Use this as the `parentHash` for the next entry you author.
+   */
+  get headHash(): Uint8Array | undefined {
+    const last = this._entryHashes[this._entryHashes.length - 1];
+    return last ? new Uint8Array(last) : undefined;
+  }
+
+  /**
+   * Snapshot of the chain's entries. Returns a shallow copy so callers
+   * can iterate without risk of seeing live mutations from concurrent
+   * appends. The entries themselves are not deeply copied; do not mutate
+   * the returned objects.
+   */
+  entries(): ReadonlyArray<ACLEntry<ChangesType>> {
+    return this._entries.slice();
+  }
+
+  /**
+   * Build, sign, and append a new entry authored by `signerKey`.
+   *
+   * The signer must currently be authorized (a writer in the chain's
+   * current state, or in `genesisAuthorizedKeys` for the genesis entry).
+   * On success the entry is verified, applied to the chain's internal
+   * state, and returned for transmission to peers.
+   *
+   * @throws Error if the signer is not authorized -- this is a programmer
+   *   error and indicates a misuse of the API, not a network attack.
+   *   Network-supplied entries should be passed through {@link ingestEntry}
+   *   instead, which returns a structured error rather than throwing.
+   */
+  async authorAndAppend(
+    change: ChangesType,
+    signerPublicKey: PublicKey,
+    signerPrivateKey: PrivateKey,
+    timestamp: number = Date.now(),
+  ): Promise<ACLEntry<ChangesType>> {
+    const signerKeyHash = await this._config.serializeKey(signerPublicKey);
+
+    const payload: Omit<ACLEntry<ChangesType>, 'signature'> = {
+      sequenceNumber: this._entries.length,
+      timestamp,
+      parentHash: this.headHash,
+      change,
+      signerKeyHash,
+    };
+
+    const encoded = canonicalEntryPayload(payload, this._serializeChange);
+    const signature = await this._config.auth.sign(encoded, signerPrivateKey);
+
+    const entry: ACLEntry<ChangesType> = { ...payload, signature };
+
+    const result = await this.ingestEntry(entry, signerPublicKey);
+    if (!result.ok) {
+      // Author tried to append an entry they're not allowed to author.
+      // This is a programmer error, not a hostile-input case.
+      throw new Error(
+        `ACLChain.authorAndAppend: refusing to append entry: ${result.reason}: ${result.message}`,
+      );
+    }
+    return entry;
+  }
+
+  /**
+   * Verify and apply a (presumably network-supplied) entry.
+   *
+   * Returns a structured result rather than throwing so callers can log
+   * and discard malicious or stale entries without unwinding their own
+   * control flow.
+   *
+   * @param entry The signed entry to apply.
+   * @param signerPublicKey The public key that the caller claims signed
+   *   `entry`. The chain verifies that this key matches
+   *   `entry.signerKeyHash` (via {@link SerializePublicKey}) AND that it
+   *   actually signed the payload.
+   */
+  async ingestEntry(
+    entry: ACLEntry<ChangesType>,
+    signerPublicKey: PublicKey,
+  ): Promise<ACLChainVerifyResult> {
+    const index = this._entries.length;
+
+    // 1. Caller-supplied key must match the hash in the entry.
+    const declared = entry.signerKeyHash;
+    const actual = await this._config.serializeKey(signerPublicKey);
+    if (!bytesEqual(declared, actual)) {
+      return {
+        ok: false,
+        reason: 'unknown-signer-key',
+        message:
+          'supplied public key does not match the entry.signerKeyHash field',
+        index,
+      };
+    }
+
+    // 2. Sequence numbers must be strictly increasing and contiguous.
+    if (entry.sequenceNumber !== index) {
+      return {
+        ok: false,
+        reason: 'sequence-out-of-order',
+        message: `expected sequenceNumber=${index}, got ${entry.sequenceNumber}`,
+        index,
+      };
+    }
+
+    // 3. Parent hash must match the current head.
+    const head = this.headHash;
+    if (head === undefined) {
+      if (entry.parentHash !== undefined) {
+        return {
+          ok: false,
+          reason: 'parent-hash-mismatch',
+          message: 'genesis entry must not declare a parentHash',
+          index,
+        };
+      }
+    } else {
+      if (entry.parentHash === undefined) {
+        return {
+          ok: false,
+          reason: 'parent-hash-mismatch',
+          message: 'non-genesis entry is missing a parentHash',
+          index,
+        };
+      }
+      if (!bytesEqual(head, entry.parentHash)) {
+        return {
+          ok: false,
+          reason: 'parent-hash-mismatch',
+          message: `parentHash does not match the current chain head`,
+          index,
+        };
+      }
+    }
+
+    // 4. Reject exact duplicates before doing expensive signature work.
+    const entryHash = await computeEntryHash(entry, this._serializeChange);
+    const entryHashHex = toHex(entryHash);
+    if (this._seenHashes.has(entryHashHex)) {
+      return {
+        ok: false,
+        reason: 'duplicate-entry',
+        message: 'entry with this hash has already been ingested',
+        index,
+      };
+    }
+
+    // 5. Signature must verify against the canonical payload.
+    const payloadBytes = canonicalEntryPayload(entry, this._serializeChange);
+    let signatureOk: boolean;
+    try {
+      signatureOk = await this._config.auth.verify(
+        payloadBytes,
+        signerPublicKey,
+        entry.signature,
+      );
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'bad-signature',
+        message: `signature verification threw: ${(err as Error).message}`,
+        index,
+      };
+    }
+    if (!signatureOk) {
+      return {
+        ok: false,
+        reason: 'bad-signature',
+        message: 'signature does not verify against the declared signer',
+        index,
+      };
+    }
+
+    // 6. Authorization: signer must be a writer in the state *before* this
+    //    entry. For the genesis entry, the bootstrap set defines who can
+    //    sign.
+    const priorState = this._state ?? this._config.ops.emptyState();
+    let authorized: boolean;
+    if (this._entries.length === 0) {
+      authorized = await this._isInBootstrapSet(signerPublicKey);
+    } else {
+      authorized = await this._config.ops.isWriter(priorState, signerPublicKey);
+    }
+    if (!authorized) {
+      return {
+        ok: false,
+        reason: 'unauthorized-signer',
+        message:
+          this._entries.length === 0
+            ? 'genesis signer is not in genesisAuthorizedKeys'
+            : 'signer was not a writer at the time this entry was authored',
+        index,
+      };
+    }
+
+    // 7. All checks passed -- apply the change and commit.
+    const newState = await this._config.ops.applyChange(priorState, entry.change);
+    this._state = newState;
+    this._entries.push(entry);
+    this._entryHashes.push(entryHash);
+    this._seenHashes.add(entryHashHex);
+
+    return { ok: true };
+  }
+
+  /**
+   * Re-verify the entire chain from genesis. Used at load time when
+   * receiving a chain snapshot from a peer.
+   *
+   * Stops at the first invalid entry and returns its index. On success
+   * the chain has the same `state` as if every entry had been ingested
+   * individually.
+   *
+   * @param entries The full chain to verify. Each entry's signer key must
+   *   be resolvable via `resolveKey(signerKeyHash)`. If `resolveKey`
+   *   returns `undefined`, the entry is rejected with
+   *   `'unknown-signer-key'`.
+   */
+  async replay(
+    entries: ReadonlyArray<ACLEntry<ChangesType>>,
+    resolveKey: (signerKeyHash: Uint8Array) => Promise<PublicKey | undefined>,
+  ): Promise<ACLChainVerifyResult> {
+    // Reset internal state so callers can use replay() as a "load from
+    // scratch" primitive without constructing a new chain.
+    this._entries.length = 0;
+    this._entryHashes.length = 0;
+    this._seenHashes.clear();
+    this._state = null;
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      const signerKey = await resolveKey(entry.signerKeyHash);
+      if (!signerKey) {
+        return {
+          ok: false,
+          reason: 'unknown-signer-key',
+          message: `no public key available for signerKeyHash at entry ${i}`,
+          index: i,
+        };
+      }
+      const result = await this.ingestEntry(entry, signerKey);
+      if (!result.ok) {
+        return result;
+      }
+    }
+    return { ok: true };
+  }
+
+  /**
+   * Current state of the ACL after applying every entry in the chain.
+   * `undefined` if the chain is empty (no entries have been applied yet).
+   */
+  get state(): ACLState<ChangesType, PublicKey> | undefined {
+    return this._state ?? undefined;
+  }
+
+  /**
+   * Check whether `candidate` matches any key in the bootstrap set.
+   * Compared via the canonical {@link SerializePublicKey} encoding so
+   * imported / re-imported key objects compare equal.
+   */
+  private async _isInBootstrapSet(candidate: PublicKey): Promise<boolean> {
+    const candidateBytes = await this._config.serializeKey(candidate);
+    for (const allowed of this._config.genesisAuthorizedKeys) {
+      const allowedBytes = await this._config.serializeKey(allowed);
+      if (bytesEqual(candidateBytes, allowedBytes)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/packages/collabswarm/src/acl-chain.ts
+++ b/packages/collabswarm/src/acl-chain.ts
@@ -99,7 +99,7 @@ export interface ACLState<_ChangesType, _PublicKey> {
  * A single signed entry in the ACL chain.
  *
  * The signature covers the canonical encoding of the entry's payload
- * (`change`, `signerKeyHash`, `sequenceNumber`, `timestamp`, `parentHash`).
+ * (`change`, `signerKeyId`, `sequenceNumber`, `timestamp`, `parentHash`).
  *
  * @typeParam ChangesType The CRDT change block type produced by the ACL.
  */
@@ -112,8 +112,10 @@ export interface ACLEntry<ChangesType> {
 
   /**
    * Author timestamp in Unix milliseconds. Advisory only -- the chain
-   * does not reject entries solely on timestamp, since clocks may drift.
-   * Used to break ties for human-readable audit logs.
+   * does not reject entries based on the *value* of the timestamp (since
+   * clocks may drift); it only requires the value to be a non-negative
+   * safe integer so the canonical encoding is unambiguous. Used to break
+   * ties for human-readable audit logs.
    */
   timestamp: number;
 
@@ -129,13 +131,15 @@ export interface ACLEntry<ChangesType> {
   change: ChangesType;
 
   /**
-   * Stable canonical serialization of the signer's public key
-   * (see {@link SerializePublicKey}). The chain uses this for fast
-   * identity comparisons; the actual public key for signature verification
-   * is supplied separately at {@link ACLChain.authorAndAppend} /
-   * {@link ACLChain.ingestEntry} time.
+   * Stable canonical identifier for the signer's public key.
+   *
+   * These are the raw bytes produced by {@link SerializePublicKey} (e.g. an
+   * SPKI or raw-point encoding of the key) -- *not* a cryptographic digest
+   * of those bytes. The chain uses this for fast identity comparisons; the
+   * actual public key for signature verification is supplied separately at
+   * {@link ACLChain.authorAndAppend} / {@link ACLChain.ingestEntry} time.
    */
-  signerKeyHash: Uint8Array;
+  signerKeyId: Uint8Array;
 
   /**
    * Signature over the canonical encoding of all fields above.
@@ -215,7 +219,7 @@ export interface ACLChainConfig<ChangesType, PrivateKey, PublicKey> {
  *   u32 BE sequenceNumber
  *   u64 BE timestamp (only low 53 bits are meaningful in JS)
  *   u32 BE parentHash.length || parentHash bytes
- *   u32 BE signerKeyHash.length || signerKeyHash bytes
+ *   u32 BE signerKeyId.length || signerKeyId bytes
  *   u32 BE change.length || change bytes
  * ```
  *
@@ -248,7 +252,7 @@ export function canonicalEntryPayload<ChangesType>(
 ): Uint8Array {
   const changeBytes = serializeChange(entry.change);
   const parent = entry.parentHash ?? new Uint8Array(0);
-  const signerKey = entry.signerKeyHash;
+  const signerKey = entry.signerKeyId;
 
   // Header is fixed-size: u32 seq + u64 ts + 3 u32 length prefixes.
   const headerLen = 4 + 8 + 4 + 4 + 4;
@@ -264,8 +268,12 @@ export function canonicalEntryPayload<ChangesType>(
 
   // Split timestamp into hi/lo 32-bit halves so we don't lose precision on
   // values >2^32. JS numbers are safe to 2^53 so this is sufficient.
+  // `validateEntryShape` enforces that this is a non-negative safe integer
+  // before we get here, so the hi/lo split is unambiguous. We keep the
+  // `Math.floor` and `>>> 0` calls as defensive belt-and-braces for the
+  // (test-only) code paths that construct payloads without going through
+  // ingestion.
   const ts = entry.timestamp;
-  // Math.floor handles negatives and fractional values defensively.
   const tsHi = Math.floor(ts / 0x100000000);
   const tsLo = ts >>> 0;
   view.setUint32(off, tsHi, false);
@@ -317,7 +325,7 @@ function toHex(bytes: Uint8Array): string {
 
 /**
  * SHA-256 byte length, used to bound the size of `parentHash` and
- * `signerKeyHash` fields. Network-supplied entries with unreasonably large
+ * `signerKeyId` fields. Network-supplied entries with unreasonably large
  * byte arrays here would otherwise force large allocations during hashing.
  */
 const MAX_HASH_BYTES = 64;
@@ -351,22 +359,30 @@ function validateEntryShape<ChangesType>(
   ) {
     return 'sequenceNumber is not a non-negative safe integer';
   }
+  // `timestamp` is encoded as two unsigned 32-bit halves in
+  // `canonicalEntryPayload`. Fractional values would be silently truncated
+  // and negative values would wrap to enormous unsigned ints, both of which
+  // would let a hostile peer manufacture two *different* timestamp values
+  // that produce identical canonical bytes (and therefore identical
+  // signatures). Reject anything that isn't a non-negative safe integer.
   if (
     typeof entry.timestamp !== 'number' ||
-    !Number.isFinite(entry.timestamp)
+    !Number.isInteger(entry.timestamp) ||
+    entry.timestamp < 0 ||
+    entry.timestamp > Number.MAX_SAFE_INTEGER
   ) {
-    return 'timestamp is not a finite number';
+    return 'timestamp is not a non-negative safe integer';
   }
-  if (!(entry.signerKeyHash instanceof Uint8Array)) {
-    return 'signerKeyHash is not a Uint8Array';
+  if (!(entry.signerKeyId instanceof Uint8Array)) {
+    return 'signerKeyId is not a Uint8Array';
   }
   if (
-    entry.signerKeyHash.byteLength === 0 ||
-    entry.signerKeyHash.byteLength > MAX_HASH_BYTES * 4
+    entry.signerKeyId.byteLength === 0 ||
+    entry.signerKeyId.byteLength > MAX_HASH_BYTES * 4
   ) {
     // Public key encodings are a couple hundred bytes at most; reject
     // anything wildly out of range.
-    return 'signerKeyHash has an implausible length';
+    return 'signerKeyId has an implausible length';
   }
   if (!(entry.signature instanceof Uint8Array)) {
     return 'signature is not a Uint8Array';
@@ -520,14 +536,14 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
     timestamp: number = Date.now(),
   ): Promise<ACLEntry<ChangesType>> {
     return this._runExclusive(async () => {
-      const signerKeyHash = await this._config.serializeKey(signerPublicKey);
+      const signerKeyId = await this._config.serializeKey(signerPublicKey);
 
       const payload: Omit<ACLEntry<ChangesType>, 'signature'> = {
         sequenceNumber: this._entries.length,
         timestamp,
         parentHash: this.headHash,
         change,
-        signerKeyHash,
+        signerKeyId,
       };
 
       const encoded = canonicalEntryPayload(payload, this._serializeChange);
@@ -563,7 +579,7 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
    * @param entry The signed entry to apply.
    * @param signerPublicKey The public key that the caller claims signed
    *   `entry`. The chain verifies that this key matches
-   *   `entry.signerKeyHash` (via {@link SerializePublicKey}) AND that it
+   *   `entry.signerKeyId` (via {@link SerializePublicKey}) AND that it
    *   actually signed the payload.
    */
   async ingestEntry(
@@ -601,7 +617,7 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
     }
 
     // 1. Caller-supplied key must match the hash in the entry.
-    const declared = entry.signerKeyHash;
+    const declared = entry.signerKeyId;
     let actual: Uint8Array;
     try {
       actual = await this._config.serializeKey(signerPublicKey);
@@ -618,7 +634,7 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
         ok: false,
         reason: 'unknown-signer-key',
         message:
-          'supplied public key does not match the entry.signerKeyHash field',
+          'supplied public key does not match the entry.signerKeyId field',
         index,
       };
     }
@@ -820,13 +836,13 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
    * throughout the replay.
    *
    * @param entries The full chain to verify. Each entry's signer key must
-   *   be resolvable via `resolveKey(signerKeyHash)`. If `resolveKey`
+   *   be resolvable via `resolveKey(signerKeyId)`. If `resolveKey`
    *   returns `undefined`, the entry is rejected with
    *   `'unknown-signer-key'`.
    */
   async replay(
     entries: ReadonlyArray<ACLEntry<ChangesType>>,
-    resolveKey: (signerKeyHash: Uint8Array) => Promise<PublicKey | undefined>,
+    resolveKey: (signerKeyId: Uint8Array) => Promise<PublicKey | undefined>,
   ): Promise<ACLChainVerifyResult> {
     return this._runExclusive(async () => {
       // Reset internal state so callers can use replay() as a "load from
@@ -843,8 +859,8 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
         const shapeError =
           entry === null || typeof entry !== 'object'
             ? 'entry is not an object'
-            : !(entry.signerKeyHash instanceof Uint8Array)
-              ? 'signerKeyHash is not a Uint8Array'
+            : !(entry.signerKeyId instanceof Uint8Array)
+              ? 'signerKeyId is not a Uint8Array'
               : null;
         if (shapeError !== null) {
           return {
@@ -856,7 +872,7 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
         }
         let signerKey: PublicKey | undefined;
         try {
-          signerKey = await resolveKey(entry.signerKeyHash);
+          signerKey = await resolveKey(entry.signerKeyId);
         } catch (err) {
           return {
             ok: false,
@@ -869,7 +885,7 @@ export class ACLChain<ChangesType, PrivateKey, PublicKey> {
           return {
             ok: false,
             reason: 'unknown-signer-key',
-            message: `no public key available for signerKeyHash at entry ${i}`,
+            message: `no public key available for signerKeyId at entry ${i}`,
             index: i,
           };
         }

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -77,6 +77,11 @@ import {
   UCANACL,
   UCANACLProvider,
 } from './ucan-acl';
+import {
+  ACLChain,
+  canonicalEntryPayload,
+  computeEntryHash,
+} from './acl-chain';
 import { NetworkStats } from './network-stats';
 import { LRUCache } from './lru-cache';
 import { bloomFilterUpdateV1 } from './wire-protocols';
@@ -151,6 +156,10 @@ export {
   // UCAN ACL
   UCANACL,
   UCANACLProvider,
+  // ACL chain-of-trust
+  ACLChain,
+  canonicalEntryPayload,
+  computeEntryHash,
   // Wire protocols
   bloomFilterUpdateV1,
   // Compaction
@@ -172,3 +181,12 @@ export type { UCAN, UCANCapability, UCANPayload } from './ucan';
 export type { UCANACLEntry } from './ucan-acl';
 export type { CRDTSnapshotNode } from './snapshot-node';
 export type { CompactionConfig } from './compaction-config';
+export type {
+  ACLChainConfig,
+  ACLChainOps,
+  ACLChainVerifyError,
+  ACLChainVerifyResult,
+  ACLEntry,
+  ACLState,
+  SerializePublicKey,
+} from './acl-chain';


### PR DESCRIPTION
## Summary

First phase of WS-4 (#186). Adds an `ACLChain` class that maintains an append-only, hash-linked log of signed ACL changes, with verification that each entry's signer was authorized as a writer at the time the entry was authored.

This is delivered as a self-contained module (`packages/collabswarm/src/acl-chain.ts`) that composes with the existing `AuthProvider` and a thin `ACLChainOps` adapter; it does **not** yet wire into `CollabswarmDocument`'s sync path. Phase 2 will integrate it with `_mergeWriters` and `_applyACLFromTree`.

## Scope decision: B (ACL chain-of-trust)

### MLS library landscape

- `@river-build/mls-rs-wasm` exists on npm (latest v0.0.16, last published **January 14, 2025** — over a year stale at the time of this PR). Package description and README warn it is primarily tested in headless Chrome; the JS API surface is undocumented beyond "wraps `mls_rs_wasm.js`".
- `@xmtp/mls-client` is alive but tied to the XMTP network stack and assumes XMTP's identity/credential model.
- `mls-ts` and other small TS-MLS forks are unmaintained.
- A direct WASM build of OpenMLS or mls-rs would mean owning the build pipeline — well out of scope for a Phase 1 PR.

Crucially, **the repo already contains a working BeeKEM implementation** (`packages/collabswarm/src/beekem/`, ~1100 LOC + tests) that delivers MLS-style ratchet-tree group key agreement with forward secrecy. The remaining work to deliver "MLS-based auth" is not a new key-agreement core — it's wiring BeeKEM into the `AuthProvider`/`KeychainProvider`/`CollabswarmDocument` flows, designing the wire protocol for path updates and welcomes, persisting group state, and updating member-add/remove handlers. That is firmly larger than a Phase 1 slice.

Given (a) a stale upstream MLS lib, (b) BeeKEM already present, and (c) the issue explicitly listing ACL chain-of-trust as a separate WS-4 deliverable, **Scope B is the more valuable, deliverable, and bounded Phase 1.** It closes a real security hole independent of any MLS work.

### The attack we're fixing

The existing `ACL` (in `packages/collabswarm/src/acl.ts`) tracks readers/writers via a CRDT (Yjs or Automerge) but the change blocks themselves are not individually signed and there is no record of *who* authorized each ACL change or in what order. Sync messages are signed at the message level, but a former writer who held their private key can still:

1. **Replay attack** — re-broadcast an ACL change that was valid before their removal (or craft a fresh one) and have other peers accept it as authoritative.
2. **Reorder / fork** — present a different history of ACL changes to different peers.
3. **Mid-chain insertion** — splice a forged entry between two legitimate ones.

`ACLChain` defends against all three by hash-linking entries, signing each entry individually, and verifying authorization against the state immediately prior to each entry.

## What's implemented

- **`ACLChain<ChangesType, PrivateKey, PublicKey>`** — append-only hash-linked log with `authorAndAppend()`, `ingestEntry()`, and `replay()` operations.
- **`ACLEntry<ChangesType>`** — canonical entry shape: `sequenceNumber`, `timestamp`, `parentHash`, `change`, `signerKeyId`, `signature`.
- **`canonicalEntryPayload()` / `computeEntryHash()`** — length-prefixed canonical encoding so entries with overlapping byte sequences cannot collide; SHA-256 of payload for `parentHash`.
- **`ACLChainOps<ChangesType, PublicKey>`** adapter interface so the chain stays decoupled from any specific CRDT backend (Yjs, Automerge, UCAN, etc.).
- **`ACLChainVerifyError`** — structured failure reasons (`bad-signature`, `unauthorized-signer`, `parent-hash-mismatch`, `sequence-out-of-order`, `unknown-signer-key`, `malformed-entry`) so callers can log and discard hostile entries without throwing. Hash-based duplicate detection was intentionally removed because the strict `sequenceNumber === head.sequenceNumber + 1` check (surfaced as `sequence-out-of-order`) is strictly stronger: any duplicate entry is necessarily a sequence violation, so a separate `duplicate-entry` variant added no coverage.
- **Bootstrap set** — `genesisAuthorizedKeys` defines who is allowed to author the very first entry (the founding members).
- **Constant-time byte equality** for signature/hash comparisons on the hot path.

### Public API surface added to `index.ts`

- value exports: `ACLChain`, `canonicalEntryPayload`, `computeEntryHash`
- type exports: `ACLChainConfig`, `ACLChainOps`, `ACLChainVerifyError`, `ACLChainVerifyResult`, `ACLEntry`, `ACLState`, `SerializePublicKey`

No existing exports were modified or removed.

## What's deliberately left for follow-up PRs

- **Phase 2 (integration)** — wire `ACLChain` into `CollabswarmDocument._mergeWriters`, `_addWriter`, `_removeWriter`, and `_applyACLFromTree`. Today the chain is dormant; you can build one manually but the sync pipeline still goes through the unverified `ACL.merge` path.
- **Provider adapter implementations** — `YjsACLChainOps` and `AutomergeACLChainOps` (concrete `ACLChainOps`) belong in their respective provider packages. Trivial to write once integration design is settled.
- **MLS / BeeKEM integration with `AuthProvider`** — the rest of WS-4. BeeKEM is already in-tree and tested; the remaining lift is auth provider wiring, wire protocol, and persistence.
- **Initial-load quorum verification** (item #4 of #186) — needs a quorum policy before it can be wired.
- **ZKP evaluation** (item #6 of #186) — independent research task.

## Test plan

19 new unit tests in `packages/collabswarm/src/acl-chain.test.ts`, all passing:

- [x] Canonical encoding: every field affects the hash; length prefixing prevents boundary ambiguity.
- [x] Legitimate chain: genesis member self-bootstrap; writer-adds-writer-adds-writer transitive case; `parentHash` correctly links.
- [x] Rejection — unauthorized signer: non-genesis key cannot author genesis; non-writer cannot author; *removed writer cannot replay* (the headline attack); historical replay against fresh chain rejected.
- [x] Rejection — tampering / replay: single-byte tamper invalidates signature; signer substitution caught up front; duplicate ingest blocked; fork at common parent — first one wins; mid-chain malicious insertion rejected; sequence-skip rejected.
- [x] `replay()` round-trip + hostile-entry replay rejection + missing-key rejection.
- [x] `headHash` returns a copy callers cannot mutate.

Verified locally:
- [x] `yarn workspace @collabswarm/collabswarm tsc` — clean
- [x] `yarn workspace @collabswarm/collabswarm test` — 329/329 pass (existing 310 + 19 new)
- [x] `yarn workspace @collabswarm/collabswarm-yjs test` — 39/39 pass
- [x] `yarn workspace @collabswarm/collabswarm-automerge test` — 24/24 pass
- [x] `tsc` of `@collabswarm/collabswarm{,-yjs,-automerge,-react,-redux}` — all clean

Pre-existing TypeScript errors in `@collabswarm/browser-test`, `@collabswarm/password-manager`, and `@collabswarm/wiki-swarm` example apps (missing `testing-library__jest-dom` types) are unrelated to this PR; they reproduce on `origin/main` at `412195b`.

## References

Issue #186 (WS-4 umbrella). This PR is Phase 1 only — does **not** close the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cryptographically-signed access control chain with full entry verification, signature validation, and authorization checks
  * Included comprehensive tamper and replay detection with sequence validation, parent-hash linking, and signature verification
  * Implemented concurrent operation safety through queued mutations ensuring proper sequencing
  * Added chain replay functionality for full validation and state reconstruction from historical entries

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/swarmbase/swarmbase/pull/265)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
