### PR TITLE
Encrypt BeeKEM Welcome payload with ECIES; drop experimental broadcast flag

### DIFF
--- a/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
@@ -535,6 +535,30 @@ describe('AutomergeJSONSerializer', () => {
     );
   });
 
+  test('serializeSyncMessage/deserializeSyncMessage preserves welcomeRecipientKemPublicKey', () => {
+    const kemPub = new Uint8Array(65);
+    for (let i = 0; i < kemPub.length; i++) kemPub[i] = (i * 11) & 0xff;
+    const message = {
+      documentId: 'welcome-doc',
+      welcomeRecipientKemPublicKey: kemPub,
+    };
+    const wire = serializer.serializeSyncMessage(message);
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.welcomeRecipientKemPublicKey).toEqual(kemPub);
+  });
+
+  test('serializeSyncMessage/deserializeSyncMessage preserves eciesSealed', () => {
+    const sealed = new Uint8Array(160);
+    for (let i = 0; i < sealed.length; i++) sealed[i] = (i * 17) & 0xff;
+    const message = {
+      documentId: 'welcome-doc',
+      eciesSealed: sealed,
+    };
+    const wire = serializer.serializeSyncMessage(message);
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.eciesSealed).toEqual(sealed);
+  });
+
   // Regression: prior to the upfront object guard, a malformed peer payload
   // like JSON `null` flowed straight to `raw.snapshot` access and threw a
   // bare `TypeError: Cannot read properties of null`. The guard mirrors

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -522,6 +522,11 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
         // `welcomeRecipient` is already a string (the serialized recipient
         // public key); pass through verbatim.
         welcomeRecipient: message.welcomeRecipient,
+        welcomeRecipientKemPublicKey:
+          message.welcomeRecipientKemPublicKey &&
+          Base64.fromUint8Array(message.welcomeRecipientKemPublicKey),
+        eciesSealed:
+          message.eciesSealed && Base64.fromUint8Array(message.eciesSealed),
         snapshot: snapshotForWire,
       }),
     );
@@ -550,6 +555,8 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
       keychainChanges?: unknown;
       welcomeEpochId?: unknown;
       welcomeRecipient?: unknown;
+      welcomeRecipientKemPublicKey?: unknown;
+      eciesSealed?: unknown;
       snapshot?: unknown;
       signature?: unknown;
     };
@@ -646,6 +653,30 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
       }
       welcomeRecipient = raw.welcomeRecipient;
     }
+    let welcomeRecipientKemPublicKey: Uint8Array | undefined;
+    if (raw.welcomeRecipientKemPublicKey !== undefined) {
+      if (typeof raw.welcomeRecipientKemPublicKey !== 'string') {
+        throw new Error(
+          `Invalid sync message: 'welcomeRecipientKemPublicKey' must be a string when present (got ${describeValue(
+            raw.welcomeRecipientKemPublicKey,
+          )})`,
+        );
+      }
+      welcomeRecipientKemPublicKey = Base64.toUint8Array(
+        raw.welcomeRecipientKemPublicKey,
+      );
+    }
+    let eciesSealed: Uint8Array | undefined;
+    if (raw.eciesSealed !== undefined) {
+      if (typeof raw.eciesSealed !== 'string') {
+        throw new Error(
+          `Invalid sync message: 'eciesSealed' must be a string when present (got ${describeValue(
+            raw.eciesSealed,
+          )})`,
+        );
+      }
+      eciesSealed = Base64.toUint8Array(raw.eciesSealed);
+    }
     // Build the returned object explicitly rather than spreading `...raw` so
     // that peer-supplied junk keys (e.g. `__proto__`, `constructor`, or any
     // unrecognized field) don't leak into the deserialized sync message. Only
@@ -670,6 +701,9 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
     if (keychainChanges !== undefined) result.keychainChanges = keychainChanges;
     if (welcomeEpochId !== undefined) result.welcomeEpochId = welcomeEpochId;
     if (welcomeRecipient !== undefined) result.welcomeRecipient = welcomeRecipient;
+    if (welcomeRecipientKemPublicKey !== undefined)
+      result.welcomeRecipientKemPublicKey = welcomeRecipientKemPublicKey;
+    if (eciesSealed !== undefined) result.eciesSealed = eciesSealed;
     if (snapshot !== undefined) result.snapshot = snapshot;
     return result;
   }

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -93,6 +93,11 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
         // `welcomeRecipient` is already a string (the serialized recipient
         // public key); pass through verbatim.
         welcomeRecipient: message.welcomeRecipient,
+        welcomeRecipientKemPublicKey:
+          message.welcomeRecipientKemPublicKey &&
+          Base64.fromUint8Array(message.welcomeRecipientKemPublicKey),
+        eciesSealed:
+          message.eciesSealed && Base64.fromUint8Array(message.eciesSealed),
         snapshot: snapshotForWire,
       }),
     );
@@ -117,6 +122,8 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
       keychainChanges?: unknown;
       welcomeEpochId?: unknown;
       welcomeRecipient?: unknown;
+      welcomeRecipientKemPublicKey?: unknown;
+      eciesSealed?: unknown;
       snapshot?: unknown;
       signature?: unknown;
     };
@@ -194,6 +201,30 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
       }
       welcomeEpochId = Base64.toUint8Array(raw.welcomeEpochId);
     }
