### PR TITLE
Add NAT traversal resilience tests (#184)

### DIFF
--- a/e2e/integration/helpers/nat-helpers.ts
+++ b/e2e/integration/helpers/nat-helpers.ts
@@ -175,13 +175,19 @@ export async function initPage(
  * previous tracker (removes its `page.on('console', ...)` listener and
  * clears its buffer) so listeners don't accumulate across multiple reloads.
  *
- * The new tracker is attached synchronously so callers can listen for output
- * emitted by the reloaded page. The returned handle's `peerId` is NOT yet
- * refreshed — call `refreshPeerId(handle)` after triggering `page.reload()`
- * to update it, since the test app generates a new libp2p node (and thus a
- * new peerId) on every reload.
+ * Named explicitly: this ONLY rebinds the console tracker. The returned
+ * handle's `peerId` is NOT refreshed and will be stale once the page
+ * reloads — the test app generates a fresh libp2p node (and thus a new
+ * peer ID) on every reload. Call `refreshPeerId(handle)` after triggering
+ * `page.reload()` to update it.
+ *
+ * Folding the peer-ID refresh into this helper isn't viable: this must be
+ * called BEFORE `page.reload()` so the new tracker is attached in time to
+ * observe the post-reload `PEER_ID:` log line, but the refresh itself
+ * must happen AFTER reload. Keeping them as two calls preserves correct
+ * ordering and makes the staleness window explicit at call sites.
  */
-export function rebindTracker(handle: PageHandle): PageHandle {
+export function rebindConsoleTracker(handle: PageHandle): PageHandle {
   handle.track.dispose();
   return { ...handle, track: trackConsole(handle.page) };
 }
@@ -193,8 +199,8 @@ export function rebindTracker(handle: PageHandle): PageHandle {
  * generates a new peerId — the prior value on the handle becomes stale.
  *
  * Expects `handle.track` to be a tracker attached before the reload was
- * triggered (e.g. via `rebindTracker`) so the `PEER_ID:` emission isn't
- * missed.
+ * triggered (e.g. via `rebindConsoleTracker`) so the `PEER_ID:` emission
+ * isn't missed.
  */
 export async function refreshPeerId(
   handle: PageHandle,

--- a/e2e/integration/helpers/nat-helpers.ts
+++ b/e2e/integration/helpers/nat-helpers.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared NAT integration-test helpers.
+ *
+ * Used by both `nat-traversal.spec.ts` (baseline cross-NAT sync) and
+ * `nat-resilience.spec.ts` (failure-recovery scenarios). Extracted so the
+ * two suites can't drift on tracker semantics, init timeouts, mesh waits,
+ * etc.
+ */
+import type { Browser, BrowserContext, ConsoleMessage, Page } from '@playwright/test';
+
+/**
+ * Default timeout for `track.waitFor('PEER_ID:', ...)` inside `initPage`.
+ *
+ * `INIT_COMPLETE` is emitted immediately before `PEER_ID:` in the test app's
+ * bootstrap (see `e2e/test-app/src/main.ts`), so under normal conditions this
+ * resolves synchronously from the buffered messages. We still want a real
+ * timeout in case the buffer is racing with a slow page on a loaded CI box.
+ */
+export const PEER_ID_WAIT_MS = 30_000;
+
+/** Default `INIT_COMPLETE` wait (test app boots libp2p before firing this). */
+export const INIT_COMPLETE_WAIT_MS = 90_000;
+
+/** Track console messages from a page; supports awaiting on prefixes. */
+export function trackConsole(page: Page) {
+  const messages: string[] = [];
+  const collector = (msg: ConsoleMessage) => messages.push(msg.text());
+  page.on('console', collector);
+
+  return {
+    messages,
+    has(prefix: string): boolean {
+      return messages.some(m => m.startsWith(prefix));
+    },
+    waitFor(prefix: string, timeout = 60_000): Promise<string> {
+      const existing = messages.find(m => m.startsWith(prefix));
+      if (existing) return Promise.resolve(existing);
+
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          page.off('console', handler);
+          reject(new Error(
+            `Timeout (${timeout}ms) waiting for console: "${prefix}"\n` +
+            `Collected ${messages.length} messages:\n${messages.slice(-20).join('\n')}`,
+          ));
+        }, timeout);
+        const handler = (msg: ConsoleMessage) => {
+          if (msg.text().startsWith(prefix)) {
+            clearTimeout(timer);
+            page.off('console', handler);
+            resolve(msg.text());
+          }
+        };
+        page.on('console', handler);
+      });
+    },
+    /** Wait for at least `count` messages with the given prefix. */
+    waitForCount(prefix: string, count: number, timeout = 60_000): Promise<string[]> {
+      const matched = () => messages.filter(m => m.startsWith(prefix));
+      if (matched().length >= count) return Promise.resolve(matched().slice(0, count));
+
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          page.off('console', handler);
+          const found = matched();
+          reject(new Error(
+            `Timeout (${timeout}ms) waiting for ${count} "${prefix}" messages (got ${found.length})\n` +
+            `Collected ${messages.length} messages:\n${messages.slice(-20).join('\n')}`,
+          ));
+        }, timeout);
+        const handler = (_msg: ConsoleMessage) => {
+          const found = matched();
+          if (found.length >= count) {
+            clearTimeout(timer);
+            page.off('console', handler);
+            resolve(found.slice(0, count));
+          }
+        };
+        page.on('console', handler);
+      });
+    },
+    /** Detach the console listener and clear the buffer. Safe to call more than once. */
+    dispose() {
+      page.off('console', collector);
+      messages.length = 0;
+    },
+  };
+}
+
+export type ConsoleTracker = ReturnType<typeof trackConsole>;
+
+export interface PageHandle {
+  page: Page;
+  track: ConsoleTracker;
+  context: BrowserContext;
+  peerId: string;
+}
+
+/**
+ * Open a new browser context + page at `url`, attach a console tracker, and
+ * wait for the test app to publish `INIT_COMPLETE` and `PEER_ID:`.
+ *
+ * `peerIdTimeoutMs` defaults to `PEER_ID_WAIT_MS` so the resilience suite
+ * stays in lockstep with the baseline NAT suite on slower machines.
+ */
+export async function initPage(
+  browser: Browser,
+  url: string,
+  opts: { initTimeoutMs?: number; peerIdTimeoutMs?: number } = {},
+): Promise<PageHandle> {
+  const initTimeoutMs = opts.initTimeoutMs ?? INIT_COMPLETE_WAIT_MS;
+  const peerIdTimeoutMs = opts.peerIdTimeoutMs ?? PEER_ID_WAIT_MS;
+
+  const context = await browser.newContext();
+  try {
+    const page = await context.newPage();
+    const track = trackConsole(page);
+    await page.goto(url);
+    await track.waitFor('INIT_COMPLETE', initTimeoutMs);
+    const peerIdMsg = await track.waitFor('PEER_ID:', peerIdTimeoutMs);
+    const peerId = peerIdMsg.replace('PEER_ID:', '').trim();
+    return { page, track, context, peerId };
+  } catch (err) {
+    await context.close();
+    throw err;
+  }
+}
+
+/**
+ * Replace the in-page console tracker after a page reload. Disposes the
+ * previous tracker (removes its `page.on('console', ...)` listener and
+ * clears its buffer) so listeners don't accumulate across multiple reloads.
+ */
+export function rebindTracker(handle: PageHandle): PageHandle {
+  handle.track.dispose();
+  return { ...handle, track: trackConsole(handle.page) };
+}
+
+/**
+ * Wait for at least 1 `PEER_CONNECTED:` console message.
+ * In CI's Docker environment only one connection event fires reliably.
+ */
+export async function waitForPeerConnection(track: ConsoleTracker, timeout = 90_000) {
+  await track.waitFor('PEER_CONNECTED:', timeout);
+}
+
+/**
+ * Idle wait used after `PEER_CONNECTED:` to let the GossipSub mesh stabilize
+ * before exchanging messages. Mesh formation through a single relay takes
+ * ~10s in steady state.
+ */
+export async function waitForMesh(page: Page, ms = 10_000) {
+  await page.waitForTimeout(ms);
+}

