### PR TITLE
Declare uuid as a direct dependency of @collabswarm/collabswarm

### DIFF
--- a/packages/collabswarm/package.json
+++ b/packages/collabswarm/package.json
@@ -76,7 +76,8 @@
     "js-base64": "^3.7.8",
     "libp2p": "^2.10.0",
     "multiformats": "^13.4.2",
-    "uint8arraylist": "^2.4.8"
+    "uint8arraylist": "^2.4.8",
+    "uuid": "^10.0.0"
   },
   "gitHead": "5d48e475ac53ef5920423d3a22a4e19201e607a1",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,6 +2035,7 @@ __metadata:
     typedoc: "npm:^0.26.7"
     typescript: "npm:^5.9.3"
     uint8arraylist: "npm:^2.4.8"
+    uuid: "npm:^10.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

`packages/collabswarm/src/collabswarm-document.ts:41` imports `uuid` directly, but `packages/collabswarm/package.json` doesn't declare it. The import currently works because `uuid` happens to be a transitive dependency of other packages we depend on (e.g. libp2p tooling) — that's a latent bug surfaced during triage of Dependabot PRs #250/#251.

If a transitive provider drops `uuid` or changes major versions in an incompatible way, the import silently breaks. Declaring the dependency directly makes the requirement explicit and gives us a single, predictable version pin to upgrade.

## Changes

- Added `"uuid": "^10.0.0"` to `dependencies` in `packages/collabswarm/package.json` (matches the range already used by `collabswarm-automerge`).
- `yarn.lock` updated by `yarn install`.

## Test plan

- [x] `yarn workspace @collabswarm/collabswarm tsc` — clean.
- [x] `yarn workspace @collabswarm/collabswarm test` — 310/310 pass (no behavior change, just declaring the existing implicit dep).