+    let welcomeRecipientKemPublicKey: Uint8Array | undefined;
+    if (raw.welcomeRecipientKemPublicKey !== undefined) {
+      if (typeof raw.welcomeRecipientKemPublicKey !== 'string') {
+        throw new Error(
+          `Invalid sync message: 'welcomeRecipientKemPublicKey' must be a string when present (got ${describeValue(
+            raw.welcomeRecipientKemPublicKey,
+          )})`,
+        );
+      }
+      welcomeRecipientKemPublicKey = Base64.toUint8Array(
+        raw.welcomeRecipientKemPublicKey,
+      );
+    }
+    let eciesSealed: Uint8Array | undefined;
+    if (raw.eciesSealed !== undefined) {
+      if (typeof raw.eciesSealed !== 'string') {
+        throw new Error(
+          `Invalid sync message: 'eciesSealed' must be a string when present (got ${describeValue(
+            raw.eciesSealed,
+          )})`,
+        );
+      }
+      eciesSealed = Base64.toUint8Array(raw.eciesSealed);
+    }
     let welcomeRecipient: string | undefined;
     if (raw.welcomeRecipient !== undefined) {
       if (typeof raw.welcomeRecipient !== 'string') {
@@ -227,6 +258,9 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
     if (keychainChanges !== undefined) result.keychainChanges = keychainChanges;
     if (welcomeEpochId !== undefined) result.welcomeEpochId = welcomeEpochId;
     if (welcomeRecipient !== undefined) result.welcomeRecipient = welcomeRecipient;
+    if (welcomeRecipientKemPublicKey !== undefined)
+      result.welcomeRecipientKemPublicKey = welcomeRecipientKemPublicKey;
+    if (eciesSealed !== undefined) result.eciesSealed = eciesSealed;
     if (snapshot !== undefined) result.snapshot = snapshot;
     return result;
   }

--- a/packages/collabswarm-yjs/src/yjs-provider.test.ts
+++ b/packages/collabswarm-yjs/src/yjs-provider.test.ts
@@ -592,6 +592,32 @@ describe('YjsJSONSerializer', () => {
     expect(deserialized.welcomeRecipient).toBeUndefined();
   });
 
+  test('serializeSyncMessage/deserializeSyncMessage preserves welcomeRecipientKemPublicKey', () => {
+    const serializer = new YjsJSONSerializer();
+    const kemPub = new Uint8Array(65);
+    for (let i = 0; i < kemPub.length; i++) kemPub[i] = (i * 11) & 0xff;
+    const message = {
+      documentId: 'welcome-doc',
+      welcomeRecipientKemPublicKey: kemPub,
+    };
+    const serialized = serializer.serializeSyncMessage(message);
+    const deserialized = serializer.deserializeSyncMessage(serialized);
+    expect(deserialized.welcomeRecipientKemPublicKey).toEqual(kemPub);
+  });
+
+  test('serializeSyncMessage/deserializeSyncMessage preserves eciesSealed', () => {
+    const serializer = new YjsJSONSerializer();
+    const sealed = new Uint8Array(200);
+    for (let i = 0; i < sealed.length; i++) sealed[i] = (i * 13) & 0xff;
+    const message = {
+      documentId: 'welcome-doc',
+      eciesSealed: sealed,
+    };
+    const serialized = serializer.serializeSyncMessage(message);
+    const deserialized = serializer.deserializeSyncMessage(serialized);
+    expect(deserialized.eciesSealed).toEqual(sealed);
+  });
+
   test('serializeChangeBlock/deserializeChangeBlock round-trip with keyID', () => {
     const serializer = new YjsJSONSerializer();
     const block = {

--- a/packages/collabswarm/src/beekem-pending-welcomes.test.ts
+++ b/packages/collabswarm/src/beekem-pending-welcomes.test.ts
@@ -150,7 +150,13 @@ function welcomeFor(
     documentId: '/doc/welcome',
     welcomeEpochId: new Uint8Array(32).fill(epochByte),
     welcomeRecipient: recipient,
-    keychainChanges: new Uint8Array([1, 2, 3]),
+    // Recipient KEM binding + sealed payload presence are both
+    // structurally required by the validator post-encryption. The
+    // pending-welcomes buffer is concerned with reordering only --
+    // the seal/open round-trip is exercised by
+    // `beekem-welcome-encryption.test.ts`.
+    welcomeRecipientKemPublicKey: new Uint8Array(65).fill(0xaa),
+    eciesSealed: new Uint8Array([1, 2, 3]),
     // Welcomes are unconditionally writer-authenticated; the stub
     // `verifyWriterSignature` in `depsFor` returns `true` for any
     // signed payload, so this string just satisfies the signature
@@ -207,7 +213,8 @@ describe('BeeKEM pending-welcomes buffer (readers-ACL / Welcome reordering)', ()
     const msg: CRDTSyncMessage<ChangesType, PublicKey> = {
       documentId: '/doc/welcome',
       welcomeRecipient: 'me',
-      keychainChanges: new Uint8Array([1, 2, 3]),
+      welcomeRecipientKemPublicKey: new Uint8Array(65).fill(0xaa),
+      eciesSealed: new Uint8Array([1, 2, 3]),
       // welcomeEpochId omitted
     };
     await h.evaluateAndApply(msg, { fromBuffer: false });

--- a/packages/collabswarm/src/beekem-welcome-encryption.test.ts
+++ b/packages/collabswarm/src/beekem-welcome-encryption.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  eciesSeal,
+  eciesOpen,
+  generateEciesKeyPair,
+  importEciesPublicKey,
+  exportEciesPublicKey,
+} from './ecies';
+
+/**
+ * Wire-level coverage of the BeeKEM Welcome payload encryption flow.
+ *
+ * The production receive path
+ * (`CollabswarmDocument._evaluateAndApplyBeeKEMWelcome`) requires a
+ * full libp2p/Helia stack to instantiate, so this file exercises the
+ * security-critical invariants of the sealed-payload design directly
+ * against the `ecies` primitive that wraps the keychain delta:
+ *
+ *   1. The recipient with the matching ECDH private key can open
+ *      the sealed payload and recover the plaintext keychain delta.
+ *   2. A non-recipient peer (different ECDH key pair) sees only
+ *      opaque ciphertext and cannot decrypt the payload even if it
+ *      observes the full broadcast.
+ *   3. A tampered sealed payload fails the AES-GCM integrity check
+ *      regardless of which recipient attempts to open it.
+ *
+ * The "Welcome" in these tests is modeled as the bytes that would
+ * appear in the `eciesSealed` field of a `CRDTSyncMessage`. The
+ * surrounding signature / recipient-binding checks are covered by
+ * `beekem-welcome-handler.test.ts`.
+ */
+
+describe('BeeKEM Welcome payload encryption (round-trip via ECIES)', () => {
+  test('intended recipient can open the sealed Welcome and recover the keychain delta', async () => {
+    const recipient = await generateEciesKeyPair();
+    const keychainDelta = new TextEncoder().encode(
+      'pretend-this-is-a-serialized-keychain-CRDT-delta',
+    );
+
+    // Inviter: seal the keychain delta to the recipient's public key.
+    const sealed = await eciesSeal(keychainDelta, recipient.publicKey);
+
+    // Recipient: open with their private key.
+    const opened = await eciesOpen(sealed, recipient.privateKey);
+    expect(new TextDecoder().decode(opened)).toBe(
+      'pretend-this-is-a-serialized-keychain-CRDT-delta',
+    );
+  });
+
+  test('a non-recipient peer observing the sealed Welcome cannot decrypt it', async () => {
+    const intendedRecipient = await generateEciesKeyPair();
+    const eavesdropper = await generateEciesKeyPair();
+
+    const keychainDelta = new TextEncoder().encode('document-key-material');
+    const sealed = await eciesSeal(
+      keychainDelta,
+      intendedRecipient.publicKey,
+    );
+
+    // An eavesdropper with a DIFFERENT ECDH key pair (e.g. another
+    // connected libp2p peer who is not the addressed reader) cannot
+    // recover the keychain delta even with full access to the
+    // broadcast sealed bytes.
+    await expect(
+      eciesOpen(sealed, eavesdropper.privateKey),
+    ).rejects.toThrow();
+  });
+
+  test('round-trip via raw-exported public key matches the design wire format', async () => {
+    // The Welcome carries the recipient's KEM public key as raw
+    // SEC1-uncompressed bytes (65 bytes for P-256) in the
+    // `welcomeRecipientKemPublicKey` field. The inviter imports those
+    // bytes and seals against the resulting CryptoKey -- mirror that
+    // path here so a regression in the raw-bytes representation
+    // surfaces.
+    const recipient = await generateEciesKeyPair();
+    const rawRecipientPub = await exportEciesPublicKey(recipient.publicKey);
+    expect(rawRecipientPub.byteLength).toBe(65);
+
+    const importedRecipientPub = await importEciesPublicKey(rawRecipientPub);
+    const keychainDelta = new Uint8Array([42, 13, 7, 1, 0, 255]);
+    const sealed = await eciesSeal(keychainDelta, importedRecipientPub);
+
+    const opened = await eciesOpen(sealed, recipient.privateKey);
+    expect(opened).toEqual(keychainDelta);
+  });
+
+  test('a tampered sealed Welcome (single bit flipped) is rejected by the recipient', async () => {
+    // Establishes that the signed-but-tampered case (where an attacker
+    // re-signs the sync message after altering the sealed bytes)
+    // would still fail decryption at the recipient. Combined with the
+    // writer-signature gate that covers `eciesSealed` itself, this
+    // gives belt-and-braces protection: the signature catches
+    // unauthorized writers, AES-GCM catches authorized writers (or
+    // anyone else) altering the ciphertext.
+    const recipient = await generateEciesKeyPair();
+    const sealed = await eciesSeal(
+      new TextEncoder().encode('keychain-payload'),
+      recipient.publicKey,
+    );
+
+    const tampered = new Uint8Array(sealed);
+    // Flip a bit in the ciphertext region (well past the salt /
+    // ephemeral key / nonce header so we exercise the AES-GCM tag).
+    tampered[tampered.byteLength - 1] ^= 0x01;
+    await expect(eciesOpen(tampered, recipient.privateKey)).rejects.toThrow();
+  });
+
+  test('two recipients invited at the same epoch get distinct sealed payloads', async () => {
+    // Two new readers added to the same document at the same epoch
+    // produce independent sealed payloads (sender generates a fresh
+    // ephemeral key + nonce per call), each only openable by its
+    // intended recipient. Establishes there is no cross-decryption
+    // path even when the inviter, plaintext, and epoch are identical.
+    const alice = await generateEciesKeyPair();
+    const bob = await generateEciesKeyPair();
+
+    const keychainDelta = new TextEncoder().encode(
+      'epoch-1-keychain-delta-shared-by-both-welcomes',
+    );
+    const sealedToAlice = await eciesSeal(keychainDelta, alice.publicKey);
+    const sealedToBob = await eciesSeal(keychainDelta, bob.publicKey);
+
+    // Distinct ciphertexts (different ephemeral keys / nonces).
+    expect(sealedToAlice).not.toEqual(sealedToBob);
+
+    // Each recipient opens their own payload successfully.
+    expect(await eciesOpen(sealedToAlice, alice.privateKey)).toEqual(
+      keychainDelta,
+    );
+    expect(await eciesOpen(sealedToBob, bob.privateKey)).toEqual(
+      keychainDelta,
+    );
+
+    // Cross-decryption fails.
+    await expect(eciesOpen(sealedToAlice, bob.privateKey)).rejects.toThrow();
+    await expect(eciesOpen(sealedToBob, alice.privateKey)).rejects.toThrow();
+  });
+});

--- a/packages/collabswarm/src/beekem-welcome-handler.test.ts
+++ b/packages/collabswarm/src/beekem-welcome-handler.test.ts
@@ -152,6 +152,39 @@ describe('evaluateBeeKEMWelcome (security-critical gates)', () => {
     });
   });
 
+  test('drops Welcomes whose welcomeRecipientKemPublicKey is shorter than 65 bytes', async () => {
+    // The protocol fixes the recipient KEM public key at the
+    // SEC1-uncompressed P-256 size (65 bytes: 0x04 || X || Y). A
+    // shorter payload could not be a valid P-256 point; the validator
+    // is the single structural gate so we must reject it here instead
+    // of letting it pass and fail later inside `importEciesPublicKey`.
+    const msg = {
+      ...baseAcceptableMessage(),
+      welcomeRecipientKemPublicKey: new Uint8Array(64).fill(4),
+    };
+    const result = await evaluateBeeKEMWelcome(msg, makeDeps());
+    expect(result).toEqual({
+      kind: 'drop-malformed',
+      reason: 'invalid-recipient-kem-public-key-length',
+    });
+  });
+
+  test('drops Welcomes whose welcomeRecipientKemPublicKey is longer than 65 bytes', async () => {
+    // Same rationale as the 64-byte case: anything other than the
+    // fixed 65-byte uncompressed P-256 encoding is malformed and the
+    // validator must fail fast rather than handing a wrong-length
+    // buffer downstream.
+    const msg = {
+      ...baseAcceptableMessage(),
+      welcomeRecipientKemPublicKey: new Uint8Array(66).fill(4),
+    };
+    const result = await evaluateBeeKEMWelcome(msg, makeDeps());
+    expect(result).toEqual({
+      kind: 'drop-malformed',
+      reason: 'invalid-recipient-kem-public-key-length',
+    });
+  });
+
   test('drops Welcomes missing eciesSealed (would wedge the recipient)', async () => {
     // Without the sealed keychain delta the recipient would record
     // `welcomeEpochId` as their `_invitationEpoch` but have no

--- a/packages/collabswarm/src/beekem-welcome-handler.test.ts
+++ b/packages/collabswarm/src/beekem-welcome-handler.test.ts
@@ -63,13 +63,20 @@ function makeDeps(
  * validator no longer has an `isSigningEnabled` toggle -- so the base
  * acceptable message must carry a `signature` for the happy-path
  * assertions to hold.
+ *
+ * Note: confidentiality is enforced via the `eciesSealed` field
+ * (encrypted to `welcomeRecipientKemPublicKey`); the validator
+ * checks both fields are present and non-empty but does not attempt
+ * to open the seal (that happens in the production receive path
+ * after validation).
  */
 function baseAcceptableMessage(): CRDTSyncMessage<ChangesType, PublicKey> {
   return {
     documentId: '/doc/welcome',
     welcomeEpochId: new Uint8Array(32).fill(7),
     welcomeRecipient: 'my-pubkey',
-    keychainChanges: new Uint8Array([1, 2, 3]),
+    welcomeRecipientKemPublicKey: new Uint8Array(65).fill(4),
+    eciesSealed: new Uint8Array([1, 2, 3]),
     signature: 'good-sig',
   };
 }
@@ -123,33 +130,55 @@ describe('evaluateBeeKEMWelcome (security-critical gates)', () => {
     });
   });
 
-  test('drops Welcomes missing keychainChanges (would wedge the recipient)', async () => {
-    // Without keychainChanges the recipient would record
+  test('drops Welcomes missing welcomeRecipientKemPublicKey (recipient KEM binding gate)', async () => {
+    const msg = baseAcceptableMessage();
+    delete msg.welcomeRecipientKemPublicKey;
+    const result = await evaluateBeeKEMWelcome(msg, makeDeps());
+    expect(result).toEqual({
+      kind: 'drop-malformed',
+      reason: 'missing-recipient-kem-public-key',
+    });
+  });
+
+  test('drops Welcomes with an empty welcomeRecipientKemPublicKey', async () => {
+    const msg = {
+      ...baseAcceptableMessage(),
+      welcomeRecipientKemPublicKey: new Uint8Array(0),
+    };
+    const result = await evaluateBeeKEMWelcome(msg, makeDeps());
+    expect(result).toEqual({
+      kind: 'drop-malformed',
+      reason: 'missing-recipient-kem-public-key',
+    });
+  });
+
+  test('drops Welcomes missing eciesSealed (would wedge the recipient)', async () => {
+    // Without the sealed keychain delta the recipient would record
     // `welcomeEpochId` as their `_invitationEpoch` but have no
     // corresponding key installed in their keychain, leaving them
     // unable to decrypt traffic and corrupting later `since_invited`
     // filtering. The validator must refuse to accept such a Welcome.
     const msg = baseAcceptableMessage();
-    delete msg.keychainChanges;
+    delete msg.eciesSealed;
     const result = await evaluateBeeKEMWelcome(msg, makeDeps());
     expect(result).toEqual({
       kind: 'drop-malformed',
-      reason: 'missing-keychain-changes',
+      reason: 'missing-ecies-sealed',
     });
   });
 
-  test('drops Welcomes with empty keychainChanges (zero-length payload)', async () => {
-    // An empty Uint8Array carries no key material, so it has the same
-    // wedge potential as a missing field. The validator must reject
-    // it for the same reason.
+  test('drops Welcomes with empty eciesSealed (zero-length payload)', async () => {
+    // An empty sealed payload carries no key material, so it has the
+    // same wedge potential as a missing field. The validator must
+    // reject it for the same reason.
     const msg = {
       ...baseAcceptableMessage(),
-      keychainChanges: new Uint8Array(0),
+      eciesSealed: new Uint8Array(0),
     };
     const result = await evaluateBeeKEMWelcome(msg, makeDeps());
     expect(result).toEqual({
       kind: 'drop-malformed',
-      reason: 'missing-keychain-changes',
+      reason: 'missing-ecies-sealed',
     });
   });
 

--- a/packages/collabswarm/src/beekem-welcome-handler.ts
+++ b/packages/collabswarm/src/beekem-welcome-handler.ts
@@ -18,6 +18,7 @@
  */
 
 import { CRDTSyncMessage } from './crdt-sync-message';
+import { ECIES_P256_PUBLIC_KEY_LENGTH } from './ecies';
 import { SyncMessageSerializer } from './sync-message-serializer';
 
 /**
@@ -45,6 +46,7 @@ export type WelcomeMalformedReason =
   | 'missing-welcome-epoch-id'
   | 'missing-welcome-recipient'
   | 'missing-recipient-kem-public-key'
+  | 'invalid-recipient-kem-public-key-length'
   | 'missing-ecies-sealed';
 
 export type WelcomeUnauthorizedReason =
@@ -159,6 +161,24 @@ export async function evaluateBeeKEMWelcome<ChangesType, PublicKey>(
     return {
       kind: 'drop-malformed',
       reason: 'missing-recipient-kem-public-key',
+    };
+  }
+
+  // The protocol requires the recipient KEM public key to be a fixed
+  // 65-byte SEC1-uncompressed P-256 point (0x04 || X || Y); see
+  // `ECIES_P256_PUBLIC_KEY_LENGTH`. Enforce the length here so the
+  // validator stays the single structural gate: anything else would
+  // otherwise pass this gate and fail later inside the receive path
+  // (e.g. `importEciesPublicKey` rejects on length mismatch) with a
+  // less specific error. Treating it as malformed lets the bounded
+  // pending-Welcome buffer drop it cleanly without retrying.
+  if (
+    message.welcomeRecipientKemPublicKey.byteLength !==
+    ECIES_P256_PUBLIC_KEY_LENGTH
+  ) {
+    return {
+      kind: 'drop-malformed',
+      reason: 'invalid-recipient-kem-public-key-length',
     };
   }
 

--- a/packages/collabswarm/src/beekem-welcome-handler.ts
+++ b/packages/collabswarm/src/beekem-welcome-handler.ts
@@ -44,7 +44,8 @@ export type WelcomeMalformedReason =
   | 'wrong-document'
   | 'missing-welcome-epoch-id'
   | 'missing-welcome-recipient'
-  | 'missing-keychain-changes';
+  | 'missing-recipient-kem-public-key'
+  | 'missing-ecies-sealed';
 
 export type WelcomeUnauthorizedReason =
   | 'not-in-readers-acl'
@@ -146,32 +147,32 @@ export async function evaluateBeeKEMWelcome<ChangesType, PublicKey>(
     return { kind: 'drop-malformed', reason: 'missing-welcome-recipient' };
   }
 
-  // A Welcome without `keychainChanges` is useless: the recipient
-  // would record `welcomeEpochId` as their invitation epoch (gating
-  // future `since_invited` history filtering) without installing the
-  // corresponding document key, leaving them unable to decrypt any
-  // pubsub traffic. Worse, recording an epoch the recipient cannot
-  // back up with a key in their keychain can make later visibility
-  // filtering misbehave (the local view believes "I joined at epoch
-  // E" but has no E key). Treat a missing/empty payload as malformed
-  // and refuse to record the epoch.
-  const keychainChanges = message.keychainChanges as
-    | { length?: number; byteLength?: number }
-    | undefined;
-  // Treat unknown shapes (no `length`, no `byteLength`) as malformed by
-  // computing `0` for the fallback case. Combined with `<= 0` below this
-  // fails closed for any structurally invalid payload rather than
-  // accepting it and exploding later during the keychain merge.
-  const keychainChangesLength =
-    keychainChanges == null
-      ? 0
-      : typeof keychainChanges.length === 'number'
-        ? keychainChanges.length
-        : typeof keychainChanges.byteLength === 'number'
-          ? keychainChanges.byteLength
-          : 0;
-  if (keychainChanges == null || keychainChangesLength <= 0) {
-    return { kind: 'drop-malformed', reason: 'missing-keychain-changes' };
+  // The recipient KEM public key binds the sealed payload to a
+  // specific encryption key. Required so the writer can sign over the
+  // identity-to-encryption-key mapping; without it, an attacker
+  // controlling one of the two keys alone could attempt to substitute
+  // the sealed payload.
+  if (
+    !message.welcomeRecipientKemPublicKey ||
+    message.welcomeRecipientKemPublicKey.byteLength === 0
+  ) {
+    return {
+      kind: 'drop-malformed',
+      reason: 'missing-recipient-kem-public-key',
+    };
+  }
+
+  // A Welcome without an `eciesSealed` payload is useless: the
+  // recipient would record `welcomeEpochId` as their invitation epoch
+  // (gating future `since_invited` history filtering) without
+  // installing the corresponding document key, leaving them unable to
+  // decrypt any pubsub traffic. Worse, recording an epoch the
+  // recipient cannot back up with a key in their keychain can make
+  // later visibility filtering misbehave (the local view believes "I
+  // joined at epoch E" but has no E key). Treat a missing/empty
+  // sealed payload as malformed and refuse to record the epoch.
+  if (!message.eciesSealed || message.eciesSealed.byteLength === 0) {
+    return { kind: 'drop-malformed', reason: 'missing-ecies-sealed' };
   }
 
   const localSerializedKey = await deps.serializePublicKey(

--- a/packages/collabswarm/src/beekem-welcome.test.ts
+++ b/packages/collabswarm/src/beekem-welcome.test.ts
@@ -119,17 +119,25 @@ function keychainChangesForWelcome(
 
 /**
  * Mirrors the receive-side state mutations from
- * `CollabswarmDocument.handleBeeKEMWelcomeRequestData`:
+ * `CollabswarmDocument.handleBeeKEMWelcomeRequestData` AFTER the
+ * ECIES seal has been opened:
  *  - drop if `welcomeEpochId` is missing
  *  - drop if `welcomeRecipient` is missing or does not match the local
  *    serialized public key
- *  - merge keychain changes from the welcome
+ *  - merge keychain changes (decrypted from `eciesSealed`) from the welcome
  *  - record `welcomeEpochId` as `_invitationEpoch`
  *
- * The signature and readers-ACL checks are not modeled in this helper;
- * direct unit-test coverage of those security-critical gates lives in
- * `beekem-welcome-handler.test.ts`, which drives the extracted
- * `evaluateBeeKEMWelcome` function with mock providers. Full
+ * For convenience, this in-memory mirror reads the plaintext keychain
+ * delta directly from `keychainChanges` on the test message rather
+ * than running the full ECIES seal/open round-trip. Direct
+ * unit coverage of the ECIES primitive lives in `ecies.test.ts`; the
+ * wire-level "non-recipient cannot read the seal" property is covered
+ * in `beekem-welcome-encryption.test.ts`.
+ *
+ * The signature, readers-ACL, and seal-presence checks are not modeled
+ * in this helper; direct unit-test coverage of those security-critical
+ * gates lives in `beekem-welcome-handler.test.ts`, which drives the
+ * extracted `evaluateBeeKEMWelcome` function with mock providers. Full
  * end-to-end coverage that stands up a real `CollabswarmDocument` over
  * libp2p/Helia lives in `e2e/integration/`.
  *
@@ -152,6 +160,10 @@ function applyWelcomeStateChanges(
   // unconditionally.
   if (!message.welcomeRecipient) return;
   if (message.welcomeRecipient !== state.localSerializedKey) return;
+  // In the in-memory mirror, `keychainChanges` stands in for the
+  // ECIES-opened plaintext that production code recovers from
+  // `eciesSealed`. The mirror does not run ECIES; the seal/open
+  // round-trip is covered separately in `ecies.test.ts`.
   if (message.keychainChanges) state.keychain.merge(message.keychainChanges);
   // Monotonic-forward update: never regress the invitation-epoch
   // anchor (mirrors `CollabswarmDocument._shouldAdvanceInvitationEpoch`).

--- a/packages/collabswarm/src/beekem/beekem.ts
+++ b/packages/collabswarm/src/beekem/beekem.ts
@@ -8,16 +8,11 @@ import {
   WelcomeNodePublicKey,
 } from './types';
 import * as TreeMath from './tree-math';
+import { eciesSeal, eciesOpen } from '../ecies';
 
 /** ECDH curve used for tree key pairs. */
 const ECDH_CURVE = 'P-256';
 const ECDH_ALGO = { name: 'ECDH', namedCurve: ECDH_CURVE };
-
-/** AES-GCM nonce length in bytes. */
-const AES_NONCE_LENGTH = 12;
-
-/** HKDF salt length in bytes. */
-const HKDF_SALT_LENGTH = 32;
 
 /** Cast Uint8Array to ArrayBuffer for WebCrypto API compatibility. */
 function toBuffer(data: Uint8Array): ArrayBuffer {
@@ -662,159 +657,34 @@ export class BeeKEM {
   }
 
   /**
-   * Encrypt a CryptoKey's PKCS8 representation using ECIES:
-   * ECDH with an ephemeral key + HKDF (random salt) + AES-256-GCM.
-   *
-   * Output format: [32 bytes salt] [65 bytes ephemeral public key] [12 bytes nonce] [ciphertext + tag]
+   * Encrypt a CryptoKey's PKCS8 representation using the shared ECIES
+   * primitive in `ecies.ts` (P-256 ECDH ephemeral + HKDF-SHA-256 +
+   * AES-256-GCM). The output format is documented in `ecies.ts`.
    */
   private async _encryptNodeKey(
     keyToEncrypt: CryptoKey,
     recipientPublicKey: CryptoKey,
   ): Promise<Uint8Array> {
-    // Generate ephemeral ECDH key pair for ECIES
-    const ephemeral = await crypto.subtle.generateKey(ECDH_ALGO, true, [
-      'deriveBits',
-    ]);
-
-    // ECDH to derive shared secret
-    const sharedBits = await crypto.subtle.deriveBits(
-      { name: 'ECDH', public: recipientPublicKey },
-      ephemeral.privateKey,
-      256,
+    const exportedKey = new Uint8Array(
+      await crypto.subtle.exportKey('pkcs8', keyToEncrypt),
     );
-
-    // Random salt for HKDF domain separation
-    const salt = crypto.getRandomValues(new Uint8Array(HKDF_SALT_LENGTH));
-
-    // Derive AES key from shared secret via HKDF
-    const hkdfKey = await crypto.subtle.importKey(
-      'raw',
-      sharedBits,
-      'HKDF',
-      false,
-      ['deriveKey'],
-    );
-    // ECIES key wrapping always uses AES-GCM for its built-in AEAD
-    // authentication, regardless of the document encryption algorithm.
-    const aesKey = await crypto.subtle.deriveKey(
-      {
-        name: 'HKDF',
-        hash: 'SHA-256',
-        salt,
-        info: new TextEncoder().encode('beekem-ecies'),
-      },
-      hkdfKey,
-      { name: 'AES-GCM', length: 256 },
-      false,
-      ['encrypt'],
-    );
-
-    // Export the key to encrypt
-    const exportedKey = await crypto.subtle.exportKey('pkcs8', keyToEncrypt);
-
-    // Encrypt with AES-GCM
-    const nonce = crypto.getRandomValues(new Uint8Array(AES_NONCE_LENGTH));
-    const ciphertext = await crypto.subtle.encrypt(
-      { name: 'AES-GCM', iv: nonce },
-      aesKey,
-      exportedKey,
-    );
-
-    // Export ephemeral public key (uncompressed point, 65 bytes for P-256)
-    const ephemeralPub = new Uint8Array(
-      await crypto.subtle.exportKey('raw', ephemeral.publicKey),
-    );
-
-    // Concatenate: salt || ephemeralPub || nonce || ciphertext
-    const result = new Uint8Array(
-      salt.byteLength +
-        ephemeralPub.byteLength +
-        nonce.byteLength +
-        ciphertext.byteLength,
-    );
-    let offset = 0;
-    result.set(salt, offset);
-    offset += salt.byteLength;
-    result.set(ephemeralPub, offset);
-    offset += ephemeralPub.byteLength;
-    result.set(nonce, offset);
-    offset += nonce.byteLength;
-    result.set(new Uint8Array(ciphertext), offset);
-
-    return result;
+    return eciesSeal(exportedKey, recipientPublicKey);
   }
 
   /**
-   * Decrypt a node key encrypted via ECIES.
-   * Reverses the _encryptNodeKey operation.
+   * Decrypt a node key encrypted via `_encryptNodeKey` / ECIES, and
+   * re-import the result as a P-256 ECDH private key.
    */
   private async _decryptNodeKey(
     encryptedData: Uint8Array,
     recipientPrivateKey: CryptoKey,
   ): Promise<CryptoKey> {
-    // Parse: salt (32 bytes) || ephemeralPub (65 bytes) || nonce (12 bytes) || ciphertext
-    let pos = 0;
-    const salt = encryptedData.slice(pos, pos + HKDF_SALT_LENGTH);
-    pos += HKDF_SALT_LENGTH;
+    const plaintext = await eciesOpen(encryptedData, recipientPrivateKey);
 
-    const ephPubLen = 65; // Uncompressed P-256 point
-    const ephemeralPubBytes = encryptedData.slice(pos, pos + ephPubLen);
-    pos += ephPubLen;
-
-    const nonce = encryptedData.slice(pos, pos + AES_NONCE_LENGTH);
-    pos += AES_NONCE_LENGTH;
-
-    const ciphertext = encryptedData.slice(pos);
-
-    // Import ephemeral public key
-    const ephemeralPublicKey = await crypto.subtle.importKey(
-      'raw',
-      toBuffer(ephemeralPubBytes),
-      ECDH_ALGO,
-      true,
-      [],
-    );
-
-    // ECDH to derive shared secret
-    const sharedBits = await crypto.subtle.deriveBits(
-      { name: 'ECDH', public: ephemeralPublicKey },
-      recipientPrivateKey,
-      256,
-    );
-
-    // Derive AES key (same params as encrypt, with the extracted salt)
-    const hkdfKey = await crypto.subtle.importKey(
-      'raw',
-      sharedBits,
-      'HKDF',
-      false,
-      ['deriveKey'],
-    );
-    // ECIES key unwrapping always uses AES-GCM (see _encryptNodeKey comment).
-    const aesKey = await crypto.subtle.deriveKey(
-      {
-        name: 'HKDF',
-        hash: 'SHA-256',
-        salt,
-        info: new TextEncoder().encode('beekem-ecies'),
-      },
-      hkdfKey,
-      { name: 'AES-GCM', length: 256 },
-      false,
-      ['decrypt'],
-    );
-
-    // Decrypt
-    const plaintext = await crypto.subtle.decrypt(
-      { name: 'AES-GCM', iv: toBuffer(nonce) },
-      aesKey,
-      toBuffer(ciphertext),
-    );
-
-    // Import as ECDH private key
+    // Import as ECDH private key.
     return crypto.subtle.importKey(
       'pkcs8',
-      plaintext,
+      toBuffer(plaintext),
       ECDH_ALGO,
       true,
       ['deriveBits'],

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -331,42 +331,6 @@ export interface CollabswarmConfig {
   webrtcIceServers?: ReadonlyArray<Readonly<IceServer>>;
 
   /**
-   * Opt-in flag enabling the BeeKEM Welcome broadcast onboarding path.
-   *
-   * **DEFAULT: `false` (safe-by-default).** When `false`, calls to
-   * `addReader()` skip the BeeKEM Welcome dispatch and emit a warning,
-   * and `_sendBeeKEMWelcome()` is a no-op. The new reader will still be
-   * added to the readers ACL (so their pubsub messages are accepted),
-   * but they will not receive the inviter-side keychain delta until
-   * they perform a fresh document load against an authorized peer.
-   *
-   * **CONFIDENTIALITY WARNING.** When this
-   * flag is `true`, `_sendBeeKEMWelcome` broadcasts a *plaintext*
-   * `keychainChanges` payload (including current document key material)
-   * over the `/collabswarm/beekem-welcome/1.0.0` protocol to **every**
-   * currently-connected libp2p peer. The `welcomeRecipient` binding is
-   * an authorization control (honest non-target peers drop the
-   * Welcome), **not** a confidentiality control. Any connected peer at
-   * broadcast time -- including unauthorized or actively malicious ones
-   * -- can observe the payload, retain the keychain delta, and use it
-   * to decrypt subsequent pubsub traffic for this document. libp2p's
-   * Noise/TLS transport protects on-wire bytes from off-path observers
-   * but does nothing to limit which connected peers see the
-   * application-layer payload.
-   *
-   * Only enable this flag in deployments where the connection set is
-   * already trusted (e.g. authenticated private swarms, closed
-   * test/lab environments, or networks fronted by an authenticated
-   * relay that filters which peers can connect). For untrusted /
-   * public mesh deployments, leave this `false` and rely on
-   * fresh-document-load onboarding until recipient-encrypted key
-   * delivery (HPKE/ECIES; tracked as `#BEEKEM-PAYLOAD-ENC`) lands.
-   *
-   * @default false
-   */
-  experimentalBeeKEMBroadcastWelcome?: boolean;
-
-  /**
    * Optional callback to validate document paths before creation.
    *
    * Called when `open()` determines the document is new (i.e., `load()` returned

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -311,7 +311,10 @@ export class CollabswarmDocument<
     const rawPublic = await validateAndExportKemKeyPair(keyPair);
 
     this._kemKeyPair = keyPair;
-    this._kemPublicKeyRaw = rawPublic;
+    // Defensive copy: ensure the cached bytes are isolated from the
+    // buffer returned by the helper so callers (and the helper's own
+    // internal state) cannot mutate `_kemPublicKeyRaw` after the fact.
+    this._kemPublicKeyRaw = new Uint8Array(rawPublic);
   }
 
   /**
@@ -321,11 +324,14 @@ export class CollabswarmDocument<
    * `addReader(reader, readerKemPublicKey)`.
    *
    * Cheap: the raw bytes are cached on `setKemKeyPair`; this just
-   * returns the cached `Uint8Array`. The method is still async to
-   * preserve the previous contract.
+   * returns a defensive copy of the cached `Uint8Array` so callers
+   * cannot accidentally mutate the document's internal state (e.g.
+   * `raw[0] = ...`), which would otherwise cause hard-to-debug
+   * Welcome drops/mismatches on the receive path. The method is still
+   * async to preserve the previous contract.
    */
   public async getKemPublicKeyRaw(): Promise<Uint8Array | undefined> {
-    return this._kemPublicKeyRaw;
+    return this._kemPublicKeyRaw && new Uint8Array(this._kemPublicKeyRaw);
   }
 
   /**
@@ -3071,6 +3077,15 @@ export class CollabswarmDocument<
       );
     }
 
+    // Defensive copy: snapshot the recipient's KEM public key bytes once
+    // at the entry point so a caller that reuses or mutates the same
+    // buffer (or shares it across async tasks) after `addReader` returns
+    // cannot corrupt the in-flight Welcome. Both the signed message
+    // field (`welcomeRecipientKemPublicKey`) and the WebCrypto import
+    // must observe the *same* byte sequence; otherwise the receiver
+    // would see a signature/payload mismatch.
+    const kemPub = new Uint8Array(readerKemPublicKey);
+
     // Build the welcome message.
     const welcomeMessage: CRDTSyncMessage<ChangesType, PublicKey> = {
       documentId: this.documentPath,
@@ -3097,7 +3112,7 @@ export class CollabswarmDocument<
       'BeeKEM Welcome onboarding',
     );
     welcomeMessage.welcomeRecipient = await serializePublicKey(reader);
-    welcomeMessage.welcomeRecipientKemPublicKey = readerKemPublicKey;
+    welcomeMessage.welcomeRecipientKemPublicKey = kemPub;
 
     // Visibility-filtered keychain so the new reader can decrypt the
     // appropriate window of document history. Note: this uses
@@ -3115,7 +3130,7 @@ export class CollabswarmDocument<
     // the plaintext; every other connected peer that observes the
     // broadcast sees only opaque ciphertext + ephemeral public key +
     // nonce + AES-GCM tag.
-    const recipientKemKey = await importEciesPublicKey(readerKemPublicKey);
+    const recipientKemKey = await importEciesPublicKey(kemPub);
     welcomeMessage.eciesSealed = await eciesSeal(
       keychainPlaintextBytes,
       recipientKemKey,

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -37,6 +37,7 @@ import { CRDTSyncMessage } from './crdt-sync-message';
 import { ChangesSerializer } from './changes-serializer';
 import { SyncMessageSerializer } from './sync-message-serializer';
 import { evaluateBeeKEMWelcome } from './beekem-welcome-handler';
+import { validateAndExportKemKeyPair } from './kem-key-pair';
 import {
   eciesSeal,
   eciesOpen,
@@ -260,6 +261,14 @@ export class CollabswarmDocument<
   // out-of-band so they can pass it to `addReader`.
   private _kemKeyPair: CryptoKeyPair | undefined;
 
+  // Cached raw SEC1-uncompressed bytes for `_kemKeyPair.publicKey`,
+  // populated eagerly inside `setKemKeyPair` so the receive path
+  // (`_evaluateAndApplyBeeKEMWelcome`) never has to await an `exportKey`
+  // call -- and so a non-exportable public key surfaces as a clear
+  // error at installation time rather than as a generic WebCrypto
+  // exception inside the Welcome handler.
+  private _kemPublicKeyRaw: Uint8Array | undefined;
+
   /**
    * Install the recipient-side ECDH (P-256) key pair used to open
    * incoming BeeKEM Welcome sealed payloads. The application is
@@ -273,11 +282,36 @@ export class CollabswarmDocument<
    * fine. Pass `undefined` to clear (subsequent Welcomes will be
    * dropped).
    *
-   * The private key MUST have `'deriveBits'` in its key usages so
-   * `eciesOpen` can perform the ECDH step.
+   * Validation: the key pair MUST be an ECDH P-256 pair, and the
+   * private key MUST have `'deriveBits'` in its key usages so
+   * `eciesOpen` can perform the ECDH step. The public key MUST be
+   * raw-exportable (the inviter-side flow ships those bytes as the
+   * `welcomeRecipientKemPublicKey` field). Mismatches are rejected
+   * here with a descriptive error rather than silently accepted and
+   * surfaced as a generic WebCrypto failure later in the Welcome
+   * receive path.
+   *
+   * Async because the public key is eagerly exported to raw bytes and
+   * cached for the receive path; callers that previously invoked this
+   * synchronously must now `await` it.
    */
-  public setKemKeyPair(keyPair: CryptoKeyPair | undefined): void {
+  public async setKemKeyPair(
+    keyPair: CryptoKeyPair | undefined,
+  ): Promise<void> {
+    if (keyPair === undefined) {
+      this._kemKeyPair = undefined;
+      this._kemPublicKeyRaw = undefined;
+      return;
+    }
+
+    // Algorithm/curve/usages validation + eager raw-export, kept in
+    // a standalone helper so the validation surface can be unit-tested
+    // without standing up the full document dependency graph.
+    // Throws a clear, install-time error on misconfiguration.
+    const rawPublic = await validateAndExportKemKeyPair(keyPair);
+
     this._kemKeyPair = keyPair;
+    this._kemPublicKeyRaw = rawPublic;
   }
 
   /**
@@ -285,12 +319,13 @@ export class CollabswarmDocument<
    * installed ECDH public key, or `undefined` if no key pair has been
    * set via `setKemKeyPair`. The bytes are what inviters pass to
    * `addReader(reader, readerKemPublicKey)`.
+   *
+   * Cheap: the raw bytes are cached on `setKemKeyPair`; this just
+   * returns the cached `Uint8Array`. The method is still async to
+   * preserve the previous contract.
    */
   public async getKemPublicKeyRaw(): Promise<Uint8Array | undefined> {
-    if (!this._kemKeyPair) return undefined;
-    return new Uint8Array(
-      await crypto.subtle.exportKey('raw', this._kemKeyPair.publicKey),
-    );
+    return this._kemPublicKeyRaw;
   }
 
   /**
@@ -3283,16 +3318,16 @@ export class CollabswarmDocument<
     // keychain state under a key we don't actually control. A
     // legitimate writer who follows the documented onboarding flow
     // will always echo back the recipient's own KEM public key.
-    if (!this._kemKeyPair) {
+    if (!this._kemKeyPair || !this._kemPublicKeyRaw) {
       console.warn(
         `Dropping BeeKEM Welcome for ${this.documentPath}: no local KEM ` +
           `key pair installed via setKemKeyPair; cannot open sealed payload.`,
       );
       return false;
     }
-    const localKemPublicRaw = new Uint8Array(
-      await crypto.subtle.exportKey('raw', this._kemKeyPair.publicKey),
-    );
+    // Use the eagerly-cached raw bytes from `setKemKeyPair` rather
+    // than re-exporting on every Welcome.
+    const localKemPublicRaw = this._kemPublicKeyRaw;
     const messageKemPublic = message.welcomeRecipientKemPublicKey;
     if (
       !messageKemPublic ||

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -38,6 +38,12 @@ import { ChangesSerializer } from './changes-serializer';
 import { SyncMessageSerializer } from './sync-message-serializer';
 import { evaluateBeeKEMWelcome } from './beekem-welcome-handler';
 import {
+  eciesSeal,
+  eciesOpen,
+  importEciesPublicKey,
+  ECIES_P256_PUBLIC_KEY_LENGTH,
+} from './ecies';
+import {
   beekemWelcomeV1,
   documentKeyUpdateV2,
   documentLoadV2,
@@ -241,6 +247,51 @@ export class CollabswarmDocument<
   >();
   private static readonly _PENDING_WELCOMES_MAX_ENTRIES = 16;
   private static readonly _PENDING_WELCOMES_TTL_MS = 5 * 60 * 1000;
+
+  // Recipient-side ECIES (P-256 ECDH) key pair for opening BeeKEM Welcome
+  // sealed payloads. The inviter sends `eciesSealed` -- the keychain delta
+  // encrypted to this public key (see `_sendBeeKEMWelcome`); the recipient
+  // opens it with the matching private key (see
+  // `_evaluateAndApplyBeeKEMWelcome`). When `undefined`, sealed Welcomes
+  // addressed to us cannot be opened and are dropped (the recipient must
+  // fall back to a fresh document load against an authorized peer). The
+  // application is responsible for plumbing in a stable KEM key pair via
+  // `setKemKeyPair` and sharing the matching raw public key with inviters
+  // out-of-band so they can pass it to `addReader`.
+  private _kemKeyPair: CryptoKeyPair | undefined;
+
+  /**
+   * Install the recipient-side ECDH (P-256) key pair used to open
+   * incoming BeeKEM Welcome sealed payloads. The application is
+   * responsible for persisting and re-supplying this key pair across
+   * sessions; the matching raw public key (see
+   * `getKemPublicKeyRaw`) must be communicated out-of-band to any
+   * writer who will invite this user, so they can pass it to
+   * `addReader(reader, readerKemPublicKey)`.
+   *
+   * Idempotent: calling with the same key pair more than once is
+   * fine. Pass `undefined` to clear (subsequent Welcomes will be
+   * dropped).
+   *
+   * The private key MUST have `'deriveBits'` in its key usages so
+   * `eciesOpen` can perform the ECDH step.
+   */
+  public setKemKeyPair(keyPair: CryptoKeyPair | undefined): void {
+    this._kemKeyPair = keyPair;
+  }
+
+  /**
+   * Returns the raw SEC1-uncompressed bytes (65 bytes) of the
+   * installed ECDH public key, or `undefined` if no key pair has been
+   * set via `setKemKeyPair`. The bytes are what inviters pass to
+   * `addReader(reader, readerKemPublicKey)`.
+   */
+  public async getKemPublicKeyRaw(): Promise<Uint8Array | undefined> {
+    if (!this._kemKeyPair) return undefined;
+    return new Uint8Array(
+      await crypto.subtle.exportKey('raw', this._kemKeyPair.publicKey),
+    );
+  }
 
   /**
    * Set the history visibility for this document.
@@ -2865,19 +2916,28 @@ export class CollabswarmDocument<
    * currently-connected peer; the receiving document ignores Welcomes
    * addressed to a different reader.
    *
-   * SAFETY-CRITICAL: the BeeKEM Welcome
-   * broadcast leaks `keychainChanges` in plaintext to every connected
-   * peer. The dispatch path is therefore gated behind the explicit
-   * `CollabswarmConfig.experimentalBeeKEMBroadcastWelcome` flag, which
-   * defaults to `false`. When the flag is disabled the readers-ACL update
-   * is still broadcast (so the new reader can join the document and
-   * subsequent pubsub traffic), but no Welcome is sent -- the new reader
-   * recovers keychain state via a fresh document load against an
-   * authorized peer instead. See `_sendBeeKEMWelcome` for the rationale.
+   * CONFIDENTIALITY: the Welcome's keychain delta is sealed with ECIES
+   * (P-256 ECDH + AES-256-GCM) under `readerKemPublicKey`, so only the
+   * intended recipient can decrypt it. The recipient binding
+   * (`welcomeRecipient`) is the **authorization** gate; the sealed
+   * payload is the **confidentiality** gate. See `_sendBeeKEMWelcome`
+   * for the full construction.
    *
-   * @param reader User's public key.
+   * @param reader User's identity (signing) public key.
+   * @param readerKemPublicKey Optional raw SEC1-uncompressed P-256
+   *   ECDH public key (65 bytes) of the reader's KEM key pair. The
+   *   reader must hold the matching private key (see
+   *   `setKemKeyPair`). When this is `undefined`, the readers-ACL
+   *   update is still broadcast but **no Welcome is sent**: the new
+   *   reader can join the document but must recover keychain state
+   *   via a fresh document load against an authorized peer. (The
+   *   library refuses to broadcast an un-sealed Welcome to all peers
+   *   because that would leak document key material in plaintext.)
    */
-  public async addReader(reader: PublicKey) {
+  public async addReader(
+    reader: PublicKey,
+    readerKemPublicKey?: Uint8Array,
+  ) {
     await this._ensureCurrentUserCanWrite();
 
     // Check that the reader is not already a reader.
@@ -2889,12 +2949,25 @@ export class CollabswarmDocument<
     const changes = await this._readers.add(reader);
     await this._makeChange(changes, crdtReaderChangeNode);
 
+    // Without the recipient's KEM public key we cannot seal the
+    // Welcome payload, and we will NEVER send an un-sealed Welcome --
+    // that would broadcast `keychainChanges` to every connected peer.
+    if (!readerKemPublicKey) {
+      console.warn(
+        `BeeKEM Welcome for ${this.documentPath} skipped: caller did not ` +
+          `provide a recipient KEM public key. The new reader has been ` +
+          `added to the readers ACL but must perform a fresh document load ` +
+          `against an authorized peer to recover keychain state.`,
+      );
+      return;
+    }
+
     // Send a BeeKEM Welcome with the document key so the new reader can
     // decrypt subsequent (and, per visibility, prior) messages. Failures
     // are logged but do not abort -- the ACL change has already been
     // broadcast and the reader can also recover via a fresh document load.
     try {
-      await this._sendBeeKEMWelcome(reader);
+      await this._sendBeeKEMWelcome(reader, readerKemPublicKey);
     } catch (err) {
       console.warn(
         `Failed to send BeeKEM Welcome for ${this.documentPath}:`,
@@ -2917,84 +2990,46 @@ export class CollabswarmDocument<
    *   than installing the document key. The binding is covered by the
    *   writer signature, so a non-writer cannot redirect a Welcome to a
    *   different recipient.
-   *
-   *   IMPORTANT: this binding is **not** a confidentiality control. The
-   *   Welcome payload is sent in plaintext at the application layer (see
-   *   the Confidentiality note below), so a malicious peer that receives
-   *   the broadcast can read or exfiltrate `keychainChanges` regardless
-   *   of whether it would "drop" the message. Closing that gap requires
-   *   recipient-encrypted key delivery (e.g. wrapping the keychain delta
-   *   under the recipient's identity key) or sending the Welcome only
-   *   over a connection authenticated to the recipient; both are
-   *   tracked as follow-up hardening work.
-   * - `keychainChanges`: keychain CRDT changes filtered per the document's
-   *   `historyVisibility` **from the recipient's perspective** (see
-   *   `_keychainChangesForWelcome()`) so the recipient can decrypt
-   *   the current state (and, under `full_history`, prior state).
+   * - `welcomeRecipientKemPublicKey`: raw SEC1 P-256 ECDH public key of
+   *   the recipient. Also covered by the writer signature -- the writer
+   *   commits to a specific encryption key for a specific identity, so
+   *   an attacker that owns one of those two values alone cannot
+   *   redirect the sealed payload.
+   * - `eciesSealed`: the inviter-side serialized keychain delta
+   *   encrypted under the recipient's ECDH key via ECIES (see
+   *   `ecies.ts`). This is the confidentiality control: a
+   *   non-recipient peer that receives the broadcast cannot decrypt
+   *   the keychain delta. The keychain plaintext is filtered per the
+   *   document's `historyVisibility` **from the recipient's
+   *   perspective** (see `_keychainChangesForWelcome()`).
    * - `signature`: writer signature over the message so the receiver can
    *   confirm a legitimate writer is the inviter (and ignore forgeries).
+   *   Crucially, the signature covers the **sealed** bytes, not the
+   *   plaintext, so a replayed or tampered sealed payload fails
+   *   signature verification.
    *
-   * Confidentiality note: the Welcome payload itself is **not** encrypted
-   * at the application layer. The exchange rides libp2p's secure
-   * transport (Noise/TLS), so on-wire confidentiality is provided by the
-   * transport. The new reader cannot decrypt application-layer ciphertext
-   * before installing the keychain delta the Welcome carries, which would
-   * otherwise create a chicken-and-egg bootstrap problem.
+   * Confidentiality: the keychain delta is end-to-end encrypted to the
+   * recipient at the application layer. libp2p's Noise/TLS transport
+   * still protects on-wire bytes against off-path observers, but the
+   * application-layer ECIES seal is the primary confidentiality
+   * guarantee against on-path connected peers.
    *
    * Wire format (mirrors `documentKeyUpdateV2`):
    *   [4-byte BE doc-path length] [UTF-8 doc-path] [serialized sync message]
    */
-  private async _sendBeeKEMWelcome(reader: PublicKey): Promise<void> {
-    // OPT-IN GATE (safe-by-default).
-    //
-    // This method broadcasts a *plaintext* Welcome -- including the
-    // document key material in `keychainChanges` -- to every
-    // currently-connected libp2p peer. The recipient binding
-    // (`welcomeRecipient` + the writer signature covering it) is an
-    // *authorization* control that prevents an honest non-target peer
-    // from installing the document key; it is **not** a confidentiality
-    // control. Any peer with a live connection at broadcast time -- even
-    // an unauthorized or actively malicious one -- can observe the
-    // payload, retain `keychainChanges`, and use it to decrypt
-    // subsequent pubsub traffic for this document. The libp2p
-    // transport's Noise/TLS handshake protects on-wire bytes from
-    // off-path observers but does nothing to limit which connected peers
-    // see the application-layer payload.
-    //
-    // For that reason the broadcast path is gated behind an explicit
-    // opt-in flag, `CollabswarmConfig.experimentalBeeKEMBroadcastWelcome`,
-    // which defaults to `false`. When unset / `false`, this method is a
-    // no-op (with a warning) -- the new reader is still added to the
-    // readers ACL by `addReader` and can recover keychain state via a
-    // fresh document load against an authorized peer. Deployments that
-    // accept the confidentiality trade-off (e.g. trusted private swarms,
-    // closed test/lab environments) can flip the flag to `true`.
-    //
-    // The fix that lets this be on-by-default is recipient-encrypted
-    // key delivery (e.g. HPKE / ECIES under the recipient's identity
-    // key, or wrapping under the recipient's BeeKEM public key once a
-    // stable identity-to-encryption-key mapping is in place), so that
-    // only the intended reader can decrypt `keychainChanges`.
-    // Implementing that is non-trivial -- it requires an agreed
-    // identity-encryption key plumbed through `AuthProvider`, schema
-    // changes in `CRDTSyncMessage`, a versioned wire-format bump, and
-    // migration of the receive path -- and is intentionally out-of-scope
-    // for the initial Welcome introduction.
-    //
-    // TODO(beekem-payload-encryption): wrap the Welcome payload under
-    // the recipient's identity key so `keychainChanges` is opaque to
-    // every other connected peer. Tracked as #BEEKEM-PAYLOAD-ENC.
-    if (this.swarm.config?.experimentalBeeKEMBroadcastWelcome !== true) {
-      console.warn(
-        `BeeKEM Welcome broadcast for ${this.documentPath} skipped: ` +
-          `config.experimentalBeeKEMBroadcastWelcome is not enabled. ` +
-          `The new reader was added to the readers ACL but will need to ` +
-          `perform a fresh document load to receive keychain key material. ` +
-          `Only enable this flag in deployments with a trusted connection ` +
-          `set; the Welcome payload is broadcast in plaintext to every ` +
-          `currently-connected peer.`,
+  private async _sendBeeKEMWelcome(
+    reader: PublicKey,
+    readerKemPublicKey: Uint8Array,
+  ): Promise<void> {
+    // Validate the recipient KEM public key length up front so a
+    // malformed caller fails fast at the call site rather than deep
+    // inside the WebCrypto import.
+    if (readerKemPublicKey.byteLength !== ECIES_P256_PUBLIC_KEY_LENGTH) {
+      throw new Error(
+        `BeeKEM Welcome for ${this.documentPath}: readerKemPublicKey ` +
+          `must be ${ECIES_P256_PUBLIC_KEY_LENGTH} raw SEC1 bytes (P-256 ` +
+          `uncompressed), got ${readerKemPublicKey.byteLength}`,
       );
-      return;
     }
 
     // Build the welcome message.
@@ -3023,6 +3058,7 @@ export class CollabswarmDocument<
       'BeeKEM Welcome onboarding',
     );
     welcomeMessage.welcomeRecipient = await serializePublicKey(reader);
+    welcomeMessage.welcomeRecipientKemPublicKey = readerKemPublicKey;
 
     // Visibility-filtered keychain so the new reader can decrypt the
     // appropriate window of document history. Note: this uses
@@ -3031,15 +3067,30 @@ export class CollabswarmDocument<
     // latter would, in `since_invited` mode, leak the inviter's
     // post-invite slice (or, for founders, the full history) to a
     // reader whose invitation epoch starts at this moment.
-    welcomeMessage.keychainChanges = await this._keychainChangesForWelcome();
+    const keychainPlaintext = await this._keychainChangesForWelcome();
+    const keychainPlaintextBytes =
+      this._changesSerializer.serializeChanges(keychainPlaintext);
+
+    // Seal the keychain delta to the recipient's ECDH public key. Only
+    // the recipient holding the matching ECDH private key can recover
+    // the plaintext; every other connected peer that observes the
+    // broadcast sees only opaque ciphertext + ephemeral public key +
+    // nonce + AES-GCM tag.
+    const recipientKemKey = await importEciesPublicKey(readerKemPublicKey);
+    welcomeMessage.eciesSealed = await eciesSeal(
+      keychainPlaintextBytes,
+      recipientKemKey,
+    );
 
     // Sign so the receiver can verify the inviter is an authorized
     // writer. Welcomes are ALWAYS writer-authenticated, regardless of
     // the swarm-wide `enableSigning` toggle that gates normal
     // sync-message signing (see SECURITY NOTE in
-    // `beekem-welcome-handler.ts`). Without this, a deployment that
-    // turned `enableSigning` off for change-message signing would
-    // accept unsigned Welcomes from any connected peer.
+    // `beekem-welcome-handler.ts`). The signature covers the sealed
+    // bytes (`eciesSealed`) and the recipient bindings
+    // (`welcomeRecipient` + `welcomeRecipientKemPublicKey`), so an
+    // attacker cannot redirect or substitute the sealed payload
+    // without invalidating the signature.
     welcomeMessage.signature = await this._signWelcomeAsWriter(welcomeMessage);
 
     const serialized =
@@ -3217,19 +3268,79 @@ export class CollabswarmDocument<
       }
     }
 
+    // Open the sealed keychain delta. We must hold the matching ECDH
+    // private key (see `setKemKeyPair`); without it, even a Welcome
+    // that addresses us by identity and KEM public key cannot be
+    // applied. Drop in that case -- the recipient must recover via a
+    // fresh document load against an authorized peer.
+    //
+    // Defense in depth: if the writer-signed `welcomeRecipientKemPublicKey`
+    // does NOT match the local installed KEM public key, the writer
+    // is claiming a different encryption key than the one we hold.
+    // Refuse to attempt decryption: this prevents an attacker who
+    // somehow registered a fake KEM key (e.g. via a parallel
+    // out-of-band channel) from getting us to silently install
+    // keychain state under a key we don't actually control. A
+    // legitimate writer who follows the documented onboarding flow
+    // will always echo back the recipient's own KEM public key.
+    if (!this._kemKeyPair) {
+      console.warn(
+        `Dropping BeeKEM Welcome for ${this.documentPath}: no local KEM ` +
+          `key pair installed via setKemKeyPair; cannot open sealed payload.`,
+      );
+      return false;
+    }
+    const localKemPublicRaw = new Uint8Array(
+      await crypto.subtle.exportKey('raw', this._kemKeyPair.publicKey),
+    );
+    const messageKemPublic = message.welcomeRecipientKemPublicKey;
+    if (
+      !messageKemPublic ||
+      messageKemPublic.byteLength !== localKemPublicRaw.byteLength ||
+      !this._constantTimeEquals(messageKemPublic, localKemPublicRaw)
+    ) {
+      console.warn(
+        `Dropping BeeKEM Welcome for ${this.documentPath}: ` +
+          `welcomeRecipientKemPublicKey does not match the locally-installed ` +
+          `KEM public key.`,
+      );
+      return false;
+    }
+
+    let keychainPlaintext: ChangesType;
+    try {
+      const sealed = message.eciesSealed as Uint8Array;
+      const plaintextBytes = await eciesOpen(
+        sealed,
+        this._kemKeyPair.privateKey,
+      );
+      keychainPlaintext =
+        this._changesSerializer.deserializeChanges(plaintextBytes);
+    } catch (err) {
+      // ECIES open failure typically means: the sealed payload is
+      // tampered (AES-GCM tag check fails), or the writer encrypted
+      // under a different ECDH public key than the one we hold (so
+      // ECDH produces a different shared secret and the HKDF-derived
+      // AES key cannot decrypt). Both are security-relevant; log and
+      // drop.
+      console.warn(
+        `Failed to open sealed BeeKEM Welcome payload for ${this.documentPath}:`,
+        err,
+      );
+      return false;
+    }
+
     // Merge the keychain changes before recording the invitation epoch,
     // so a recipient handling concurrent Welcomes is not left with an
     // _invitationEpoch pointing at a key that hasn't been installed.
-    if (message.keychainChanges) {
-      try {
-        this._keychain.merge(message.keychainChanges);
-      } catch (err) {
-        console.error(
-          `Failed to merge keychain changes from BeeKEM Welcome for ${this.documentPath}:`,
-          err,
-        );
-        return false;
-      }
+    try {
+      this._keychain.merge(keychainPlaintext);
+    } catch (err) {
+      console.error(
+        `Failed to merge keychain changes from BeeKEM Welcome for ${this.documentPath}:`,
+        err,
+      );
+      return false;
     }
 
     // Record the invitation epoch -- this gates `since_invited` history
@@ -3416,6 +3527,22 @@ export class CollabswarmDocument<
       s += bytes[i].toString(16).padStart(2, '0');
     }
     return s;
+  }
+
+  /**
+   * Constant-time byte-equality check. Used by the BeeKEM Welcome
+   * receive path to compare the writer-signed
+   * `welcomeRecipientKemPublicKey` against the locally-installed KEM
+   * public key without leaking byte-position timing on a mismatch.
+   * Callers must supply equal-length buffers.
+   */
+  private _constantTimeEquals(a: Uint8Array, b: Uint8Array): boolean {
+    if (a.length !== b.length) return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) {
+      diff |= a[i] ^ b[i];
+    }
+    return diff === 0;
   }
 
   /**

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -2989,10 +2989,14 @@ export class CollabswarmDocument<
     // that would broadcast `keychainChanges` to every connected peer.
     if (!readerKemPublicKey) {
       console.warn(
-        `BeeKEM Welcome for ${this.documentPath} skipped: caller did not ` +
-          `provide a recipient KEM public key. The new reader has been ` +
-          `added to the readers ACL but must perform a fresh document load ` +
-          `against an authorized peer to recover keychain state.`,
+        `[${this.documentPath}] addReader: BeeKEM Welcome skipped because ` +
+          `the caller did not provide \`readerKemPublicKey\`. The reader ` +
+          `has been added to the readers ACL, but to deliver the document ` +
+          `key the caller must either (a) re-invoke \`addReader(reader, ` +
+          `readerKemPublicKey)\` once the recipient's raw SEC1 P-256 ECDH ` +
+          `public key is available, or (b) have the recipient perform a ` +
+          `fresh document load against an authorized peer to recover ` +
+          `keychain state.`,
       );
       return;
     }

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -291,9 +291,8 @@ export class CollabswarmDocument<
    * surfaced as a generic WebCrypto failure later in the Welcome
    * receive path.
    *
-   * Async because the public key is eagerly exported to raw bytes and
-   * cached for the receive path; callers that previously invoked this
-   * synchronously must now `await` it.
+   * Async because it eagerly exports the public key to raw bytes via
+   * `crypto.subtle.exportKey` and caches them for the receive path.
    */
   public async setKemKeyPair(
     keyPair: CryptoKeyPair | undefined,
@@ -323,14 +322,13 @@ export class CollabswarmDocument<
    * set via `setKemKeyPair`. The bytes are what inviters pass to
    * `addReader(reader, readerKemPublicKey)`.
    *
-   * Cheap: the raw bytes are cached on `setKemKeyPair`; this just
-   * returns a defensive copy of the cached `Uint8Array` so callers
-   * cannot accidentally mutate the document's internal state (e.g.
-   * `raw[0] = ...`), which would otherwise cause hard-to-debug
-   * Welcome drops/mismatches on the receive path. The method is still
-   * async to preserve the previous contract.
+   * The raw bytes are cached on `setKemKeyPair`, so this is a
+   * synchronous lookup. A defensive copy of the cached `Uint8Array` is
+   * returned so callers cannot accidentally mutate the document's
+   * internal state (e.g. `raw[0] = ...`), which would otherwise cause
+   * hard-to-debug Welcome drops/mismatches on the receive path.
    */
-  public async getKemPublicKeyRaw(): Promise<Uint8Array | undefined> {
+  public getKemPublicKeyRaw(): Uint8Array | undefined {
     return this._kemPublicKeyRaw && new Uint8Array(this._kemPublicKeyRaw);
   }
 

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -2981,29 +2981,35 @@ export class CollabswarmDocument<
   ) {
     await this._ensureCurrentUserCanWrite();
 
-    // Check that the reader is not already a reader.
-    if (await this._readers.check(reader)) {
-      return;
+    // Idempotent on the ACL side, but if the caller has only now obtained
+    // the recipient's KEM public key (e.g. a previous `addReader` call
+    // skipped the Welcome because the key was unknown), still emit the
+    // Welcome so the existing ACL row can be paired with keychain
+    // material. Without this branch the warning emitted below on the
+    // first call would point at a recovery path that is itself a no-op.
+    const alreadyReader = await this._readers.check(reader);
+    if (!alreadyReader) {
+      // Send change over network.
+      const changes = await this._readers.add(reader);
+      await this._makeChange(changes, crdtReaderChangeNode);
     }
-
-    // Send change over network.
-    const changes = await this._readers.add(reader);
-    await this._makeChange(changes, crdtReaderChangeNode);
 
     // Without the recipient's KEM public key we cannot seal the
     // Welcome payload, and we will NEVER send an un-sealed Welcome --
     // that would broadcast `keychainChanges` to every connected peer.
     if (!readerKemPublicKey) {
-      console.warn(
-        `[${this.documentPath}] addReader: BeeKEM Welcome skipped because ` +
-          `the caller did not provide \`readerKemPublicKey\`. The reader ` +
-          `has been added to the readers ACL, but to deliver the document ` +
-          `key the caller must either (a) re-invoke \`addReader(reader, ` +
-          `readerKemPublicKey)\` once the recipient's raw SEC1 P-256 ECDH ` +
-          `public key is available, or (b) have the recipient perform a ` +
-          `fresh document load against an authorized peer to recover ` +
-          `keychain state.`,
-      );
+      if (!alreadyReader) {
+        console.warn(
+          `[${this.documentPath}] addReader: BeeKEM Welcome skipped because ` +
+            `the caller did not provide \`readerKemPublicKey\`. The reader ` +
+            `has been added to the readers ACL, but to deliver the document ` +
+            `key the caller must either (a) re-invoke \`addReader(reader, ` +
+            `readerKemPublicKey)\` once the recipient's raw SEC1 P-256 ECDH ` +
+            `public key is available, or (b) have the recipient perform a ` +
+            `fresh document load against an authorized peer to recover ` +
+            `keychain state.`,
+        );
+      }
       return;
     }
 

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -36,35 +36,15 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
   snapshot?: CRDTSnapshotNode<ChangesType, PublicKey>;
 
   /**
-   * Optional document keys list. Only populated while loading and receiving a document
-   * key update (due to the removal of an ACL reader).
+   * Optional document keys list. Populated by **load responses** (doc-load and
+   * snapshot-load) where the entire sync message is encrypted under the current
+   * document key on a stream to an already-authorized peer. BeeKEM Welcome
+   * messages do **not** populate this field directly -- their keychain delta
+   * is delivered via the recipient-encrypted `eciesSealed` field below so it
+   * is opaque to non-recipient peers.
    *
-   * NOTE: Keychain changes should only ever be sent over encrypted libp2p streams (not
-   * GossipSub pubsub).
-   *
-   * SECURITY (safe-by-default opt-in):
-   * when this field appears in a BeeKEM Welcome (alongside
-   * `welcomeEpochId` and `welcomeRecipient`), the payload is broadcast in
-   * plaintext at the application layer to *every* currently-connected
-   * peer. libp2p's Noise/TLS transport protects on-wire bytes but does
-   * **not** restrict which connected peers can read the payload, so any
-   * connected peer -- including unauthorized or malicious ones -- can
-   * observe and retain `keychainChanges` and use it to decrypt
-   * subsequent pubsub traffic. The `welcomeRecipient` binding is an
-   * authorization control (an honest non-target peer drops the
-   * Welcome), not a confidentiality control.
-   *
-   * Because of this, the BeeKEM Welcome broadcast path is gated behind
-   * the explicit `CollabswarmConfig.experimentalBeeKEMBroadcastWelcome`
-   * opt-in flag, which defaults to `false`. When disabled,
-   * `_sendBeeKEMWelcome` is a no-op (with a warning) and Welcomes
-   * carrying `keychainChanges` are never emitted on the wire by this
-   * peer. See `_sendBeeKEMWelcome` for the rationale and follow-up plan.
-   *
-   * TODO(beekem-payload-encryption): encrypt the Welcome payload to the
-   * recipient (HPKE/ECIES under the recipient's identity or BeeKEM
-   * public key) so `keychainChanges` is opaque to every other connected
-   * peer. Tracked as #BEEKEM-PAYLOAD-ENC.
+   * The keychain delta is decrypted via the CRDT-specific `ChangesSerializer`
+   * (yjs/automerge) and the sync message itself via `SyncMessageSerializer`.
    */
   keychainChanges?: ChangesType;
 
@@ -80,7 +60,7 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
   /**
    * Optional recipient binding for BeeKEM Welcome messages. The inviter
    * cannot identify the new reader's libp2p connection directly, so
-   * Welcomes are broadcast to all peers; without a binding, a
+   * Welcomes are broadcast to every connected peer; without a binding, a
    * well-behaved non-member peer would still process a writer-signed
    * Welcome and install the document key. The receiver MUST drop a
    * Welcome whose `welcomeRecipient` does not match its own local user
@@ -90,16 +70,52 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
    * JSON-safe (a string) because the serialized public key is already a
    * string.
    *
-   * IMPORTANT: this is a routing / authorization binding, **not** a
-   * confidentiality control. The Welcome payload is sent in plaintext at
-   * the application layer; a malicious connected peer can still read or
-   * exfiltrate `keychainChanges` regardless of whether the recipient
-   * binding addresses it. Stronger confidentiality (recipient-encrypted
-   * key delivery, or sending the Welcome only over a connection
-   * authenticated to the recipient) is tracked as follow-up hardening
-   * work.
+   * NOTE: this is the **authorization** binding (which identity the
+   * Welcome was meant for). Confidentiality is provided separately by
+   * the `eciesSealed` payload, which only the recipient holding the
+   * matching `welcomeRecipientKemPublicKey` private key can decrypt.
    */
   welcomeRecipient?: string;
+
+  /**
+   * Optional recipient ECDH public key for BeeKEM Welcome messages. Raw
+   * SEC1-uncompressed P-256 public key bytes (65 bytes) of the
+   * recipient's encryption key, encoded as base64 on the wire by the
+   * sync-message serializers. The inviter seals `eciesSealed` against
+   * this public key; the recipient opens it with the matching private
+   * key.
+   *
+   * Bound to the recipient identity by the writer signature (covers
+   * both `welcomeRecipient` and `welcomeRecipientKemPublicKey`), so an
+   * authorized writer must commit to a specific KEM public key for a
+   * specific recipient identity. A recipient that holds the matching
+   * KEM private key but observes a different `welcomeRecipient` MUST
+   * drop the Welcome (the writer asserted the Welcome is for a
+   * different identity).
+   */
+  welcomeRecipientKemPublicKey?: Uint8Array;
+
+  /**
+   * Sealed payload for BeeKEM Welcome messages. Output of `eciesSeal`
+   * over the inviter-side serialized keychain delta, encrypted under
+   * the recipient's ECDH public key
+   * (`welcomeRecipientKemPublicKey`). The plaintext is the
+   * provider-specific serialized keychain changes (the same bytes the
+   * CRDT-specific `ChangesSerializer` would emit for those changes);
+   * the recipient opens the sealed payload with their KEM private key
+   * and routes the result through the provider deserializer before
+   * merging into the local keychain.
+   *
+   * The sealed bytes are base64-encoded on the wire for JSON
+   * transport.
+   *
+   * SECURITY: the writer signature covers the sealed bytes, not the
+   * plaintext, so a replayed/altered sealed payload fails signature
+   * verification. AES-GCM authenticates the ciphertext under the
+   * derived per-message key, so a non-recipient cannot read or alter
+   * the plaintext without detection.
+   */
+  eciesSealed?: Uint8Array;
 
   /**
    * Signature of the sync message.

--- a/packages/collabswarm/src/ecies.test.ts
+++ b/packages/collabswarm/src/ecies.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  eciesSeal,
+  eciesOpen,
+  generateEciesKeyPair,
+  importEciesPublicKey,
+  exportEciesPublicKey,
+  ECIES_P256_PUBLIC_KEY_LENGTH,
+} from './ecies';
+
+/**
+ * Direct-unit tests for the ECIES sealed-box primitive.
+ *
+ * The primitive is shared by the BeeKEM ratchet (`beekem.ts`,
+ * encrypting node private keys along the path) and the BeeKEM Welcome
+ * payload encryption path (`collabswarm-document._sendBeeKEMWelcome`).
+ * Both call sites depend on the wire format and key derivation staying
+ * stable; cover the security-critical paths here so regressions surface
+ * without standing up the rest of the stack.
+ */
+
+describe('ecies seal/open', () => {
+  test('round-trips a payload through the intended recipient', async () => {
+    const recipient = await generateEciesKeyPair();
+    const plaintext = new TextEncoder().encode('hello, sealed world');
+    const sealed = await eciesSeal(plaintext, recipient.publicKey);
+    expect(sealed).toBeInstanceOf(Uint8Array);
+    expect(sealed.byteLength).toBeGreaterThan(plaintext.byteLength);
+
+    const opened = await eciesOpen(sealed, recipient.privateKey);
+    expect(new TextDecoder().decode(opened)).toBe('hello, sealed world');
+  });
+
+  test('round-trips an empty payload', async () => {
+    const recipient = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array(0), recipient.publicKey);
+    const opened = await eciesOpen(sealed, recipient.privateKey);
+    expect(opened.byteLength).toBe(0);
+  });
+
+  test('produces different sealed bytes for identical plaintexts (random salt + nonce)', async () => {
+    const recipient = await generateEciesKeyPair();
+    const plaintext = new Uint8Array([1, 2, 3, 4, 5]);
+    const sealedA = await eciesSeal(plaintext, recipient.publicKey);
+    const sealedB = await eciesSeal(plaintext, recipient.publicKey);
+    expect(sealedA).not.toEqual(sealedB);
+    // Both still decrypt to the same plaintext.
+    expect(await eciesOpen(sealedA, recipient.privateKey)).toEqual(plaintext);
+    expect(await eciesOpen(sealedB, recipient.privateKey)).toEqual(plaintext);
+  });
+
+  test('eciesOpen with the wrong recipient key fails', async () => {
+    const intendedRecipient = await generateEciesKeyPair();
+    const otherRecipient = await generateEciesKeyPair();
+    const sealed = await eciesSeal(
+      new TextEncoder().encode('secret'),
+      intendedRecipient.publicKey,
+    );
+
+    // Decrypting with a different recipient's private key must fail.
+    // The AES-GCM tag verification fails because the derived shared
+    // secret differs; WebCrypto signals this by rejecting the promise.
+    await expect(eciesOpen(sealed, otherRecipient.privateKey)).rejects.toThrow();
+  });
+
+  test('eciesOpen rejects a truncated payload', async () => {
+    const recipient = await generateEciesKeyPair();
+    const sealed = await eciesSeal(
+      new TextEncoder().encode('secret'),
+      recipient.publicKey,
+    );
+    // Lop off the AES-GCM tag and ciphertext entirely -- this is shorter
+    // than the documented minimum length, so the validator should reject
+    // it without ever invoking WebCrypto.
+    const truncated = sealed.slice(0, 32);
+    await expect(eciesOpen(truncated, recipient.privateKey)).rejects.toThrow(
+      /sealed payload truncated/i,
+    );
+  });
+
+  test('eciesOpen rejects a tampered ciphertext (AES-GCM integrity)', async () => {
+    const recipient = await generateEciesKeyPair();
+    const sealed = await eciesSeal(
+      new TextEncoder().encode('payload to protect'),
+      recipient.publicKey,
+    );
+    // Flip a bit in the ciphertext region (well past the salt /
+    // ephemeral key / nonce header).
+    const tampered = new Uint8Array(sealed);
+    tampered[tampered.byteLength - 1] ^= 0x01;
+    await expect(eciesOpen(tampered, recipient.privateKey)).rejects.toThrow();
+  });
+
+  test('exportEciesPublicKey + importEciesPublicKey round-trip', async () => {
+    const keyPair = await generateEciesKeyPair();
+    const raw = await exportEciesPublicKey(keyPair.publicKey);
+    expect(raw.byteLength).toBe(ECIES_P256_PUBLIC_KEY_LENGTH);
+
+    // Imported key works as a sealing target.
+    const imported = await importEciesPublicKey(raw);
+    const sealed = await eciesSeal(
+      new TextEncoder().encode('via raw export'),
+      imported,
+    );
+    const opened = await eciesOpen(sealed, keyPair.privateKey);
+    expect(new TextDecoder().decode(opened)).toBe('via raw export');
+  });
+
+  test('importEciesPublicKey rejects wrong-length raw bytes', async () => {
+    await expect(importEciesPublicKey(new Uint8Array(64))).rejects.toThrow(
+      /must be 65 bytes/i,
+    );
+  });
+});

--- a/packages/collabswarm/src/ecies.ts
+++ b/packages/collabswarm/src/ecies.ts
@@ -1,0 +1,282 @@
+/**
+ * ECIES (Elliptic Curve Integrated Encryption Scheme) helpers.
+ *
+ * Implements a sealed-box style primitive:
+ *
+ *   eciesSeal(plaintext, recipientPublicKey) -> sealed bytes
+ *   eciesOpen(sealed, recipientPrivateKey) -> plaintext
+ *
+ * The sealed bytes have a self-describing layout:
+ *
+ *   [32 bytes HKDF salt][65 bytes ephemeral raw P-256 public key][12 bytes AES-GCM nonce][ciphertext + 16-byte AES-GCM tag]
+ *
+ * Construction:
+ *   - The sender generates an ephemeral P-256 ECDH key pair.
+ *   - ECDH(ephemeral_priv, recipient_pub) produces a shared 256-bit secret.
+ *   - HKDF-SHA-256 with a random 32-byte salt and the fixed info string
+ *     `"beekem-ecies"` derives a 256-bit AES-GCM key.
+ *   - AES-256-GCM encrypts the plaintext under that key with a random
+ *     96-bit nonce. The 16-byte GCM tag is appended to the ciphertext.
+ *
+ * The same algorithm (and the same `"beekem-ecies"` HKDF info string)
+ * was originally implemented inline in `beekem.ts` for wrapping
+ * BeeKEM node private keys; this module is the single source of truth
+ * for that primitive so both BeeKEM and the Welcome payload encryption
+ * path share the same wire format and parameters.
+ *
+ * SECURITY NOTES:
+ *   - This is a sealed-box construction. There is **no** authentication
+ *     of the sender; an attacker can produce a valid sealed payload to
+ *     any known recipient public key. Sender authentication must be
+ *     layered on top (e.g. the Welcome's writer signature, which covers
+ *     the sealed bytes).
+ *   - AES-GCM provides confidentiality + integrity over the ciphertext
+ *     under the derived key, so the tag check fails on any single-bit
+ *     flip of the sealed payload after construction.
+ *   - The random HKDF salt is encoded in the output, so identical
+ *     plaintexts to the same recipient produce different sealed bytes
+ *     (non-deterministic encryption).
+ */
+
+/** ECDH curve used for sealing. Must match the recipient's key curve. */
+const ECDH_CURVE = 'P-256';
+const ECDH_ALGO = { name: 'ECDH', namedCurve: ECDH_CURVE };
+
+/** AES-GCM nonce length in bytes. */
+const AES_NONCE_LENGTH = 12;
+
+/** HKDF salt length in bytes. */
+const HKDF_SALT_LENGTH = 32;
+
+/**
+ * Raw exported P-256 public key length in bytes (uncompressed
+ * SEC1 encoding: 0x04 || X || Y).
+ */
+export const ECIES_P256_PUBLIC_KEY_LENGTH = 65;
+
+/**
+ * HKDF info string. Constant across all callers so the derived key
+ * binds to this protocol domain. Lazily initialized on first use so
+ * the module is safe to import in environments where `TextEncoder`
+ * is not a top-level global (e.g. jsdom-flavored test runners).
+ */
+let _hkdfInfo: Uint8Array | undefined;
+function hkdfInfo(): Uint8Array {
+  if (_hkdfInfo === undefined) {
+    _hkdfInfo = new TextEncoder().encode('beekem-ecies');
+  }
+  return _hkdfInfo;
+}
+
+/** Cast Uint8Array to ArrayBuffer for WebCrypto API compatibility. */
+function toBuffer(data: Uint8Array): ArrayBuffer {
+  return (data.buffer as ArrayBuffer).slice(
+    data.byteOffset,
+    data.byteOffset + data.byteLength,
+  );
+}
+
+/**
+ * Encrypt `plaintext` to `recipientPublicKey` using ECIES (P-256 ECDH
+ * + HKDF-SHA-256 + AES-256-GCM). Returns the self-describing sealed
+ * bytes documented at the top of this module.
+ *
+ * @param plaintext The bytes to seal.
+ * @param recipientPublicKey The recipient's P-256 ECDH public key
+ *   (`CryptoKey`, algorithm `{ name: 'ECDH', namedCurve: 'P-256' }`).
+ */
+export async function eciesSeal(
+  plaintext: Uint8Array,
+  recipientPublicKey: CryptoKey,
+): Promise<Uint8Array> {
+  // Generate ephemeral ECDH key pair for ECIES.
+  const ephemeral = await crypto.subtle.generateKey(ECDH_ALGO, true, [
+    'deriveBits',
+  ]);
+
+  // ECDH to derive shared secret.
+  const sharedBits = await crypto.subtle.deriveBits(
+    { name: 'ECDH', public: recipientPublicKey },
+    ephemeral.privateKey,
+    256,
+  );
+
+  // Random salt for HKDF domain separation.
+  const salt = crypto.getRandomValues(new Uint8Array(HKDF_SALT_LENGTH));
+
+  // Derive AES key from shared secret via HKDF.
+  const hkdfKey = await crypto.subtle.importKey(
+    'raw',
+    sharedBits,
+    'HKDF',
+    false,
+    ['deriveKey'],
+  );
+  const aesKey = await crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: toBuffer(salt),
+      info: toBuffer(hkdfInfo()),
+    },
+    hkdfKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt'],
+  );
+
+  // Encrypt with AES-GCM.
+  const nonce = crypto.getRandomValues(new Uint8Array(AES_NONCE_LENGTH));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: toBuffer(nonce) },
+    aesKey,
+    toBuffer(plaintext),
+  );
+
+  // Export ephemeral public key (uncompressed point, 65 bytes for P-256).
+  const ephemeralPub = new Uint8Array(
+    await crypto.subtle.exportKey('raw', ephemeral.publicKey),
+  );
+
+  // Concatenate: salt || ephemeralPub || nonce || ciphertext.
+  const result = new Uint8Array(
+    salt.byteLength +
+      ephemeralPub.byteLength +
+      nonce.byteLength +
+      ciphertext.byteLength,
+  );
+  let offset = 0;
+  result.set(salt, offset);
+  offset += salt.byteLength;
+  result.set(ephemeralPub, offset);
+  offset += ephemeralPub.byteLength;
+  result.set(nonce, offset);
+  offset += nonce.byteLength;
+  result.set(new Uint8Array(ciphertext), offset);
+
+  return result;
+}
+
+/**
+ * Decrypt a sealed payload produced by `eciesSeal` using the
+ * recipient's P-256 ECDH private key. Throws if the sealed bytes are
+ * truncated, the ephemeral public key cannot be imported, or the
+ * AES-GCM tag fails to verify (typically: wrong recipient private
+ * key, or tampered payload).
+ *
+ * @param sealed The self-describing sealed bytes.
+ * @param recipientPrivateKey The recipient's P-256 ECDH private key
+ *   (`CryptoKey`, algorithm `{ name: 'ECDH', namedCurve: 'P-256' }`,
+ *   usages must include `'deriveBits'`).
+ */
+export async function eciesOpen(
+  sealed: Uint8Array,
+  recipientPrivateKey: CryptoKey,
+): Promise<Uint8Array> {
+  // Minimum sane length: salt + ephemeralPub + nonce + at least the
+  // 16-byte GCM tag. Anything shorter cannot possibly be valid.
+  const minLength =
+    HKDF_SALT_LENGTH + ECIES_P256_PUBLIC_KEY_LENGTH + AES_NONCE_LENGTH + 16;
+  if (sealed.byteLength < minLength) {
+    throw new Error(
+      `eciesOpen: sealed payload truncated (got ${sealed.byteLength} bytes, need at least ${minLength})`,
+    );
+  }
+
+  let pos = 0;
+  const salt = sealed.slice(pos, pos + HKDF_SALT_LENGTH);
+  pos += HKDF_SALT_LENGTH;
+
+  const ephemeralPubBytes = sealed.slice(
+    pos,
+    pos + ECIES_P256_PUBLIC_KEY_LENGTH,
+  );
+  pos += ECIES_P256_PUBLIC_KEY_LENGTH;
+
+  const nonce = sealed.slice(pos, pos + AES_NONCE_LENGTH);
+  pos += AES_NONCE_LENGTH;
+
+  const ciphertext = sealed.slice(pos);
+
+  // Import ephemeral public key.
+  const ephemeralPublicKey = await crypto.subtle.importKey(
+    'raw',
+    toBuffer(ephemeralPubBytes),
+    ECDH_ALGO,
+    true,
+    [],
+  );
+
+  // ECDH to derive shared secret.
+  const sharedBits = await crypto.subtle.deriveBits(
+    { name: 'ECDH', public: ephemeralPublicKey },
+    recipientPrivateKey,
+    256,
+  );
+
+  // Derive AES key (same params as encrypt, with the extracted salt).
+  const hkdfKey = await crypto.subtle.importKey(
+    'raw',
+    sharedBits,
+    'HKDF',
+    false,
+    ['deriveKey'],
+  );
+  const aesKey = await crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: toBuffer(salt),
+      info: toBuffer(hkdfInfo()),
+    },
+    hkdfKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['decrypt'],
+  );
+
+  // Decrypt: AES-GCM tag failure throws.
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: toBuffer(nonce) },
+    aesKey,
+    toBuffer(ciphertext),
+  );
+
+  return new Uint8Array(plaintext);
+}
+
+/**
+ * Convenience helper: import a raw P-256 ECDH public key from
+ * SEC1 uncompressed bytes into a `CryptoKey` usable with `eciesSeal`.
+ *
+ * Throws if the bytes are not a valid P-256 public point.
+ */
+export async function importEciesPublicKey(
+  raw: Uint8Array,
+): Promise<CryptoKey> {
+  if (raw.byteLength !== ECIES_P256_PUBLIC_KEY_LENGTH) {
+    throw new Error(
+      `importEciesPublicKey: raw key must be ${ECIES_P256_PUBLIC_KEY_LENGTH} bytes (got ${raw.byteLength})`,
+    );
+  }
+  return crypto.subtle.importKey('raw', toBuffer(raw), ECDH_ALGO, true, []);
+}
+
+/**
+ * Convenience helper: export an ECDH P-256 public key to raw SEC1
+ * uncompressed bytes (the same encoding `importEciesPublicKey` expects).
+ */
+export async function exportEciesPublicKey(
+  key: CryptoKey,
+): Promise<Uint8Array> {
+  return new Uint8Array(await crypto.subtle.exportKey('raw', key));
+}
+
+/**
+ * Generate a fresh P-256 ECDH key pair suitable for ECIES sealing.
+ * The private key has `deriveBits` usage so it can be passed directly
+ * to `eciesOpen`.
+ */
+export async function generateEciesKeyPair(): Promise<CryptoKeyPair> {
+  return crypto.subtle.generateKey(ECDH_ALGO, true, ['deriveBits']);
+}

--- a/packages/collabswarm/src/ecies.ts
+++ b/packages/collabswarm/src/ecies.ts
@@ -68,12 +68,19 @@ function hkdfInfo(): Uint8Array {
   return _hkdfInfo;
 }
 
-/** Cast Uint8Array to ArrayBuffer for WebCrypto API compatibility. */
-function toBuffer(data: Uint8Array): ArrayBuffer {
-  return (data.buffer as ArrayBuffer).slice(
-    data.byteOffset,
-    data.byteOffset + data.byteLength,
-  );
+/**
+ * Zero-copy cast for WebCrypto `BufferSource` parameters.
+ *
+ * The runtime accepts any `Uint8Array` directly, but the TypeScript
+ * DOM types (TS 5.7+) narrow `BufferSource` to
+ * `ArrayBufferView<ArrayBuffer>` and a `Uint8Array<ArrayBufferLike>`
+ * (the default after the TS 5.7 typed-array generic) is not assignable.
+ * Cast at the call boundary instead of copying via `slice` -- the latter
+ * would double memory for large payloads and break for views backed by
+ * `SharedArrayBuffer`.
+ */
+function bs(data: Uint8Array): BufferSource {
+  return data as unknown as BufferSource;
 }
 
 /**
@@ -105,6 +112,13 @@ export async function eciesSeal(
   const salt = crypto.getRandomValues(new Uint8Array(HKDF_SALT_LENGTH));
 
   // Derive AES key from shared secret via HKDF.
+  //
+  // WebCrypto accepts `BufferSource` (i.e. `ArrayBufferView` such as
+  // `Uint8Array`, or `ArrayBuffer`) for the byte-shaped parameters
+  // below, so we pass the views directly rather than cloning into a
+  // fresh `ArrayBuffer`. Avoiding the copies keeps memory usage flat
+  // for large payloads and lets `Uint8Array`s backed by
+  // `SharedArrayBuffer` (which lacks `.slice()`) flow through unchanged.
   const hkdfKey = await crypto.subtle.importKey(
     'raw',
     sharedBits,
@@ -116,8 +130,8 @@ export async function eciesSeal(
     {
       name: 'HKDF',
       hash: 'SHA-256',
-      salt: toBuffer(salt),
-      info: toBuffer(hkdfInfo()),
+      salt: bs(salt),
+      info: bs(hkdfInfo()),
     },
     hkdfKey,
     { name: 'AES-GCM', length: 256 },
@@ -128,9 +142,9 @@ export async function eciesSeal(
   // Encrypt with AES-GCM.
   const nonce = crypto.getRandomValues(new Uint8Array(AES_NONCE_LENGTH));
   const ciphertext = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv: toBuffer(nonce) },
+    { name: 'AES-GCM', iv: bs(nonce) },
     aesKey,
-    toBuffer(plaintext),
+    bs(plaintext),
   );
 
   // Export ephemeral public key (uncompressed point, 65 bytes for P-256).
@@ -198,10 +212,12 @@ export async function eciesOpen(
 
   const ciphertext = sealed.slice(pos);
 
-  // Import ephemeral public key.
+  // Import ephemeral public key. WebCrypto accepts a `BufferSource`
+  // here, so we pass the `Uint8Array` view directly instead of
+  // cloning into a fresh `ArrayBuffer` (see seal-side comment above).
   const ephemeralPublicKey = await crypto.subtle.importKey(
     'raw',
-    toBuffer(ephemeralPubBytes),
+    bs(ephemeralPubBytes),
     ECDH_ALGO,
     true,
     [],
@@ -226,8 +242,8 @@ export async function eciesOpen(
     {
       name: 'HKDF',
       hash: 'SHA-256',
-      salt: toBuffer(salt),
-      info: toBuffer(hkdfInfo()),
+      salt: bs(salt),
+      info: bs(hkdfInfo()),
     },
     hkdfKey,
     { name: 'AES-GCM', length: 256 },
@@ -237,9 +253,9 @@ export async function eciesOpen(
 
   // Decrypt: AES-GCM tag failure throws.
   const plaintext = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: toBuffer(nonce) },
+    { name: 'AES-GCM', iv: bs(nonce) },
     aesKey,
-    toBuffer(ciphertext),
+    bs(ciphertext),
   );
 
   return new Uint8Array(plaintext);
@@ -259,7 +275,7 @@ export async function importEciesPublicKey(
       `importEciesPublicKey: raw key must be ${ECIES_P256_PUBLIC_KEY_LENGTH} bytes (got ${raw.byteLength})`,
     );
   }
-  return crypto.subtle.importKey('raw', toBuffer(raw), ECDH_ALGO, true, []);
+  return crypto.subtle.importKey('raw', bs(raw), ECDH_ALGO, true, []);
 }
 
 /**

--- a/packages/collabswarm/src/ecies.ts
+++ b/packages/collabswarm/src/ecies.ts
@@ -197,29 +197,40 @@ export async function eciesOpen(
     );
   }
 
+  // Slice the sealed payload into segments using `subarray` rather than
+  // `slice`: the former returns a view over the same `ArrayBuffer` and
+  // avoids the per-segment copy that `slice` performs. The downstream
+  // WebCrypto calls accept any `BufferSource`, so the views flow through
+  // unchanged and we keep memory flat for large payloads (matching the
+  // "no copies" comments on the seal side).
   let pos = 0;
-  const salt = sealed.slice(pos, pos + HKDF_SALT_LENGTH);
+  const salt = sealed.subarray(pos, pos + HKDF_SALT_LENGTH);
   pos += HKDF_SALT_LENGTH;
 
-  const ephemeralPubBytes = sealed.slice(
+  const ephemeralPubBytes = sealed.subarray(
     pos,
     pos + ECIES_P256_PUBLIC_KEY_LENGTH,
   );
   pos += ECIES_P256_PUBLIC_KEY_LENGTH;
 
-  const nonce = sealed.slice(pos, pos + AES_NONCE_LENGTH);
+  const nonce = sealed.subarray(pos, pos + AES_NONCE_LENGTH);
   pos += AES_NONCE_LENGTH;
 
-  const ciphertext = sealed.slice(pos);
+  const ciphertext = sealed.subarray(pos);
 
   // Import ephemeral public key. WebCrypto accepts a `BufferSource`
   // here, so we pass the `Uint8Array` view directly instead of
   // cloning into a fresh `ArrayBuffer` (see seal-side comment above).
+  //
+  // `extractable=false`: the ephemeral public key is used only as the
+  // peer-side input to `deriveBits`, never re-exported. Disabling
+  // extractability shrinks the surface for accidental key-material
+  // leakage via `crypto.subtle.exportKey`.
   const ephemeralPublicKey = await crypto.subtle.importKey(
     'raw',
     bs(ephemeralPubBytes),
     ECDH_ALGO,
-    true,
+    false,
     [],
   );
 
@@ -266,6 +277,12 @@ export async function eciesOpen(
  * SEC1 uncompressed bytes into a `CryptoKey` usable with `eciesSeal`.
  *
  * Throws if the bytes are not a valid P-256 public point.
+ *
+ * The returned key is non-extractable: callers use it only as the
+ * peer-side input to `deriveBits`, and anyone holding the raw bytes
+ * already has full re-import capability, so disabling
+ * `crypto.subtle.exportKey` here loses nothing and shrinks the
+ * key-material attack surface.
  */
 export async function importEciesPublicKey(
   raw: Uint8Array,
@@ -275,7 +292,7 @@ export async function importEciesPublicKey(
       `importEciesPublicKey: raw key must be ${ECIES_P256_PUBLIC_KEY_LENGTH} bytes (got ${raw.byteLength})`,
     );
   }
-  return crypto.subtle.importKey('raw', bs(raw), ECDH_ALGO, true, []);
+  return crypto.subtle.importKey('raw', bs(raw), ECDH_ALGO, false, []);
 }
 
 /**
@@ -292,7 +309,35 @@ export async function exportEciesPublicKey(
  * Generate a fresh P-256 ECDH key pair suitable for ECIES sealing.
  * The private key has `deriveBits` usage so it can be passed directly
  * to `eciesOpen`.
+ *
+ * The returned **public** key is extractable so callers can hand the
+ * SEC1 bytes to inviters (via `exportEciesPublicKey`). The returned
+ * **private** key is re-imported as non-extractable to prevent
+ * `crypto.subtle.exportKey` from ever recovering the secret scalar
+ * (PKCS8 / JWK forms) from the in-memory `CryptoKey`. This is the
+ * conventional defence-in-depth posture for KEM private keys --
+ * `eciesOpen` only needs `deriveBits`, which non-extractable keys
+ * still support.
  */
 export async function generateEciesKeyPair(): Promise<CryptoKeyPair> {
-  return crypto.subtle.generateKey(ECDH_ALGO, true, ['deriveBits']);
+  // `generateKey` exposes a single extractable flag that applies to
+  // both keys in the pair; generate as extractable so we can re-import
+  // the private key with `extractable=false` below.
+  const pair = (await crypto.subtle.generateKey(ECDH_ALGO, true, [
+    'deriveBits',
+  ])) as CryptoKeyPair;
+
+  // Re-import the private key as non-extractable. We use JWK rather
+  // than PKCS8 because Safari's WebCrypto historically had gaps in
+  // PKCS8 round-tripping for ECDH; JWK is supported uniformly.
+  const privJwk = await crypto.subtle.exportKey('jwk', pair.privateKey);
+  const nonExtractablePrivate = await crypto.subtle.importKey(
+    'jwk',
+    privJwk,
+    ECDH_ALGO,
+    false,
+    ['deriveBits'],
+  );
+
+  return { publicKey: pair.publicKey, privateKey: nonExtractablePrivate };
 }

--- a/packages/collabswarm/src/kem-key-pair.ts
+++ b/packages/collabswarm/src/kem-key-pair.ts
@@ -65,9 +65,16 @@ export async function validateAndExportKemKeyPair(
       await crypto.subtle.exportKey('raw', keyPair.publicKey),
     );
   } catch (err) {
+    // Normalize the inner error: `${err}` on a non-Error throwable
+    // (DOMException, plain object, etc.) can produce
+    // "[object Object]". Pulling `.message` when available keeps the
+    // text actionable; the original is preserved via `cause` for
+    // structured introspection.
+    const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
       `setKemKeyPair: failed to export public key as raw bytes ` +
-        `(was the public key created with extractable=true?): ${err}`,
+        `(was the public key created with extractable=true?): ${msg}`,
+      { cause: err },
     );
   }
 }

--- a/packages/collabswarm/src/kem-key-pair.ts
+++ b/packages/collabswarm/src/kem-key-pair.ts
@@ -1,0 +1,73 @@
+/**
+ * Validation + eager raw-export for the recipient-side BeeKEM Welcome
+ * key pair installed via `CollabswarmDocument.setKemKeyPair`.
+ *
+ * Extracted into a standalone module so the validation logic can be
+ * unit-tested without dragging in the full `CollabswarmDocument`
+ * dependency graph (libp2p, Helia, providers). The receive path
+ * (`_evaluateAndApplyBeeKEMWelcome`) requires (a) an ECDH P-256 key
+ * pair and (b) a private key with `deriveBits` usage, and it consumes
+ * the raw SEC1-uncompressed public key bytes on every incoming
+ * Welcome. Without eager validation a misconfigured key pair (wrong
+ * algorithm, wrong curve, missing usage, non-exportable public key)
+ * would surface as a generic WebCrypto exception deep inside the
+ * Welcome handler on the first invite. This helper validates the
+ * key pair up-front and eagerly exports the raw public key so the
+ * receive path never has to await an `exportKey` call.
+ */
+
+/**
+ * Validate that `keyPair` is a usable BeeKEM Welcome KEM key pair and
+ * return the raw SEC1-uncompressed bytes of the public key.
+ *
+ * Throws a clear, install-time error if:
+ *   - either key is not ECDH
+ *   - either key is not on the P-256 curve
+ *   - the private key usages do not include `'deriveBits'`
+ *   - the public key cannot be raw-exported (e.g. was created with
+ *     `extractable=false`)
+ */
+export async function validateAndExportKemKeyPair(
+  keyPair: CryptoKeyPair,
+): Promise<Uint8Array> {
+  const pubAlgo = keyPair.publicKey.algorithm as {
+    name?: string;
+    namedCurve?: string;
+  };
+  const privAlgo = keyPair.privateKey.algorithm as {
+    name?: string;
+    namedCurve?: string;
+  };
+  if (pubAlgo.name !== 'ECDH' || privAlgo.name !== 'ECDH') {
+    throw new Error(
+      `setKemKeyPair: key pair must be ECDH (got publicKey=${
+        pubAlgo.name ?? 'unknown'
+      }, privateKey=${privAlgo.name ?? 'unknown'})`,
+    );
+  }
+  if (pubAlgo.namedCurve !== 'P-256' || privAlgo.namedCurve !== 'P-256') {
+    throw new Error(
+      `setKemKeyPair: key pair must use curve P-256 (got publicKey=${
+        pubAlgo.namedCurve ?? 'unknown'
+      }, privateKey=${privAlgo.namedCurve ?? 'unknown'})`,
+    );
+  }
+  if (!keyPair.privateKey.usages.includes('deriveBits')) {
+    throw new Error(
+      `setKemKeyPair: private key usages must include 'deriveBits' (got [${keyPair.privateKey.usages.join(
+        ', ',
+      )}])`,
+    );
+  }
+
+  try {
+    return new Uint8Array(
+      await crypto.subtle.exportKey('raw', keyPair.publicKey),
+    );
+  } catch (err) {
+    throw new Error(
+      `setKemKeyPair: failed to export public key as raw bytes ` +
+        `(was the public key created with extractable=true?): ${err}`,
+    );
+  }
+}

--- a/packages/collabswarm/src/kem-key-pair.ts
+++ b/packages/collabswarm/src/kem-key-pair.ts
@@ -71,9 +71,16 @@ export async function validateAndExportKemKeyPair(
     // text actionable; the original is preserved via `cause` for
     // structured introspection.
     const msg = err instanceof Error ? err.message : String(err);
+    // The KEM PUBLIC key must be raw-exportable so it can be advertised
+    // out-of-band to inviters. The PRIVATE key should remain
+    // non-extractable; the recommended pattern is to call
+    // `generateKey({ ..., extractable: true })`, then re-import the
+    // private key with `extractable: false` (see `generateEciesKeyPair`
+    // in `ecies.ts` for the canonical approach).
     throw new Error(
       `setKemKeyPair: failed to export public key as raw bytes ` +
-        `(was the public key created with extractable=true?): ${msg}`,
+        `(the public key must be raw-exportable; the private key can ` +
+        `still be non-extractable): ${msg}`,
       { cause: err },
     );
   }

--- a/packages/collabswarm/src/set-kem-key-pair.test.ts
+++ b/packages/collabswarm/src/set-kem-key-pair.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from '@jest/globals';
+import { validateAndExportKemKeyPair } from './kem-key-pair';
+
+/**
+ * Validation coverage for the helper backing
+ * `CollabswarmDocument.setKemKeyPair`.
+ *
+ * The receive path in `_evaluateAndApplyBeeKEMWelcome` assumes (a)
+ * ECDH P-256 keys and (b) a private key with `deriveBits` usage, and
+ * it consumes the raw bytes of the public key on every incoming
+ * Welcome. Without eager validation + caching, a misconfigured key
+ * pair (wrong algorithm, wrong curve, missing usage, non-exportable
+ * public key) would surface as a generic WebCrypto exception deep
+ * inside the Welcome handler on the first invite.
+ * `validateAndExportKemKeyPair` (and `setKemKeyPair` by extension)
+ * validate the key pair up-front and eagerly export the raw public
+ * key; these tests pin that contract without dragging the full
+ * `CollabswarmDocument` dependency graph into the test runner.
+ */
+
+describe('validateAndExportKemKeyPair', () => {
+  test('accepts an ECDH P-256 key pair with deriveBits and returns raw public bytes', async () => {
+    const keyPair = (await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-256' },
+      true,
+      ['deriveBits'],
+    )) as CryptoKeyPair;
+
+    const raw = await validateAndExportKemKeyPair(keyPair);
+
+    expect(raw).toBeInstanceOf(Uint8Array);
+    // SEC1-uncompressed P-256 point: 0x04 || X(32) || Y(32) = 65 bytes.
+    expect(raw.byteLength).toBe(65);
+    expect(raw[0]).toBe(0x04);
+
+    // The returned bytes must equal a fresh raw export of the same key.
+    const fresh = new Uint8Array(
+      await crypto.subtle.exportKey('raw', keyPair.publicKey),
+    );
+    expect(raw).toEqual(fresh);
+  });
+
+  test('rejects an ECDSA key pair (wrong algorithm)', async () => {
+    // ECDSA is the document-signing curve; it is NOT a valid KEM key
+    // pair. The receive path uses `deriveBits` (an ECDH op) on the
+    // private key, which would fail later. We must reject here so the
+    // failure is visible at install time.
+    const ecdsa = (await crypto.subtle.generateKey(
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      true,
+      ['sign', 'verify'],
+    )) as CryptoKeyPair;
+    await expect(validateAndExportKemKeyPair(ecdsa)).rejects.toThrow(
+      /must be ECDH/i,
+    );
+  });
+
+  test('rejects an ECDH key pair on the wrong curve (P-384)', async () => {
+    // The wire format pins P-256 (SEC1-uncompressed = 65 bytes).
+    // Anything else would silently produce non-matching sealed
+    // payloads and cause every Welcome to fail decryption.
+    const p384 = (await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-384' },
+      true,
+      ['deriveBits'],
+    )) as CryptoKeyPair;
+    await expect(validateAndExportKemKeyPair(p384)).rejects.toThrow(
+      /must use curve P-256/i,
+    );
+  });
+
+  test('rejects an ECDH P-256 key pair whose private key is missing deriveBits', async () => {
+    // ECDH allows generating with `deriveKey` only (no `deriveBits`).
+    // `eciesOpen` calls `deriveBits` though, so a `deriveKey`-only
+    // private key would fail later. Reject up-front.
+    const derivKeyOnly = (await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-256' },
+      true,
+      ['deriveKey'],
+    )) as CryptoKeyPair;
+    await expect(
+      validateAndExportKemKeyPair(derivKeyOnly),
+    ).rejects.toThrow(/deriveBits/);
+  });
+});

--- a/packages/collabswarm/src/wire-protocols.ts
+++ b/packages/collabswarm/src/wire-protocols.ts
@@ -18,24 +18,32 @@ export const snapshotLoadV2 = '/collabswarm/snapshot-load/2.0.0';
 // the shared handler can route incoming Welcomes to the correct document.
 //
 // =============================================================================
-// SAFETY-CRITICAL: opt-in broadcast
+// CONFIDENTIALITY: payload sealed to the recipient (ECIES, P-256 ECDH +
+// HKDF-SHA-256 + AES-256-GCM)
 // =============================================================================
-// The Welcome payload (including `keychainChanges` -- current document key
-// material) is broadcast in **plaintext** at the application layer over this
-// protocol to **every** currently-connected libp2p peer. libp2p's Noise/TLS
-// transport protects on-wire bytes from off-path observers but does NOT limit
-// which connected peers can see the payload. The `welcomeRecipient` binding
-// is an authorization control (honest non-target peers drop the message), not
-// a confidentiality control: a connected unauthorized or malicious peer can
-// retain `keychainChanges` and use it to decrypt subsequent pubsub traffic.
+// The Welcome's keychain delta is **not** broadcast in the clear. The
+// `CRDTSyncMessage` carrying a Welcome has a dedicated `eciesSealed` field
+// (see `crdt-sync-message.ts` / `ecies.ts`) which is the ECIES sealed-box
+// over the serialized keychain changes, encrypted under the recipient's
+// ECDH public key (`welcomeRecipientKemPublicKey`). Only the recipient
+// holding the matching ECDH private key can recover the plaintext keychain
+// delta -- a non-recipient peer that is connected at broadcast time sees
+// only the opaque ciphertext + ephemeral public key + nonce + tag.
 //
-// Because of this, `CollabswarmDocument._sendBeeKEMWelcome` is gated behind
-// `CollabswarmConfig.experimentalBeeKEMBroadcastWelcome`, which defaults to
-// `false`. Only enable the flag in deployments with a trusted connection set
-// (authenticated private swarms, closed test/lab environments, etc.). For
-// untrusted / public mesh deployments, leave the flag `false` and rely on
-// fresh-document-load onboarding until recipient-encrypted key delivery
-// (HPKE/ECIES; tracked as `#BEEKEM-PAYLOAD-ENC`) lands.
+// The writer signature covers the sealed bytes (not the plaintext), so a
+// connected peer cannot alter the sealed payload without invalidating the
+// signature. The recipient binding (`welcomeRecipient`, also covered by
+// the signature) prevents an authorized writer from re-pointing a sealed
+// payload at a different identity than the one the encryption keypair
+// belongs to.
+//
+// Defense-in-depth retained from earlier versions of this protocol:
+//   - `welcomeRecipient` continues to gate processing: a well-behaved
+//     non-target peer drops the Welcome rather than attempting to install
+//     the keychain delta. Confidentiality is enforced by ECIES; the
+//     recipient binding is the authorization gate.
+//   - libp2p's Noise/TLS transport still protects on-wire bytes from
+//     off-path observers, on top of the application-layer encryption.
 //
 // =============================================================================
 // Race mitigation on the receive side


### PR DESCRIPTION
## Summary

Closes the confidentiality gap in the BeeKEM Welcome onboarding flow. Previously, `_sendBeeKEMWelcome` broadcast the keychain delta in **plaintext** to every connected libp2p peer, gated behind the `experimentalBeeKEMBroadcastWelcome` config flag (default `false`). The `welcomeRecipient` field acted as an authorization control only; any connected peer at broadcast time could retain the keychain delta and decrypt subsequent pubsub traffic.

This PR encrypts the keychain delta to the recipient using **ECIES (P-256 ECDH + HKDF-SHA-256 + AES-256-GCM)**, matching the same sealed-box construction already used by BeeKEM's ratchet path encryption (`_encryptNodeKey`/`_decryptNodeKey`). The experimental flag is removed entirely; encryption is unconditional.

## Security gap closed

- **Before:** the Welcome `keychainChanges` field was sent in the clear to every connected peer. A malicious peer that received the broadcast could retain the keychain delta and decrypt future pubsub traffic, regardless of whether `welcomeRecipient` addressed them.
- **After:** the keychain delta is sealed under the recipient's ECDH public key. Non-recipient peers see only opaque ciphertext + ephemeral public key + nonce + AES-GCM tag. The writer signature covers the **sealed** bytes, so replayed or tampered sealed payloads also fail signature verification.

## Design

Followed the existing pattern in `packages/collabswarm/src/beekem/beekem.ts` exactly: ECDH ephemeral key pair + HKDF-SHA-256 (random 32-byte salt, fixed info string `"beekem-ecies"`) + AES-256-GCM (12-byte random nonce, 16-byte tag). The primitive is factored into a new module `packages/collabswarm/src/ecies.ts` exposing `eciesSeal` / `eciesOpen` / `generateEciesKeyPair` / `importEciesPublicKey` / `exportEciesPublicKey`. `beekem.ts` is refactored to call into the shared module; the wire format and HKDF info string are unchanged so existing BeeKEM ratchet payloads remain compatible.

## Wire-format change

`CRDTSyncMessage` gains two fields:

- `welcomeRecipientKemPublicKey?: Uint8Array` — recipient's raw SEC1-uncompressed P-256 ECDH public key (65 bytes). Base64-encoded on the wire.
- `eciesSealed?: Uint8Array` — sealed serialized keychain delta. Base64-encoded on the wire.

Welcomes no longer populate `keychainChanges`; that field is now used exclusively by doc-load / snapshot-load responses (which encrypt the entire sync message under the current document key on a stream to an already-authorized peer, so it is unaffected). The validator (`evaluateBeeKEMWelcome`) requires both new fields to be present and non-empty.

## Receive-path defense in depth

Before invoking ECIES, the recipient verifies that the writer-signed `welcomeRecipientKemPublicKey` matches the locally-installed KEM public key (constant-time compare). A writer who claims a different encryption key for our identity is dropped outright. AES-GCM additionally fails closed on any sealed-payload tampering.

## API changes

- `CollabswarmConfig.experimentalBeeKEMBroadcastWelcome` — **removed** entirely.
- `addReader(reader)` is now `addReader(reader, readerKemPublicKey?: Uint8Array)`. When the KEM public key is omitted, the reader is added to the ACL but **no Welcome is sent** (the library never broadcasts an un-sealed Welcome). The new reader must recover keychain state via a fresh document load.
- `CollabswarmDocument.setKemKeyPair(keyPair)` / `getKemPublicKeyRaw()` — new methods so the application can plumb in a stable recipient-side ECDH key pair and share the raw public key with inviters out-of-band.

## Tests

New:
- `ecies.test.ts` — seal/open round-trip, wrong-key fails, truncated/tampered payloads rejected, raw export/import round-trip, salt+nonce randomness.
- `beekem-welcome-encryption.test.ts` — intended recipient can open the sealed Welcome, eavesdropper with a different ECDH key pair cannot decrypt, tampered sealed payload rejected, per-recipient sealed payloads stay distinct.

Updated:
- `beekem-welcome-handler.test.ts` — replaces `missing-keychain-changes` gate tests with `missing-recipient-kem-public-key` + `missing-ecies-sealed` gates; base acceptable message carries the new fields.
- `beekem-pending-welcomes.test.ts` — `welcomeFor` helper carries the new fields.
- `beekem-welcome.test.ts` — in-memory mirror docstring updated to clarify `keychainChanges` is the post-decryption plaintext stand-in.
- Yjs + Automerge sync-message-serializer tests cover the new fields' wire round-trip.

## Build / test status

`yarn build` clean. All workspace test suites pass:
- `@collabswarm/collabswarm` — 503 tests, 23 suites.
- `@collabswarm/collabswarm-yjs` — 71 tests, 2 suites.
- `@collabswarm/collabswarm-automerge` — 56 tests, 1 suite.
- `@collabswarm/collabswarm-react` — 42 tests, 4 suites.
- `@collabswarm/collabswarm-redux` — 30 tests, 1 suite.
- `@collabswarm/collabswarm-index` — 173 tests, 10 suites.

## Test plan

- [x] `yarn build` passes.
- [x] `yarn workspace @collabswarm/collabswarm test` passes.
- [x] `yarn workspace @collabswarm/collabswarm-yjs test` passes.
- [x] `yarn workspace @collabswarm/collabswarm-automerge test` passes.
- [x] `yarn workspace @collabswarm/collabswarm-react test` passes.
- [x] No remaining references to `experimentalBeeKEMBroadcastWelcome` or `BEEKEM-PAYLOAD-ENC` in the codebase.