### PR TITLE
Clean up legacy notes and 'backward compatibility' framing

### DIFF
--- a/notes/TODO-2021-07-28.md
+++ b/notes/TODO-2021-07-28.md
@@ -1,3 +1,0 @@
-- Send current document key along with sync messages
-- Save current document key with change block
-- Add/remove readers

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -245,7 +245,7 @@ export interface CollabswarmConfig {
    * traffic on the pubsub mesh and avoid collisions with other topic types.
    *
    * Set to an empty string (`''`) to disable prefixing; topic strings
-   * will be the bare document path (legacy behavior).
+   * will be the bare document path.
    *
    * @default DEFAULT_DOCUMENT_TOPIC_PREFIX
    */

--- a/packages/collabswarm/src/document-topic.ts
+++ b/packages/collabswarm/src/document-topic.ts
@@ -8,10 +8,7 @@ export const DEFAULT_DOCUMENT_TOPIC_PREFIX = '/document/';
  *
  * The default prefix is `'/document/'`, which namespaces document traffic
  * on the pubsub mesh. Pass an empty string to disable prefixing (the topic
- * will be the bare document path, matching legacy behavior).
- *
- * **Edge case:** An empty string (`''`) prefix returns `documentPath`
- * unchanged. This is intentional for backward compatibility.
+ * will be the bare document path).
  *
  * @param documentPath - The path identifying the document.
  * @param topicPrefix - Prefix to prepend (defaults to `'/document/'`).
@@ -21,8 +18,6 @@ export function documentTopic(
   documentPath: string,
   topicPrefix: string = DEFAULT_DOCUMENT_TOPIC_PREFIX,
 ): string {
-  // When the prefix is empty, return the path unchanged to preserve
-  // backward-compatible topic strings.
   if (topicPrefix === '') {
     return documentPath;
   }

--- a/packages/collabswarm/src/keychain.ts
+++ b/packages/collabswarm/src/keychain.ts
@@ -1,9 +1,9 @@
 /**
  * A keychain contains a CollabswarmDocument's encryption keys.
  *
- * Keys are identified by a key ID. In the legacy model, key IDs are 16-byte
- * UUID v4 values. In the epoch-based model, key IDs are 32-byte SHA-256
- * hashes (epoch IDs).
+ * Keys are identified by a key ID. Two key-ID schemes coexist: 16-byte UUID v4
+ * values (used by `add()` for keys not tied to a specific epoch) and 32-byte
+ * SHA-256 hashes from `addEpochKey()` for epoch-based key management.
  *
  * @typeParam KeychainChange Type of a block of change(s) describing edits made to the document keychain.
  * @typeParam DocumentKey Type of a document encryption key.


### PR DESCRIPTION
## Summary

- Delete `notes/TODO-2021-07-28.md` (5-year-old, all items shipped — current document key sending, change blocks, and reader management are all in place)
- Rephrase "legacy model"/"legacy behavior" wording in `keychain.ts`, `document-topic.ts`, and `collabswarm-config.ts` to neutral descriptions of the current dual API (no runtime change)

The keychain has two coexisting key-ID schemes (16-byte UUID v4 from `add()` and 32-byte epoch hash from `addEpochKey()`); neither is deprecated, so calling the UUID one "legacy" was misleading. The empty-string topic prefix is also a supported configuration, not a legacy hack.

## Test plan

- [x] No runtime changes; tests should pass unchanged