--- a/e2e/integration/helpers/nat-helpers.ts
+++ b/e2e/integration/helpers/nat-helpers.ts
@@ -174,10 +174,35 @@ export async function initPage(
  * Replace the in-page console tracker after a page reload. Disposes the
  * previous tracker (removes its `page.on('console', ...)` listener and
  * clears its buffer) so listeners don't accumulate across multiple reloads.
+ *
+ * The new tracker is attached synchronously so callers can listen for output
+ * emitted by the reloaded page. The returned handle's `peerId` is NOT yet
+ * refreshed — call `refreshPeerId(handle)` after triggering `page.reload()`
+ * to update it, since the test app generates a new libp2p node (and thus a
+ * new peerId) on every reload.
  */
 export function rebindTracker(handle: PageHandle): PageHandle {
   handle.track.dispose();
   return { ...handle, track: trackConsole(handle.page) };
+}
+
+/**
+ * Await a fresh `PEER_ID:` log line from the (re)loaded page and return a
+ * handle with `peerId` updated to match. Use this after `page.reload()` (or
+ * any flow that restarts the test app's libp2p node) since each restart
+ * generates a new peerId — the prior value on the handle becomes stale.
+ *
+ * Expects `handle.track` to be a tracker attached before the reload was
+ * triggered (e.g. via `rebindTracker`) so the `PEER_ID:` emission isn't
+ * missed.
+ */
+export async function refreshPeerId(
+  handle: PageHandle,
+  timeoutMs = PEER_ID_WAIT_MS,
+): Promise<PageHandle> {
+  const peerIdMsg = await handle.track.waitFor('PEER_ID:', timeoutMs);
+  const peerId = peerIdMsg.replace('PEER_ID:', '').trim();
+  return { ...handle, peerId };
 }
 
 /**

--- a/e2e/integration/helpers/nat-helpers.ts
+++ b/e2e/integration/helpers/nat-helpers.ts
@@ -11,10 +11,13 @@ import type { Browser, BrowserContext, ConsoleMessage, Page } from '@playwright/
 /**
  * Default timeout for `track.waitFor('PEER_ID:', ...)` inside `initPage`.
  *
- * `INIT_COMPLETE` is emitted immediately before `PEER_ID:` in the test app's
- * bootstrap (see `e2e/test-app/src/main.ts`), so under normal conditions this
- * resolves synchronously from the buffered messages. We still want a real
- * timeout in case the buffer is racing with a slow page on a loaded CI box.
+ * In the test app's bootstrap (see `e2e/test-app/app.js`), `PEER_ID:` is
+ * logged immediately after the libp2p node is created, while `INIT_COMPLETE`
+ * is logged later — after pubsub subscribe, message handlers, and UI wiring
+ * have all completed. So callers that `waitFor('INIT_COMPLETE')` will, by
+ * definition, see `PEER_ID:` already in the buffer. We still keep a real
+ * timeout here for direct `PEER_ID:` callers, in case the buffer is racing
+ * with a slow page on a loaded CI box.
  */
 export const PEER_ID_WAIT_MS = 30_000;
 

--- a/e2e/integration/helpers/nat-helpers.ts
+++ b/e2e/integration/helpers/nat-helpers.ts
@@ -30,6 +30,14 @@ export function trackConsole(page: Page) {
   const collector = (msg: ConsoleMessage) => messages.push(msg.text());
   page.on('console', collector);
 
+  /**
+   * Detach functions for any in-flight `waitFor` / `waitForCount` listeners.
+   * Each pending wait registers its cleanup here and removes itself on
+   * resolve/reject; `dispose()` drains anything still outstanding so we
+   * don't leak per-call listeners (or their timers) across page reloads.
+   */
+  const pendingDetachers = new Set<() => void>();
+
   return {
     messages,
     has(prefix: string): boolean {
@@ -40,8 +48,9 @@ export function trackConsole(page: Page) {
       if (existing) return Promise.resolve(existing);
 
       return new Promise((resolve, reject) => {
+        let detach: () => void;
         const timer = setTimeout(() => {
-          page.off('console', handler);
+          detach();
           reject(new Error(
             `Timeout (${timeout}ms) waiting for console: "${prefix}"\n` +
             `Collected ${messages.length} messages:\n${messages.slice(-20).join('\n')}`,
@@ -49,11 +58,16 @@ export function trackConsole(page: Page) {
         }, timeout);
         const handler = (msg: ConsoleMessage) => {
           if (msg.text().startsWith(prefix)) {
-            clearTimeout(timer);
-            page.off('console', handler);
+            detach();
             resolve(msg.text());
           }
         };
+        detach = () => {
+          clearTimeout(timer);
+          page.off('console', handler);
+          pendingDetachers.delete(detach);
+        };
+        pendingDetachers.add(detach);
         page.on('console', handler);
       });
     },
@@ -63,8 +77,9 @@ export function trackConsole(page: Page) {
       if (matched().length >= count) return Promise.resolve(matched().slice(0, count));
 
       return new Promise((resolve, reject) => {
+        let detach: () => void;
         const timer = setTimeout(() => {
-          page.off('console', handler);
+          detach();
           const found = matched();
           reject(new Error(
             `Timeout (${timeout}ms) waiting for ${count} "${prefix}" messages (got ${found.length})\n` +
@@ -74,17 +89,30 @@ export function trackConsole(page: Page) {
         const handler = (_msg: ConsoleMessage) => {
           const found = matched();
           if (found.length >= count) {
-            clearTimeout(timer);
-            page.off('console', handler);
+            detach();
             resolve(found.slice(0, count));
           }
         };
+        detach = () => {
+          clearTimeout(timer);
+          page.off('console', handler);
+          pendingDetachers.delete(detach);
+        };
+        pendingDetachers.add(detach);
         page.on('console', handler);
       });
     },
-    /** Detach the console listener and clear the buffer. Safe to call more than once. */
+    /**
+     * Detach the long-lived collector listener, cancel any pending
+     * `waitFor` / `waitForCount` listeners (clearing their timers and
+     * removing their `page.on('console', ...)` handlers), and clear the
+     * buffer. Safe to call more than once.
+     */
     dispose() {
       page.off('console', collector);
+      // Snapshot first — each detach() mutates pendingDetachers.
+      for (const detach of [...pendingDetachers]) detach();
+      pendingDetachers.clear();
       messages.length = 0;
     },
   };

--- a/e2e/integration/helpers/nat-helpers.ts
+++ b/e2e/integration/helpers/nat-helpers.ts
@@ -31,12 +31,15 @@ export function trackConsole(page: Page) {
   page.on('console', collector);
 
   /**
-   * Detach functions for any in-flight `waitFor` / `waitForCount` listeners.
-   * Each pending wait registers its cleanup here and removes itself on
-   * resolve/reject; `dispose()` drains anything still outstanding so we
-   * don't leak per-call listeners (or their timers) across page reloads.
+   * Pending in-flight `waitFor` / `waitForCount` waits. Each entry holds the
+   * cleanup hook (clears the timer + removes the per-call console handler)
+   * and the Promise's `reject`, so `dispose()` can both stop the listener
+   * AND reject the awaited Promise — otherwise callers awaiting through a
+   * `dispose()` would hang forever. Pending waits self-unregister on their
+   * normal resolve/reject paths.
    */
-  const pendingDetachers = new Set<() => void>();
+  type PendingWait = { detach: () => void; reject: (err: Error) => void };
+  const pendingWaits = new Set<PendingWait>();
 
   return {
     messages,
@@ -47,10 +50,13 @@ export function trackConsole(page: Page) {
       const existing = messages.find(m => m.startsWith(prefix));
       if (existing) return Promise.resolve(existing);
 
-      return new Promise((resolve, reject) => {
-        let detach: () => void;
+      return new Promise<string>((resolve, reject) => {
+        const pending: PendingWait = {
+          detach: () => {}, // assigned below
+          reject,
+        };
         const timer = setTimeout(() => {
-          detach();
+          pending.detach();
           reject(new Error(
             `Timeout (${timeout}ms) waiting for console: "${prefix}"\n` +
             `Collected ${messages.length} messages:\n${messages.slice(-20).join('\n')}`,
@@ -58,16 +64,16 @@ export function trackConsole(page: Page) {
         }, timeout);
         const handler = (msg: ConsoleMessage) => {
           if (msg.text().startsWith(prefix)) {
-            detach();
+            pending.detach();
             resolve(msg.text());
           }
         };
-        detach = () => {
+        pending.detach = () => {
           clearTimeout(timer);
           page.off('console', handler);
-          pendingDetachers.delete(detach);
+          pendingWaits.delete(pending);
         };
-        pendingDetachers.add(detach);
+        pendingWaits.add(pending);
         page.on('console', handler);
       });
     },
@@ -76,10 +82,13 @@ export function trackConsole(page: Page) {
       const matched = () => messages.filter(m => m.startsWith(prefix));
       if (matched().length >= count) return Promise.resolve(matched().slice(0, count));
 
-      return new Promise((resolve, reject) => {
-        let detach: () => void;
+      return new Promise<string[]>((resolve, reject) => {
+        const pending: PendingWait = {
+          detach: () => {}, // assigned below
+          reject,
+        };
         const timer = setTimeout(() => {
-          detach();
+          pending.detach();
           const found = matched();
           reject(new Error(
             `Timeout (${timeout}ms) waiting for ${count} "${prefix}" messages (got ${found.length})\n` +
@@ -89,30 +98,34 @@ export function trackConsole(page: Page) {
         const handler = (_msg: ConsoleMessage) => {
           const found = matched();
           if (found.length >= count) {
-            detach();
+            pending.detach();
             resolve(found.slice(0, count));
           }
         };
-        detach = () => {
+        pending.detach = () => {
           clearTimeout(timer);
           page.off('console', handler);
-          pendingDetachers.delete(detach);
+          pendingWaits.delete(pending);
         };
-        pendingDetachers.add(detach);
+        pendingWaits.add(pending);
         page.on('console', handler);
       });
     },
     /**
      * Detach the long-lived collector listener, cancel any pending
      * `waitFor` / `waitForCount` listeners (clearing their timers and
-     * removing their `page.on('console', ...)` handlers), and clear the
-     * buffer. Safe to call more than once.
+     * removing their `page.on('console', ...)` handlers), reject their
+     * Promises so any in-flight awaits unblock instead of hanging, and
+     * clear the buffer. Safe to call more than once.
      */
     dispose() {
       page.off('console', collector);
-      // Snapshot first — each detach() mutates pendingDetachers.
-      for (const detach of [...pendingDetachers]) detach();
-      pendingDetachers.clear();
+      // Snapshot first — each detach() mutates pendingWaits.
+      for (const pending of [...pendingWaits]) {
+        pending.detach();
+        pending.reject(new Error('trackConsole disposed'));
+      }
+      pendingWaits.clear();
       messages.length = 0;
     },
   };

--- a/e2e/integration/nat-resilience.spec.ts
+++ b/e2e/integration/nat-resilience.spec.ts
@@ -51,10 +51,11 @@ import { execSync } from 'node:child_process';
 import { test, expect, type Page } from '@playwright/test';
 import {
   initPage,
-  rebindTracker,
+  rebindConsoleTracker,
   refreshPeerId,
   waitForMesh,
   waitForPeerConnection,
+  type PageHandle,
 } from './helpers/nat-helpers';
 
 const APP_A_URL = 'http://localhost:3001';
@@ -208,9 +209,15 @@ test.describe('NAT Relay Failure Recovery', () => {
   );
 
   test('cross-NAT sync resumes after relay container restart', async ({ browser }) => {
-    let a = await initPage(browser, APP_A_URL);
-    let b = await initPage(browser, APP_B_URL);
+    // Declare with definite-assignment so the `try` body sees a non-nullable
+    // type. Assigning inside `try` ensures that if the second `initPage`
+    // throws, the first context is still closed by the `finally` (which
+    // guards with optional chaining against partial init).
+    let a!: PageHandle;
+    let b!: PageHandle;
     try {
+      a = await initPage(browser, APP_A_URL);
+      b = await initPage(browser, APP_B_URL);
       await Promise.all([
         waitForPeerConnection(a.track),
         waitForPeerConnection(b.track),
@@ -296,8 +303,8 @@ test.describe('NAT Relay Failure Recovery', () => {
       // match against the buffer's initial contents).
       expect(postMessagesB.length).toBeGreaterThan(baselineMessageCountB);
     } finally {
-      await a.context.close().catch(() => {});
-      await b.context.close().catch(() => {});
+      await a?.context.close().catch(() => {});
+      await b?.context.close().catch(() => {});
     }
   });
 });
@@ -312,9 +319,12 @@ test.describe('NAT Browser Page Reload', () => {
   test.setTimeout(300_000);
 
   test('cross-NAT peer catches up after page reload', async ({ browser }) => {
-    const a = await initPage(browser, APP_A_URL);
-    let b = await initPage(browser, APP_B_URL);
+    // See test 1 for the rationale on definite-assignment + assign-in-try.
+    let a!: PageHandle;
+    let b!: PageHandle;
     try {
+      a = await initPage(browser, APP_A_URL);
+      b = await initPage(browser, APP_B_URL);
       await Promise.all([
         waitForPeerConnection(a.track),
         waitForPeerConnection(b.track),
@@ -330,7 +340,7 @@ test.describe('NAT Browser Page Reload', () => {
       // Reload B (simulates the cross-NAT browser dropping & coming back).
       // The test app spins up a fresh libp2p node on reload, so we must
       // refresh `b.peerId` to match — the prior value is stale.
-      b = rebindTracker(b);
+      b = rebindConsoleTracker(b);
       await b.page.reload();
       await b.track.waitFor('INIT_COMPLETE', 90_000);
       b = await refreshPeerId(b);
@@ -348,8 +358,8 @@ test.describe('NAT Browser Page Reload', () => {
       );
       expect(messagesB.some((m) => m.text === 'after-reload')).toBe(true);
     } finally {
-      await a.context.close().catch(() => {});
-      await b.context.close().catch(() => {});
+      await a?.context.close().catch(() => {});
+      await b?.context.close().catch(() => {});
     }
   });
 });
@@ -363,9 +373,12 @@ test.describe('NAT Browser Network Toggle', () => {
   test.skip(!!process.env.CI, 'Cross-NAT setOffline toggle is flaky on CI mesh re-formation; run with `yarn test:nat` locally');
 
   test('cross-NAT peer can send after context.setOffline offline/online cycle', async ({ browser }) => {
-    const a = await initPage(browser, APP_A_URL);
-    const b = await initPage(browser, APP_B_URL);
+    // See test 1 for the rationale on definite-assignment + assign-in-try.
+    let a!: PageHandle;
+    let b!: PageHandle;
     try {
+      a = await initPage(browser, APP_A_URL);
+      b = await initPage(browser, APP_B_URL);
       await Promise.all([
         waitForPeerConnection(a.track),
         waitForPeerConnection(b.track),
@@ -400,8 +413,8 @@ test.describe('NAT Browser Network Toggle', () => {
       );
       expect(messagesA.some((m) => m.text === 'post-offline-from-b')).toBe(true);
     } finally {
-      await a.context.close().catch(() => {});
-      await b.context.close().catch(() => {});
+      await a?.context.close().catch(() => {});
+      await b?.context.close().catch(() => {});
     }
   });
 });
@@ -415,9 +428,12 @@ test.describe('NAT Rapid Concurrent Edits', () => {
   test.skip(!!process.env.CI, 'Rapid cross-NAT concurrent edits are flaky on CI; run with `yarn test:nat` locally');
 
   test('both peers converge after rapid bidirectional cross-NAT messages', async ({ browser }) => {
-    const a = await initPage(browser, APP_A_URL);
-    const b = await initPage(browser, APP_B_URL);
+    // See test 1 for the rationale on definite-assignment + assign-in-try.
+    let a!: PageHandle;
+    let b!: PageHandle;
     try {
+      a = await initPage(browser, APP_A_URL);
+      b = await initPage(browser, APP_B_URL);
       await Promise.all([
         waitForPeerConnection(a.track),
         waitForPeerConnection(b.track),
@@ -481,8 +497,8 @@ test.describe('NAT Rapid Concurrent Edits', () => {
       expect(aFromB).toBeGreaterThanOrEqual(target);
       expect(bFromA).toBeGreaterThanOrEqual(target);
     } finally {
-      await a.context.close().catch(() => {});
-      await b.context.close().catch(() => {});
+      await a?.context.close().catch(() => {});
+      await b?.context.close().catch(() => {});
     }
   });
 });

--- a/e2e/integration/nat-resilience.spec.ts
+++ b/e2e/integration/nat-resilience.spec.ts
@@ -52,6 +52,7 @@ import { test, expect, type Page } from '@playwright/test';
 import {
   initPage,
   rebindTracker,
+  refreshPeerId,
   waitForMesh,
   waitForPeerConnection,
 } from './helpers/nat-helpers';
@@ -327,9 +328,12 @@ test.describe('NAT Browser Page Reload', () => {
       await preReload;
 
       // Reload B (simulates the cross-NAT browser dropping & coming back).
+      // The test app spins up a fresh libp2p node on reload, so we must
+      // refresh `b.peerId` to match — the prior value is stale.
       b = rebindTracker(b);
       await b.page.reload();
       await b.track.waitFor('INIT_COMPLETE', 90_000);
+      b = await refreshPeerId(b);
       await b.track.waitFor('PEER_CONNECTED:', 120_000);
       await waitForMesh(b.page, 12_000);
 

--- a/e2e/integration/nat-resilience.spec.ts
+++ b/e2e/integration/nat-resilience.spec.ts
@@ -21,96 +21,23 @@
  * libp2p's discovery cadence. We use generous timeouts and, where useful,
  * a minimum-success-rate threshold instead of strict equality so the suite
  * stays meaningful without becoming noise.
+ *
+ * Shared helpers (`initPage`, `trackConsole`, etc.) live in
+ * `./helpers/nat-helpers.ts` and are also used by `nat-traversal.spec.ts`.
  */
 import { execSync } from 'node:child_process';
-import { test, expect, type Browser, type Page, type BrowserContext, type ConsoleMessage } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+import {
+  initPage,
+  rebindTracker,
+  waitForMesh,
+  waitForPeerConnection,
+} from './helpers/nat-helpers';
 
 const APP_A_URL = 'http://localhost:3001';
 const APP_B_URL = 'http://localhost:3002';
 
 const COMPOSE_FILE = 'docker-compose.nat-test.yaml';
-
-/** Track console messages from a page; supports awaiting on prefixes. */
-function trackConsole(page: Page) {
-  const messages: string[] = [];
-  const collector = (msg: ConsoleMessage) => messages.push(msg.text());
-  page.on('console', collector);
-
-  return {
-    messages,
-    has(prefix: string): boolean {
-      return messages.some(m => m.startsWith(prefix));
-    },
-    waitFor(prefix: string, timeout = 60_000): Promise<string> {
-      const existing = messages.find(m => m.startsWith(prefix));
-      if (existing) return Promise.resolve(existing);
-
-      return new Promise((resolve, reject) => {
-        const timer = setTimeout(() => {
-          page.off('console', handler);
-          reject(new Error(
-            `Timeout (${timeout}ms) waiting for console: "${prefix}"\n` +
-            `Collected ${messages.length} messages:\n${messages.slice(-20).join('\n')}`,
-          ));
-        }, timeout);
-        const handler = (msg: ConsoleMessage) => {
-          if (msg.text().startsWith(prefix)) {
-            clearTimeout(timer);
-            page.off('console', handler);
-            resolve(msg.text());
-          }
-        };
-        page.on('console', handler);
-      });
-    },
-    /** Detach the console listener and clear the buffer. Safe to call more than once. */
-    dispose() {
-      page.off('console', collector);
-      messages.length = 0;
-    },
-  };
-}
-
-interface PageHandle {
-  page: Page;
-  track: ReturnType<typeof trackConsole>;
-  context: BrowserContext;
-  peerId: string;
-}
-
-async function initPage(browser: Browser, url: string): Promise<PageHandle> {
-  const context = await browser.newContext();
-  try {
-    const page = await context.newPage();
-    const track = trackConsole(page);
-    await page.goto(url);
-    await track.waitFor('INIT_COMPLETE', 90_000);
-    const peerIdMsg = await track.waitFor('PEER_ID:', 5_000);
-    const peerId = peerIdMsg.replace('PEER_ID:', '').trim();
-    return { page, track, context, peerId };
-  } catch (err) {
-    await context.close();
-    throw err;
-  }
-}
-
-/**
- * Replace the in-page console tracker after a reload. Disposes the previous
- * tracker (removes its `page.on('console', ...)` listener and clears its
- * buffer) so listeners don't accumulate across multiple reloads.
- */
-function rebindTracker(handle: PageHandle): PageHandle {
-  handle.track.dispose();
-  return { ...handle, track: trackConsole(handle.page) };
-}
-
-async function waitForPeerConnection(track: ReturnType<typeof trackConsole>, timeout = 90_000) {
-  await track.waitFor('PEER_CONNECTED:', timeout);
-}
-
-async function waitForMesh(page: Page, ms = 10_000) {
-  await page.waitForTimeout(ms);
-}
 
 /**
  * Run a docker compose subcommand against the NAT-test compose file.
@@ -204,7 +131,13 @@ test.describe('NAT Relay Failure Recovery', () => {
   // in via their entrypoint script. We therefore restart relay + both
   // test-app containers and reload browser pages so they pick up the new
   // relay info. The end-state assertion is that cross-NAT sync resumes.
-  test.skip(!!process.env.CI && !process.env.RUN_NAT_RESTART, 'Relay restart cycle is too slow / flaky for default CI runs (set RUN_NAT_RESTART=1 to enable)');
+  //
+  // Opt-in only when `RUN_NAT_RESTART=1` is explicitly set, so values like
+  // "0" or "false" don't accidentally enable this slow/flaky scenario.
+  test.skip(
+    !!process.env.CI && process.env.RUN_NAT_RESTART !== '1',
+    'Relay restart cycle is too slow / flaky for default CI runs (set RUN_NAT_RESTART=1 to enable)',
+  );
 
   test('cross-NAT sync resumes after relay container restart', async ({ browser }) => {
     let a = await initPage(browser, APP_A_URL);

--- a/e2e/integration/nat-resilience.spec.ts
+++ b/e2e/integration/nat-resilience.spec.ts
@@ -1,0 +1,375 @@
+/**
+ * NAT Traversal Resilience Tests (issue #184)
+ *
+ * Exercises failure-recovery scenarios for SwarmDB peers communicating across
+ * isolated NAT-simulated Docker networks. Builds on the topology established
+ * by `docker-compose.nat-test.yaml`:
+ *
+ *   nat-a: [test-app-a (3001), test-app-c (3003), relay]
+ *   nat-b: [test-app-b (3002), relay]
+ *
+ * Cross-NAT traffic between test-app-a and test-app-b MUST flow through the
+ * relay. These tests verify that the system tolerates:
+ *
+ *   1. Relay container restart mid-sync (container churn, recovers via
+ *      bootstrap re-dial + fresh config fetch).
+ *   2. Browser-side reconnection (page reload on the cross-NAT peer).
+ *   3. Rapid, concurrent cross-NAT edits without message loss.
+ *
+ * Many of these scenarios are inherently flaky in CI because GossipSub mesh
+ * re-formation through a single relay takes time (10s+) and depends on
+ * libp2p's discovery cadence. We use generous timeouts and, where useful,
+ * a minimum-success-rate threshold instead of strict equality so the suite
+ * stays meaningful without becoming noise.
+ */
+import { execSync } from 'node:child_process';
+import { test, expect, type Browser, type Page, type BrowserContext, type ConsoleMessage } from '@playwright/test';
+
+const APP_A_URL = 'http://localhost:3001';
+const APP_B_URL = 'http://localhost:3002';
+
+const COMPOSE_FILE = 'docker-compose.nat-test.yaml';
+
+/** Track console messages from a page; supports awaiting on prefixes. */
+function trackConsole(page: Page) {
+  const messages: string[] = [];
+  page.on('console', (msg) => messages.push(msg.text()));
+
+  return {
+    messages,
+    has(prefix: string): boolean {
+      return messages.some(m => m.startsWith(prefix));
+    },
+    waitFor(prefix: string, timeout = 60_000): Promise<string> {
+      const existing = messages.find(m => m.startsWith(prefix));
+      if (existing) return Promise.resolve(existing);
+
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          page.off('console', handler);
+          reject(new Error(
+            `Timeout (${timeout}ms) waiting for console: "${prefix}"\n` +
+            `Collected ${messages.length} messages:\n${messages.slice(-20).join('\n')}`,
+          ));
+        }, timeout);
+        const handler = (msg: ConsoleMessage) => {
+          if (msg.text().startsWith(prefix)) {
+            clearTimeout(timer);
+            page.off('console', handler);
+            resolve(msg.text());
+          }
+        };
+        page.on('console', handler);
+      });
+    },
+  };
+}
+
+interface PageHandle {
+  page: Page;
+  track: ReturnType<typeof trackConsole>;
+  context: BrowserContext;
+  peerId: string;
+}
+
+async function initPage(browser: Browser, url: string): Promise<PageHandle> {
+  const context = await browser.newContext();
+  try {
+    const page = await context.newPage();
+    const track = trackConsole(page);
+    await page.goto(url);
+    await track.waitFor('INIT_COMPLETE', 90_000);
+    const peerIdMsg = await track.waitFor('PEER_ID:', 5_000);
+    const peerId = peerIdMsg.replace('PEER_ID:', '').trim();
+    return { page, track, context, peerId };
+  } catch (err) {
+    await context.close();
+    throw err;
+  }
+}
+
+/** Replace the in-page console tracker after a reload (keeps closing helpers happy). */
+function rebindTracker(handle: PageHandle): PageHandle {
+  return { ...handle, track: trackConsole(handle.page) };
+}
+
+async function waitForPeerConnection(track: ReturnType<typeof trackConsole>, timeout = 90_000) {
+  await track.waitFor('PEER_CONNECTED:', timeout);
+}
+
+async function waitForMesh(page: Page, ms = 10_000) {
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Run a docker compose subcommand against the NAT-test compose file.
+ * Failures are surfaced via thrown Error so the test fails loudly.
+ */
+function compose(args: string): string {
+  try {
+    return execSync(`docker compose -f ${COMPOSE_FILE} ${args}`, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+      timeout: 120_000,
+    });
+  } catch (err) {
+    const e = err as { stdout?: Buffer; stderr?: Buffer; message: string };
+    throw new Error(
+      `docker compose ${args} failed: ${e.message}\n` +
+      `stdout: ${e.stdout?.toString() ?? ''}\n` +
+      `stderr: ${e.stderr?.toString() ?? ''}`,
+    );
+  }
+}
+
+/**
+ * Poll an HTTP URL until it responds with 2xx or `timeoutMs` elapses.
+ * Used after restarting test-app containers to wait for `serve` to come back.
+ */
+async function waitForUrl(page: Page, url: string, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const resp = await page.request.get(url, { timeout: 2000 });
+      if (resp.ok()) return;
+    } catch {
+      // ignore and retry
+    }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  throw new Error(`Timed out waiting for ${url} to respond after ${timeoutMs}ms`);
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+test.describe('NAT Relay Failure Recovery', () => {
+  test.setTimeout(360_000);
+
+  // The relay container generates a fresh peer ID on every start, so a true
+  // restart cycle invalidates the config.json that test-app containers baked
+  // in via their entrypoint script. We therefore restart relay + both
+  // test-app containers and reload browser pages so they pick up the new
+  // relay info. The end-state assertion is that cross-NAT sync resumes.
+  test.skip(!!process.env.CI && !process.env.RUN_NAT_RESTART, 'Relay restart cycle is too slow / flaky for default CI runs (set RUN_NAT_RESTART=1 to enable)');
+
+  test('cross-NAT sync resumes after relay container restart', async ({ browser }) => {
+    let a = await initPage(browser, APP_A_URL);
+    let b = await initPage(browser, APP_B_URL);
+    try {
+      await Promise.all([
+        waitForPeerConnection(a.track),
+        waitForPeerConnection(b.track),
+      ]);
+      await waitForMesh(a.page);
+
+      // Establish working baseline: A -> B over relay.
+      const preMsg = b.track.waitFor('PUBSUB_MESSAGE:', 45_000);
+      await a.page.fill('#message-input', 'pre-restart');
+      await a.page.click('#send-btn');
+      await preMsg;
+
+      // Snapshot pre-restart message counts so we can confirm growth later.
+      const preMessagesB = await b.page.evaluate(() => (window as any).__messages);
+      expect(preMessagesB.some((m: any) => m.text === 'pre-restart')).toBe(true);
+
+      // Restart the relay. We also restart the test-app containers so their
+      // entrypoint script picks up the new relay-info.json and rewrites
+      // config.json with the new peer ID. Browsers will be reloaded next.
+      compose('restart relay');
+      compose('restart test-app-a test-app-b');
+
+      // Wait for the test-app HTTP servers to come back online before reload.
+      await waitForUrl(a.page, APP_A_URL, 90_000);
+      await waitForUrl(b.page, APP_B_URL, 90_000);
+
+      // Close stale browser contexts (the existing libp2p instances are
+      // pinned to the old relay peer ID and will not be able to recover).
+      await a.context.close();
+      await b.context.close();
+
+      // Re-open both pages. They will fetch the new config.json (new relay
+      // peer ID & multiaddr) and re-bootstrap.
+      a = await initPage(browser, APP_A_URL);
+      b = await initPage(browser, APP_B_URL);
+
+      await Promise.all([
+        waitForPeerConnection(a.track, 120_000),
+        waitForPeerConnection(b.track, 120_000),
+      ]);
+      await waitForMesh(a.page, 15_000);
+
+      // Verify cross-NAT sync works again post-restart.
+      const postMsg = b.track.waitFor('PUBSUB_MESSAGE:', 60_000);
+      await a.page.fill('#message-input', 'post-restart');
+      await a.page.click('#send-btn');
+      await postMsg;
+
+      const postMessagesB = await b.page.evaluate(() => (window as any).__messages);
+      expect(postMessagesB.some((m: any) => m.text === 'post-restart')).toBe(true);
+    } finally {
+      await a.context.close().catch(() => {});
+      await b.context.close().catch(() => {});
+    }
+  });
+});
+
+test.describe('NAT Browser Reconnection', () => {
+  test.setTimeout(300_000);
+
+  // Mesh re-formation through a single relay can take 10s+ after a peer
+  // rejoins; in CI this is occasionally flaky. Same caveat as resilience.spec.ts.
+  test.skip(!!process.env.CI, 'Cross-NAT browser reconnect is flaky on CI mesh re-formation; run with `yarn test:nat` locally');
+
+  test('cross-NAT peer catches up after page reload', async ({ browser }) => {
+    const a = await initPage(browser, APP_A_URL);
+    let b = await initPage(browser, APP_B_URL);
+    try {
+      await Promise.all([
+        waitForPeerConnection(a.track),
+        waitForPeerConnection(b.track),
+      ]);
+      await waitForMesh(a.page);
+
+      // Send a baseline message before reload to confirm sync is healthy.
+      const preReload = b.track.waitFor('PUBSUB_MESSAGE:', 45_000);
+      await a.page.fill('#message-input', 'before-reload');
+      await a.page.click('#send-btn');
+      await preReload;
+
+      // Reload B (simulates the cross-NAT browser dropping & coming back).
+      b = rebindTracker(b);
+      await b.page.reload();
+      await b.track.waitFor('INIT_COMPLETE', 90_000);
+      await b.track.waitFor('PEER_CONNECTED:', 120_000);
+      await waitForMesh(b.page, 12_000);
+
+      // Send a fresh message from A; B should receive it after reconnecting.
+      const postReload = b.track.waitFor('PUBSUB_MESSAGE:', 60_000);
+      await a.page.fill('#message-input', 'after-reload');
+      await a.page.click('#send-btn');
+      await postReload;
+
+      const messagesB = await b.page.evaluate(() => (window as any).__messages);
+      expect(messagesB.some((m: any) => m.text === 'after-reload')).toBe(true);
+    } finally {
+      await a.context.close().catch(() => {});
+      await b.context.close().catch(() => {});
+    }
+  });
+
+  test('cross-NAT peer can send after navigator.onLine offline/online cycle', async ({ browser }) => {
+    const a = await initPage(browser, APP_A_URL);
+    const b = await initPage(browser, APP_B_URL);
+    try {
+      await Promise.all([
+        waitForPeerConnection(a.track),
+        waitForPeerConnection(b.track),
+      ]);
+      await waitForMesh(a.page);
+
+      // Sanity check: bi-directional baseline.
+      const baseline = b.track.waitFor('PUBSUB_MESSAGE:', 45_000);
+      await a.page.fill('#message-input', 'pre-offline');
+      await a.page.click('#send-btn');
+      await baseline;
+
+      // Simulate B losing connectivity for a few seconds.
+      await b.context.setOffline(true);
+      await b.page.waitForTimeout(5_000);
+      await b.context.setOffline(false);
+
+      // Give libp2p time to re-establish (transports must reconnect through relay).
+      await waitForMesh(b.page, 20_000);
+
+      // After coming back online, B should be able to send a message that A
+      // receives. We don't require A's send to reach B (depends on whether
+      // the relay also dropped the connection), but B sending to A is a
+      // stronger indicator that the browser end recovered.
+      const aReceives = a.track.waitFor('PUBSUB_MESSAGE:', 60_000);
+      await b.page.fill('#message-input', 'post-offline-from-b');
+      await b.page.click('#send-btn');
+      await aReceives;
+
+      const messagesA = await a.page.evaluate(() => (window as any).__messages);
+      expect(messagesA.some((m: any) => m.text === 'post-offline-from-b')).toBe(true);
+    } finally {
+      await a.context.close().catch(() => {});
+      await b.context.close().catch(() => {});
+    }
+  });
+});
+
+test.describe('NAT Rapid Concurrent Edits', () => {
+  test.setTimeout(240_000);
+
+  // Volume test for cross-NAT sync. We require at least 60% delivery on each
+  // side (out of 10 messages from each peer). Higher than the existing 50%
+  // threshold in nat-traversal.spec.ts since this is a focused stress test.
+  test.skip(!!process.env.CI, 'Rapid cross-NAT concurrent edits are flaky on CI; run with `yarn test:nat` locally');
+
+  test('both peers converge after rapid bidirectional cross-NAT messages', async ({ browser }) => {
+    const a = await initPage(browser, APP_A_URL);
+    const b = await initPage(browser, APP_B_URL);
+    try {
+      await Promise.all([
+        waitForPeerConnection(a.track),
+        waitForPeerConnection(b.track),
+      ]);
+      await waitForMesh(a.page);
+
+      // Warmup to ensure mesh is settled.
+      const warmup = b.track.waitFor('PUBSUB_MESSAGE:', 60_000);
+      await a.page.fill('#message-input', 'warmup');
+      await a.page.click('#send-btn');
+      await warmup;
+
+      const count = 10;
+      // Interleave sends from both sides as fast as possible, with tiny
+      // pauses so gossipsub has a chance to forward each one. The point of
+      // this test is high cross-NAT throughput, not back-pressure handling.
+      for (let i = 0; i < count; i++) {
+        await a.page.fill('#message-input', `A-edit-${i}`);
+        await a.page.click('#send-btn');
+        await b.page.fill('#message-input', `B-edit-${i}`);
+        await b.page.click('#send-btn');
+        await a.page.waitForTimeout(150);
+      }
+
+      // Wait for both sides to receive at least 60% of the other's messages.
+      const target = Math.ceil(count * 0.6);
+      await Promise.all([
+        a.page.waitForFunction(
+          (n) => (window as any).__messages?.filter((m: any) => m.text.startsWith('B-edit-')).length >= n,
+          target,
+          { timeout: 90_000 },
+        ),
+        b.page.waitForFunction(
+          (n) => (window as any).__messages?.filter((m: any) => m.text.startsWith('A-edit-')).length >= n,
+          target,
+          { timeout: 90_000 },
+        ),
+      ]);
+
+      const messagesA = await a.page.evaluate(() => (window as any).__messages);
+      const messagesB = await b.page.evaluate(() => (window as any).__messages);
+
+      // Each side should always have all of its own messages.
+      for (let i = 0; i < count; i++) {
+        expect(messagesA.some((m: any) => m.text === `A-edit-${i}`)).toBe(true);
+        expect(messagesB.some((m: any) => m.text === `B-edit-${i}`)).toBe(true);
+      }
+
+      const aFromB = messagesA.filter((m: any) => m.text.startsWith('B-edit-')).length;
+      const bFromA = messagesB.filter((m: any) => m.text.startsWith('A-edit-')).length;
+      console.log(`Cross-NAT rapid delivery: A<-B ${aFromB}/${count}, B<-A ${bFromA}/${count}`);
+
+      expect(aFromB).toBeGreaterThanOrEqual(target);
+      expect(bFromA).toBeGreaterThanOrEqual(target);
+    } finally {
+      await a.context.close().catch(() => {});
+      await b.context.close().catch(() => {});
+    }
+  });
+});

--- a/e2e/integration/nat-resilience.spec.ts
+++ b/e2e/integration/nat-resilience.spec.ts
@@ -33,7 +33,8 @@ const COMPOSE_FILE = 'docker-compose.nat-test.yaml';
 /** Track console messages from a page; supports awaiting on prefixes. */
 function trackConsole(page: Page) {
   const messages: string[] = [];
-  page.on('console', (msg) => messages.push(msg.text()));
+  const collector = (msg: ConsoleMessage) => messages.push(msg.text());
+  page.on('console', collector);
 
   return {
     messages,
@@ -62,6 +63,11 @@ function trackConsole(page: Page) {
         page.on('console', handler);
       });
     },
+    /** Detach the console listener and clear the buffer. Safe to call more than once. */
+    dispose() {
+      page.off('console', collector);
+      messages.length = 0;
+    },
   };
 }
 
@@ -88,8 +94,13 @@ async function initPage(browser: Browser, url: string): Promise<PageHandle> {
   }
 }
 
-/** Replace the in-page console tracker after a reload (keeps closing helpers happy). */
+/**
+ * Replace the in-page console tracker after a reload. Disposes the previous
+ * tracker (removes its `page.on('console', ...)` listener and clears its
+ * buffer) so listeners don't accumulate across multiple reloads.
+ */
 function rebindTracker(handle: PageHandle): PageHandle {
+  handle.track.dispose();
   return { ...handle, track: trackConsole(handle.page) };
 }
 
@@ -140,6 +151,47 @@ async function waitForUrl(page: Page, url: string, timeoutMs = 60_000): Promise<
   throw new Error(`Timed out waiting for ${url} to respond after ${timeoutMs}ms`);
 }
 
+/**
+ * Read the relay's `/shared/relay-info.json` from inside the relay container.
+ * Returns null while the file is missing or unparseable (e.g., mid-write).
+ */
+function readRelayInfo(): { peerId: string } | null {
+  try {
+    const raw = execSync(`docker compose -f ${COMPOSE_FILE} exec -T relay cat /shared/relay-info.json`, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+      timeout: 10_000,
+    });
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.peerId === 'string' && parsed.peerId.length > 0) {
+      return { peerId: parsed.peerId };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * After restarting the relay, the relay container rewrites
+ * `/shared/relay-info.json` with a fresh peer ID. The `test-app-*` entrypoint
+ * only waits for the file to *exist*, so if we restart `test-app-*` before
+ * the relay has written the new info, they will re-publish `config.json`
+ * with the *old* peer ID. Poll until the file's `peerId` differs from
+ * `previousPeerId` so callers can sequence the restart deterministically.
+ */
+async function waitForRelayInfoChange(previousPeerId: string, timeoutMs = 60_000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const info = readRelayInfo();
+    if (info && info.peerId !== previousPeerId) return info.peerId;
+    await new Promise(r => setTimeout(r, 500));
+  }
+  throw new Error(
+    `Timed out (${timeoutMs}ms) waiting for relay-info.json peerId to change from ${previousPeerId}`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Test suites
 // ---------------------------------------------------------------------------
@@ -174,10 +226,24 @@ test.describe('NAT Relay Failure Recovery', () => {
       const preMessagesB = await b.page.evaluate(() => (window as any).__messages);
       expect(preMessagesB.some((m: any) => m.text === 'pre-restart')).toBe(true);
 
+      // Capture the pre-restart relay peer ID so we can detect when the
+      // restarted relay has rewritten /shared/relay-info.json.
+      const preRestartInfo = readRelayInfo();
+      if (!preRestartInfo) {
+        throw new Error('Could not read pre-restart relay-info.json from the relay container');
+      }
+
       // Restart the relay. We also restart the test-app containers so their
       // entrypoint script picks up the new relay-info.json and rewrites
       // config.json with the new peer ID. Browsers will be reloaded next.
       compose('restart relay');
+
+      // The test-app entrypoint only waits for the file to *exist*, not for
+      // it to change, so we must explicitly wait for the new peer ID to land
+      // in /shared/relay-info.json before restarting the test-apps —
+      // otherwise they may rewrite config.json with the stale peer ID.
+      await waitForRelayInfoChange(preRestartInfo.peerId, 90_000);
+
       compose('restart test-app-a test-app-b');
 
       // Wait for the test-app HTTP servers to come back online before reload.

--- a/e2e/integration/nat-resilience.spec.ts
+++ b/e2e/integration/nat-resilience.spec.ts
@@ -14,13 +14,34 @@
  *   1. Relay container restart mid-sync (container churn, recovers via
  *      bootstrap re-dial + fresh config fetch).
  *   2. Browser-side reconnection (page reload on the cross-NAT peer).
- *   3. Rapid, concurrent cross-NAT edits without message loss.
+ *   3. Browser-side network toggle (navigator.onLine offline/online cycle).
+ *   4. Rapid, concurrent cross-NAT edits without message loss.
  *
  * Many of these scenarios are inherently flaky in CI because GossipSub mesh
  * re-formation through a single relay takes time (10s+) and depends on
  * libp2p's discovery cadence. We use generous timeouts and, where useful,
  * a minimum-success-rate threshold instead of strict equality so the suite
  * stays meaningful without becoming noise.
+ *
+ * CI gating strategy
+ * ------------------
+ * To balance signal vs. noise the four scenarios above are gated as follows:
+ *
+ *   1. Relay restart   — opt-in via `RUN_NAT_RESTART=1`. Restarts docker
+ *      services and rebuilds the gossipsub mesh from scratch; the slowest
+ *      and most volatile scenario, so it does not run in CI by default.
+ *   2. Page reload     — RUNS IN CI. Single-peer reload + cross-NAT message
+ *      round-trip; the most stable resilience scenario and the one CI
+ *      assertion this suite contributes.
+ *   3. Network toggle  — CI-skip. `navigator.onLine` cycling depends on
+ *      transport-level reconnection timing through the relay, which has
+ *      historically been flaky on shared CI runners.
+ *   4. Rapid concurrent — CI-skip. 10-message bidirectional burst with a 60%
+ *      delivery threshold; deliberately stress-shaped, expected to be flaky
+ *      on shared CI runners.
+ *
+ * Skipped scenarios run locally with `yarn test:nat` (and `RUN_NAT_RESTART=1
+ * yarn test:nat` for the relay restart).
  *
  * Shared helpers (`initPage`, `trackConsole`, etc.) live in
  * `./helpers/nat-helpers.ts` and are also used by `nat-traversal.spec.ts`.
@@ -229,12 +250,14 @@ test.describe('NAT Relay Failure Recovery', () => {
   });
 });
 
-test.describe('NAT Browser Reconnection', () => {
+// This describe block is intentionally kept enabled on CI. It is the most
+// stable resilience scenario in this suite (no docker churn, no stress
+// thresholds — just a single page reload plus a cross-NAT round-trip) and
+// provides the CI assertion that this PR contributes to the nat-traversal
+// job. If this scenario starts flaking on CI, prefer fixing the underlying
+// instability over re-adding a CI-skip — opt out only as a last resort.
+test.describe('NAT Browser Page Reload', () => {
   test.setTimeout(300_000);
-
-  // Mesh re-formation through a single relay can take 10s+ after a peer
-  // rejoins; in CI this is occasionally flaky. Same caveat as resilience.spec.ts.
-  test.skip(!!process.env.CI, 'Cross-NAT browser reconnect is flaky on CI mesh re-formation; run with `yarn test:nat` locally');
 
   test('cross-NAT peer catches up after page reload', async ({ browser }) => {
     const a = await initPage(browser, APP_A_URL);
@@ -272,6 +295,15 @@ test.describe('NAT Browser Reconnection', () => {
       await b.context.close().catch(() => {});
     }
   });
+});
+
+test.describe('NAT Browser Network Toggle', () => {
+  test.setTimeout(300_000);
+
+  // navigator.onLine cycling depends on transport-level reconnection timing
+  // through the relay, which has historically been flaky on shared CI
+  // runners. Keep CI-skip; run with `yarn test:nat` locally.
+  test.skip(!!process.env.CI, 'Cross-NAT navigator.onLine toggle is flaky on CI mesh re-formation; run with `yarn test:nat` locally');
 
   test('cross-NAT peer can send after navigator.onLine offline/online cycle', async ({ browser }) => {
     const a = await initPage(browser, APP_A_URL);

--- a/e2e/integration/nat-resilience.spec.ts
+++ b/e2e/integration/nat-resilience.spec.ts
@@ -62,22 +62,66 @@ const APP_B_URL = 'http://localhost:3002';
 const COMPOSE_FILE = 'docker-compose.nat-test.yaml';
 
 /**
+ * Shape of the `messages` array stored on `window` by `e2e/test-app/app.js`.
+ * Each entry is a single pubsub-delivered message that the test app rendered.
+ */
+interface TestAppMessage {
+  text: string;
+  // Other fields (id, ts, from, etc.) may be present but aren't asserted on.
+  [key: string]: unknown;
+}
+
+/**
+ * Subset of the test-app's window globals consumed by these tests.
+ * Declaring these explicitly avoids `(window as any)` casts when calling
+ * `page.evaluate(...)` and gives us proper typing for `__messages`.
+ */
+interface TestAppWindow extends Window {
+  __messages: TestAppMessage[];
+  // `__libp2p` is also exposed by the test app but is opaque to these tests.
+  __libp2p?: unknown;
+}
+
+/**
+ * Narrowed shape of execSync's thrown error. The Node typings declare
+ * `stdout`/`stderr` as `string | Buffer | undefined`; with `encoding: 'utf8'`
+ * they are typically strings, but we keep the union to stay safe.
+ */
+interface ExecError {
+  message: string;
+  stdout?: string | Buffer;
+  stderr?: string | Buffer;
+}
+
+function isExecError(err: unknown): err is ExecError {
+  return typeof err === 'object' && err !== null && 'message' in err;
+}
+
+function decode(buf: string | Buffer | undefined): string {
+  if (buf === undefined) return '';
+  return typeof buf === 'string' ? buf : buf.toString('utf8');
+}
+
+/**
  * Run a docker compose subcommand against the NAT-test compose file.
  * Failures are surfaced via thrown Error so the test fails loudly.
  */
 function compose(args: string): string {
+  const fullCommand = `docker compose -f ${COMPOSE_FILE} ${args}`;
   try {
-    return execSync(`docker compose -f ${COMPOSE_FILE} ${args}`, {
+    return execSync(fullCommand, {
       stdio: ['ignore', 'pipe', 'pipe'],
       encoding: 'utf8',
       timeout: 120_000,
     });
-  } catch (err) {
-    const e = err as { stdout?: Buffer; stderr?: Buffer; message: string };
+  } catch (err: unknown) {
+    const message = isExecError(err) ? err.message : String(err);
+    const stdout = isExecError(err) ? decode(err.stdout) : '';
+    const stderr = isExecError(err) ? decode(err.stderr) : '';
     throw new Error(
-      `docker compose ${args} failed: ${e.message}\n` +
-      `stdout: ${e.stdout?.toString() ?? ''}\n` +
-      `stderr: ${e.stderr?.toString() ?? ''}`,
+      `\`${fullCommand}\` failed: ${message}\n` +
+      `stdout: ${stdout}\n` +
+      `stderr: ${stderr}`,
     );
   }
 }
@@ -182,8 +226,10 @@ test.describe('NAT Relay Failure Recovery', () => {
       // anything down. The post-restart assertion below snapshots the new
       // page's message buffer length right after reload and verifies it
       // grows once the post-restart send round-trips.
-      const preMessagesB = await b.page.evaluate(() => (window as any).__messages);
-      expect(preMessagesB.some((m: any) => m.text === 'pre-restart')).toBe(true);
+      const preMessagesB = await b.page.evaluate(
+        () => (window as unknown as TestAppWindow).__messages,
+      );
+      expect(preMessagesB.some((m) => m.text === 'pre-restart')).toBe(true);
 
       // Capture the pre-restart relay peer ID so we can detect when the
       // restarted relay has rewritten /shared/relay-info.json.
@@ -229,7 +275,9 @@ test.describe('NAT Relay Failure Recovery', () => {
       // restart send) so we can verify the buffer actually grows as a result
       // of new cross-NAT traffic, not just because the assertion happens to
       // match a stale entry.
-      const baselineMessagesB = await b.page.evaluate(() => (window as any).__messages);
+      const baselineMessagesB = await b.page.evaluate(
+        () => (window as unknown as TestAppWindow).__messages,
+      );
       const baselineMessageCountB = baselineMessagesB.length;
 
       // Verify cross-NAT sync works again post-restart.
@@ -238,8 +286,10 @@ test.describe('NAT Relay Failure Recovery', () => {
       await a.page.click('#send-btn');
       await postMsg;
 
-      const postMessagesB = await b.page.evaluate(() => (window as any).__messages);
-      expect(postMessagesB.some((m: any) => m.text === 'post-restart')).toBe(true);
+      const postMessagesB = await b.page.evaluate(
+        () => (window as unknown as TestAppWindow).__messages,
+      );
+      expect(postMessagesB.some((m) => m.text === 'post-restart')).toBe(true);
       // Confirm the message buffer actually grew after the post-restart send,
       // proving we observed new traffic on this fresh page (not a stale
       // match against the buffer's initial contents).
@@ -289,8 +339,10 @@ test.describe('NAT Browser Page Reload', () => {
       await a.page.click('#send-btn');
       await postReload;
 
-      const messagesB = await b.page.evaluate(() => (window as any).__messages);
-      expect(messagesB.some((m: any) => m.text === 'after-reload')).toBe(true);
+      const messagesB = await b.page.evaluate(
+        () => (window as unknown as TestAppWindow).__messages,
+      );
+      expect(messagesB.some((m) => m.text === 'after-reload')).toBe(true);
     } finally {
       await a.context.close().catch(() => {});
       await b.context.close().catch(() => {});
@@ -339,8 +391,10 @@ test.describe('NAT Browser Network Toggle', () => {
       await b.page.click('#send-btn');
       await aReceives;
 
-      const messagesA = await a.page.evaluate(() => (window as any).__messages);
-      expect(messagesA.some((m: any) => m.text === 'post-offline-from-b')).toBe(true);
+      const messagesA = await a.page.evaluate(
+        () => (window as unknown as TestAppWindow).__messages,
+      );
+      expect(messagesA.some((m) => m.text === 'post-offline-from-b')).toBe(true);
     } finally {
       await a.context.close().catch(() => {});
       await b.context.close().catch(() => {});
@@ -388,28 +442,36 @@ test.describe('NAT Rapid Concurrent Edits', () => {
       const target = Math.ceil(count * 0.6);
       await Promise.all([
         a.page.waitForFunction(
-          (n) => (window as any).__messages?.filter((m: any) => m.text.startsWith('B-edit-')).length >= n,
+          (n) =>
+            ((window as unknown as TestAppWindow).__messages ?? [])
+              .filter((m) => m.text.startsWith('B-edit-')).length >= n,
           target,
           { timeout: 90_000 },
         ),
         b.page.waitForFunction(
-          (n) => (window as any).__messages?.filter((m: any) => m.text.startsWith('A-edit-')).length >= n,
+          (n) =>
+            ((window as unknown as TestAppWindow).__messages ?? [])
+              .filter((m) => m.text.startsWith('A-edit-')).length >= n,
           target,
           { timeout: 90_000 },
         ),
       ]);
 
-      const messagesA = await a.page.evaluate(() => (window as any).__messages);
-      const messagesB = await b.page.evaluate(() => (window as any).__messages);
+      const messagesA = await a.page.evaluate(
+        () => (window as unknown as TestAppWindow).__messages,
+      );
+      const messagesB = await b.page.evaluate(
+        () => (window as unknown as TestAppWindow).__messages,
+      );
 
       // Each side should always have all of its own messages.
       for (let i = 0; i < count; i++) {
-        expect(messagesA.some((m: any) => m.text === `A-edit-${i}`)).toBe(true);
-        expect(messagesB.some((m: any) => m.text === `B-edit-${i}`)).toBe(true);
+        expect(messagesA.some((m) => m.text === `A-edit-${i}`)).toBe(true);
+        expect(messagesB.some((m) => m.text === `B-edit-${i}`)).toBe(true);
       }
 
-      const aFromB = messagesA.filter((m: any) => m.text.startsWith('B-edit-')).length;
-      const bFromA = messagesB.filter((m: any) => m.text.startsWith('A-edit-')).length;
+      const aFromB = messagesA.filter((m) => m.text.startsWith('B-edit-')).length;
+      const bFromA = messagesB.filter((m) => m.text.startsWith('A-edit-')).length;
       console.log(`Cross-NAT rapid delivery: A<-B ${aFromB}/${count}, B<-A ${bFromA}/${count}`);
 
       expect(aFromB).toBeGreaterThanOrEqual(target);

--- a/e2e/integration/nat-resilience.spec.ts
+++ b/e2e/integration/nat-resilience.spec.ts
@@ -14,7 +14,8 @@
  *   1. Relay container restart mid-sync (container churn, recovers via
  *      bootstrap re-dial + fresh config fetch).
  *   2. Browser-side reconnection (page reload on the cross-NAT peer).
- *   3. Browser-side network toggle (navigator.onLine offline/online cycle).
+ *   3. Browser-side network toggle (Playwright `context.setOffline(true)`
+ *      then `setOffline(false)` to simulate a transient network drop).
  *   4. Rapid, concurrent cross-NAT edits without message loss.
  *
  * Many of these scenarios are inherently flaky in CI because GossipSub mesh
@@ -33,7 +34,7 @@
  *   2. Page reload     — RUNS IN CI. Single-peer reload + cross-NAT message
  *      round-trip; the most stable resilience scenario and the one CI
  *      assertion this suite contributes.
- *   3. Network toggle  — CI-skip. `navigator.onLine` cycling depends on
+ *   3. Network toggle  — CI-skip. `context.setOffline()` cycling depends on
  *      transport-level reconnection timing through the relay, which has
  *      historically been flaky on shared CI runners.
  *   4. Rapid concurrent — CI-skip. 10-message bidirectional burst with a 60%
@@ -300,12 +301,12 @@ test.describe('NAT Browser Page Reload', () => {
 test.describe('NAT Browser Network Toggle', () => {
   test.setTimeout(300_000);
 
-  // navigator.onLine cycling depends on transport-level reconnection timing
-  // through the relay, which has historically been flaky on shared CI
+  // `context.setOffline()` cycling depends on transport-level reconnection
+  // timing through the relay, which has historically been flaky on shared CI
   // runners. Keep CI-skip; run with `yarn test:nat` locally.
-  test.skip(!!process.env.CI, 'Cross-NAT navigator.onLine toggle is flaky on CI mesh re-formation; run with `yarn test:nat` locally');
+  test.skip(!!process.env.CI, 'Cross-NAT setOffline toggle is flaky on CI mesh re-formation; run with `yarn test:nat` locally');
 
-  test('cross-NAT peer can send after navigator.onLine offline/online cycle', async ({ browser }) => {
+  test('cross-NAT peer can send after context.setOffline offline/online cycle', async ({ browser }) => {
     const a = await initPage(browser, APP_A_URL);
     const b = await initPage(browser, APP_B_URL);
     try {

--- a/e2e/integration/nat-resilience.spec.ts
+++ b/e2e/integration/nat-resilience.spec.ts
@@ -132,11 +132,12 @@ test.describe('NAT Relay Failure Recovery', () => {
   // test-app containers and reload browser pages so they pick up the new
   // relay info. The end-state assertion is that cross-NAT sync resumes.
   //
-  // Opt-in only when `RUN_NAT_RESTART=1` is explicitly set, so values like
-  // "0" or "false" don't accidentally enable this slow/flaky scenario.
+  // Opt-in only when `RUN_NAT_RESTART=1` is explicitly set, regardless of
+  // whether we're in CI. Any other value (unset, "0", "false", "true", etc.)
+  // skips this slow/flaky scenario.
   test.skip(
-    !!process.env.CI && process.env.RUN_NAT_RESTART !== '1',
-    'Relay restart cycle is too slow / flaky for default CI runs (set RUN_NAT_RESTART=1 to enable)',
+    process.env.RUN_NAT_RESTART !== '1',
+    'Relay restart cycle is opt-in (set RUN_NAT_RESTART=1 to enable)',
   );
 
   test('cross-NAT sync resumes after relay container restart', async ({ browser }) => {
@@ -155,7 +156,10 @@ test.describe('NAT Relay Failure Recovery', () => {
       await a.page.click('#send-btn');
       await preMsg;
 
-      // Snapshot pre-restart message counts so we can confirm growth later.
+      // Confirm the pre-restart message was received on B before we tear
+      // anything down. The post-restart assertion below snapshots the new
+      // page's message buffer length right after reload and verifies it
+      // grows once the post-restart send round-trips.
       const preMessagesB = await b.page.evaluate(() => (window as any).__messages);
       expect(preMessagesB.some((m: any) => m.text === 'pre-restart')).toBe(true);
 
@@ -199,6 +203,13 @@ test.describe('NAT Relay Failure Recovery', () => {
       ]);
       await waitForMesh(a.page, 15_000);
 
+      // Snapshot B's message buffer right after reload (before the post-
+      // restart send) so we can verify the buffer actually grows as a result
+      // of new cross-NAT traffic, not just because the assertion happens to
+      // match a stale entry.
+      const baselineMessagesB = await b.page.evaluate(() => (window as any).__messages);
+      const baselineMessageCountB = baselineMessagesB.length;
+
       // Verify cross-NAT sync works again post-restart.
       const postMsg = b.track.waitFor('PUBSUB_MESSAGE:', 60_000);
       await a.page.fill('#message-input', 'post-restart');
@@ -207,6 +218,10 @@ test.describe('NAT Relay Failure Recovery', () => {
 
       const postMessagesB = await b.page.evaluate(() => (window as any).__messages);
       expect(postMessagesB.some((m: any) => m.text === 'post-restart')).toBe(true);
+      // Confirm the message buffer actually grew after the post-restart send,
+      // proving we observed new traffic on this fresh page (not a stale
+      // match against the buffer's initial contents).
+      expect(postMessagesB.length).toBeGreaterThan(baselineMessageCountB);
     } finally {
       await a.context.close().catch(() => {});
       await b.context.close().catch(() => {});

--- a/e2e/integration/nat-traversal.spec.ts
+++ b/e2e/integration/nat-traversal.spec.ts
@@ -15,95 +15,16 @@
  * test-app-a and test-app-c are on the same network (same "LAN").
  * All traffic between nat-a and nat-b must route through the relay.
  */
-import { test, expect, type Browser, type Page, type ConsoleMessage } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import {
+  initPage,
+  waitForMesh,
+  waitForPeerConnection,
+} from './helpers/nat-helpers';
 
 const APP_A_URL = 'http://localhost:3001';
 const APP_B_URL = 'http://localhost:3002';
 const APP_C_URL = 'http://localhost:3003';
-
-function trackConsole(page: Page) {
-  const messages: string[] = [];
-  page.on('console', (msg) => messages.push(msg.text()));
-
-  return {
-    messages,
-    waitFor(prefix: string, timeout = 60_000): Promise<string> {
-      const existing = messages.find(m => m.startsWith(prefix));
-      if (existing) return Promise.resolve(existing);
-
-      return new Promise((resolve, reject) => {
-        const timer = setTimeout(() => {
-          page.off('console', handler);
-          reject(new Error(
-            `Timeout (${timeout}ms) waiting for console: "${prefix}"\n` +
-            `Collected ${messages.length} messages:\n${messages.slice(-20).join('\n')}`,
-          ));
-        }, timeout);
-        const handler = (msg: ConsoleMessage) => {
-          if (msg.text().startsWith(prefix)) {
-            clearTimeout(timer);
-            page.off('console', handler);
-            resolve(msg.text());
-          }
-        };
-        page.on('console', handler);
-      });
-    },
-    /** Wait for at least `count` messages with the given prefix. */
-    waitForCount(prefix: string, count: number, timeout = 60_000): Promise<string[]> {
-      const matched = () => messages.filter(m => m.startsWith(prefix));
-      if (matched().length >= count) return Promise.resolve(matched().slice(0, count));
-
-      return new Promise((resolve, reject) => {
-        const timer = setTimeout(() => {
-          page.off('console', handler);
-          const found = matched();
-          reject(new Error(
-            `Timeout (${timeout}ms) waiting for ${count} "${prefix}" messages (got ${found.length})\n` +
-            `Collected ${messages.length} messages:\n${messages.slice(-20).join('\n')}`,
-          ));
-        }, timeout);
-        const handler = (msg: ConsoleMessage) => {
-          const found = matched();
-          if (found.length >= count) {
-            clearTimeout(timer);
-            page.off('console', handler);
-            resolve(found.slice(0, count));
-          }
-        };
-        page.on('console', handler);
-      });
-    },
-  };
-}
-
-async function initPage(browser: Browser, url: string) {
-  const context = await browser.newContext();
-  try {
-    const page = await context.newPage();
-    const track = trackConsole(page);
-    await page.goto(url);
-    await track.waitFor('INIT_COMPLETE');
-    const peerIdMsg = await track.waitFor('PEER_ID:');
-    const peerId = peerIdMsg.replace('PEER_ID:', '').trim();
-    return { page, track, context, peerId };
-  } catch (err) {
-    await context.close();
-    throw err;
-  }
-}
-
-/**
- * Wait for at least 1 PEER_CONNECTED message.
- * In CI's Docker environment only one connection event fires reliably.
- */
-async function waitForPeerConnection(track: ReturnType<typeof trackConsole>, timeout = 90_000) {
-  await track.waitFor('PEER_CONNECTED:', timeout);
-}
-
-async function waitForMesh(page: Page, ms = 10_000) {
-  await page.waitForTimeout(ms);
-}
 
 test.describe('Cross-NAT Document Sync', () => {
   test.setTimeout(180_000);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e',
-  testIgnore: '**/nat-traversal*',
+  testIgnore: ['**/nat-traversal*', '**/nat-resilience*'],
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e/integration',
-  testIgnore: '**/nat-traversal*',
+  testIgnore: ['**/nat-traversal*', '**/nat-resilience*'],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/playwright.nat-test.config.ts
+++ b/playwright.nat-test.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e/integration',
-  testMatch: 'nat-traversal.spec.ts',
+  testMatch: /nat-(traversal|resilience)\.spec\.ts/,
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,


### PR DESCRIPTION
## Summary

Closes part of #184. Adds four new NAT-resilience scenarios alongside the existing `nat-traversal.spec.ts` baseline:

1. **NAT Relay Failure Recovery** — restart the relay container mid-session, restart browser apps to pick up the new peer ID, verify cross-NAT sync resumes. **Opt-in** via `RUN_NAT_RESTART=1`; not in CI (slowest, most volatile scenario).
2. **NAT Browser Page Reload** — page reload of a cross-NAT peer, then send a fresh message after `INIT_COMPLETE + PEER_CONNECTED + mesh`. **CI-enabled** (most stable resilience scenario).
3. **NAT Browser Network Toggle** — Playwright `context.setOffline(true)` then `setOffline(false)` to simulate a transient network drop on the cross-NAT peer. **CI-skip** (transport-level reconnection timing through the relay has been flaky on shared CI runners); runs locally via `yarn test:nat`.
4. **NAT Rapid Concurrent Edits** — 10 interleaved A<->B sends across the NAT boundary with a stricter >=60% delivery threshold (vs. the existing 50%). **CI-skip** (deliberately stress-shaped); runs locally via `yarn test:nat`.

`playwright.nat-test.config.ts` now picks up both nat spec files via a regex `testMatch`. `playwright.integration.config.ts` adds `testIgnore` so the nat specs don't run during the integration suite. CI invokes `yarn test:nat`; CI-skip scenarios are guarded with `test.skip(!!process.env.CI, ...)` consistent with `resilience.spec.ts`.

See the top-of-file comment in `e2e/integration/nat-resilience.spec.ts` for the full CI gating strategy.

## Test plan

- [ ] CI: NAT traversal job picks up the new spec file; page-reload scenario runs and passes
- [ ] Local: `docker compose -f docker-compose.nat-test.yaml up -d && yarn test:nat` exercises all four scenarios
- [ ] Local: `RUN_NAT_RESTART=1 yarn test:nat` exercises the relay-restart path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added NAT resilience integration tests exercising relay failure recovery, page reloads, network toggles, and rapid concurrent edits to validate cross-network messaging and recovery.
  * Added shared Playwright NAT traversal test utilities to standardize console-based synchronization and peer lifecycle handling.
* **Chores**
  * Updated Playwright test configuration to include the new NAT test suites and adjust ignored/matched test patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/swarmbase/swarmbase/pull/271)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->