### PR TITLE
Initial-load quorum verification (#186 / #189 §5.4.2)

### DIFF
--- a/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
@@ -706,6 +706,36 @@ describe('AutomergeJSONSerializer', () => {
     );
   });
 
+  // Round-trip for the initial-load quorum tip-set hash (#189 §5.4.2).
+  test('serializeSyncMessage/deserializeSyncMessage preserves tipsHash (quorum)', () => {
+    const hash = new Uint8Array(32);
+    for (let i = 0; i < hash.length; i++) hash[i] = (i * 7 + 3) & 0xff;
+    const message = {
+      documentId: 'quorum-doc',
+      tipsHash: hash,
+    };
+    const wire = serializer.serializeSyncMessage(message);
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.tipsHash).toEqual(hash);
+  });
+
+  test('deserializeSyncMessage omits tipsHash when absent on wire', () => {
+    const message = { documentId: 'no-quorum-doc' };
+    const wire = serializer.serializeSyncMessage(message);
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.tipsHash).toBeUndefined();
+  });
+
+  test('deserializeSyncMessage rejects non-string tipsHash', () => {
+    const wire = buildWire({
+      documentId: 'doc',
+      tipsHash: 42,
+    });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+      /tipsHash/,
+    );
+  });
+
   // Regression: prior to the upfront object guard, a malformed peer payload
   // like JSON `null` flowed straight to `raw.snapshot` access and threw a
   // bare `TypeError: Cannot read properties of null`. The guard mirrors

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
@@ -707,17 +707,29 @@ describe('AutomergeJSONSerializer', () => {
   });
 
   // Round-trip for the initial-load quorum tip-set hash (#189 §5.4.2).
-  test('serializeSyncMessage/deserializeSyncMessage preserves tipsHash (quorum)', () => {
-    const hash = new Uint8Array(32);
-    for (let i = 0; i < hash.length; i++) hash[i] = (i * 7 + 3) & 0xff;
-    const message = {
-      documentId: 'quorum-doc',
-      tipsHash: hash,
-    };
-    const wire = serializer.serializeSyncMessage(message);
-    const deserialized = serializer.deserializeSyncMessage(wire);
-    expect(deserialized.tipsHash).toEqual(hash);
-  });
+  // Table-driven: covers a deterministic-pattern hash and the all-zeros
+  // boundary (base64 leading-zero handling is a common regression source).
+  test.each([
+    [
+      'deterministic-pattern',
+      (() => {
+        const h = new Uint8Array(32);
+        for (let i = 0; i < h.length; i++) h[i] = (i * 7 + 3) & 0xff;
+        return h;
+      })(),
+    ],
+    ['all-zeros', new Uint8Array(32)],
+  ])(
+    'serializeSyncMessage/deserializeSyncMessage preserves tipsHash (quorum, %s)',
+    (_label, hash) => {
+      const wire = serializer.serializeSyncMessage({
+        documentId: 'quorum-doc',
+        tipsHash: hash,
+      });
+      const deserialized = serializer.deserializeSyncMessage(wire);
+      expect(deserialized.tipsHash).toEqual(hash);
+    },
+  );
 
   test('deserializeSyncMessage omits tipsHash when absent on wire', () => {
     const message = { documentId: 'no-quorum-doc' };
@@ -726,6 +738,9 @@ describe('AutomergeJSONSerializer', () => {
     expect(deserialized.tipsHash).toBeUndefined();
   });
 
+  // Left as a standalone `test` (not folded into the round-trip table) because
+  // it builds a malformed wire payload via `buildWire` to exercise the
+  // deserialize-side validator -- different setup from the round-trip cases.
   test('deserializeSyncMessage rejects non-string tipsHash', () => {
     const wire = buildWire({
       documentId: 'doc',
@@ -734,6 +749,43 @@ describe('AutomergeJSONSerializer', () => {
     expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
       /tipsHash/,
     );
+  });
+
+  // Quorum frontier binding wire-encoding (#186 / #189 §5.4.2). The `tips`
+  // field carries an explicit string[] of CIDs on load responses so the
+  // loader can bind the served state to the responder's frontier hash.
+  test.each([
+    ['typical', ['bafy1', 'bafy2', 'bafy3']],
+    ['single-tip', ['bafyOnly']],
+    ['empty-frontier', [] as string[]],
+  ])(
+    'serializeSyncMessage/deserializeSyncMessage preserves tips (%s)',
+    (_label, tips) => {
+      const wire = serializer.serializeSyncMessage({
+        documentId: 'frontier-doc',
+        tips,
+      });
+      const deserialized = serializer.deserializeSyncMessage(wire);
+      expect(deserialized.tips).toEqual(tips);
+    },
+  );
+
+  test('deserializeSyncMessage omits tips when absent on wire', () => {
+    const wire = serializer.serializeSyncMessage({
+      documentId: 'no-frontier-doc',
+    });
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.tips).toBeUndefined();
+  });
+
+  test('deserializeSyncMessage rejects non-array tips', () => {
+    const wire = buildWire({ documentId: 'doc', tips: 'not-an-array' });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(/tips/);
+  });
+
+  test('deserializeSyncMessage rejects non-string tips entries', () => {
+    const wire = buildWire({ documentId: 'doc', tips: ['ok', 42] });
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(/tips/);
   });
 
   // Regression: prior to the upfront object guard, a malformed peer payload

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
@@ -751,6 +751,25 @@ describe('AutomergeJSONSerializer', () => {
     );
   });
 
+  // PR #284 r24 Copilot review: `tipsHash` is defined as a fixed 32-byte
+  // SHA-256 digest; the deserializer previously accepted any base64-decoded
+  // length and let downstream quorum logic mis-bucket the value. Reject
+  // wrong-length payloads at the wire boundary.
+  test.each([
+    ['empty', new Uint8Array(0)],
+    ['short (16 bytes)', new Uint8Array(16)],
+    ['long (64 bytes)', new Uint8Array(64)],
+  ])(
+    'deserializeSyncMessage rejects tipsHash that is not exactly 32 bytes (%s)',
+    (_label, malformedHash) => {
+      const b64 = Buffer.from(malformedHash).toString('base64');
+      const wire = buildWire({ documentId: 'doc', tipsHash: b64 });
+      expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+        /tipsHash.*32 bytes/,
+      );
+    },
+  );
+
   // Quorum frontier binding wire-encoding (#186 / #189 §5.4.2). The `tips`
   // field carries an explicit string[] of CIDs on load responses so the
   // loader can bind the served state to the responder's frontier hash.

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -581,6 +581,11 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
         tipsHash:
           message.tipsHash &&
           Base64.fromUint8Array(message.tipsHash),
+        // Explicit tip-set advertisement populated on load responses to
+        // bind the served state to the responder's frontier (see
+        // `CRDTSyncMessage.tips`). Plain string[] of CIDs; passes through
+        // JSON verbatim.
+        tips: message.tips,
         snapshot: snapshotForWire,
       }),
     );
@@ -614,6 +619,7 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
       pathUpdate?: unknown;
       pathUpdateEpochId?: unknown;
       tipsHash?: unknown;
+      tips?: unknown;
       snapshot?: unknown;
       signature?: unknown;
     };
@@ -778,6 +784,29 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
       }
       tipsHash = Base64.toUint8Array(raw.tipsHash);
     }
+    // Initial-load quorum frontier binding (#186 / #189 §5.4.2). Untrusted
+    // input -- reject non-arrays or arrays containing non-strings up front
+    // so the loader's binding check never has to defensively coerce.
+    let tips: string[] | undefined;
+    if (raw.tips !== undefined) {
+      if (!Array.isArray(raw.tips)) {
+        throw new Error(
+          `Invalid sync message: 'tips' must be an array when present (got ${describeValue(
+            raw.tips,
+          )})`,
+        );
+      }
+      for (const entry of raw.tips) {
+        if (typeof entry !== 'string') {
+          throw new Error(
+            `Invalid sync message: 'tips' entries must be strings (got ${describeValue(
+              entry,
+            )})`,
+          );
+        }
+      }
+      tips = raw.tips as string[];
+    }
     // Build the returned object explicitly rather than spreading `...raw` so
     // that peer-supplied junk keys (e.g. `__proto__`, `constructor`, or any
     // unrecognized field) don't leak into the deserialized sync message. Only
@@ -809,6 +838,7 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
       result.pathUpdate = pathUpdate as CRDTSyncMessage<BinaryChange[], CryptoKey>['pathUpdate'];
     if (pathUpdateEpochId !== undefined) result.pathUpdateEpochId = pathUpdateEpochId;
     if (tipsHash !== undefined) result.tipsHash = tipsHash;
+    if (tips !== undefined) result.tips = tips;
     if (snapshot !== undefined) result.snapshot = snapshot;
     return result;
   }

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -575,6 +575,12 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
         pathUpdateEpochId:
           message.pathUpdateEpochId &&
           Base64.fromUint8Array(message.pathUpdateEpochId),
+        // Initial-load quorum tip-set hash (#189 §5.4.2). Base64-encoded
+        // for JSON-safe transport, mirrored on the deserialize path below.
+        // Only populated on tip-advertise responses.
+        tipsHash:
+          message.tipsHash &&
+          Base64.fromUint8Array(message.tipsHash),
         snapshot: snapshotForWire,
       }),
     );
@@ -607,6 +613,7 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
       eciesSealed?: unknown;
       pathUpdate?: unknown;
       pathUpdateEpochId?: unknown;
+      tipsHash?: unknown;
       snapshot?: unknown;
       signature?: unknown;
     };
@@ -757,6 +764,20 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
       }
       pathUpdateEpochId = Base64.toUint8Array(raw.pathUpdateEpochId);
     }
+    // Initial-load quorum tip-set hash (#189 §5.4.2). Decoded from base64
+    // on the way back to Uint8Array; mirrors the serializer above.
+    // Untrusted input -- reject anything that isn't a string.
+    let tipsHash: Uint8Array | undefined;
+    if (raw.tipsHash !== undefined) {
+      if (typeof raw.tipsHash !== 'string') {
+        throw new Error(
+          `Invalid sync message: 'tipsHash' must be a string when present (got ${describeValue(
+            raw.tipsHash,
+          )})`,
+        );
+      }
+      tipsHash = Base64.toUint8Array(raw.tipsHash);
+    }
     // Build the returned object explicitly rather than spreading `...raw` so
     // that peer-supplied junk keys (e.g. `__proto__`, `constructor`, or any
     // unrecognized field) don't leak into the deserialized sync message. Only
@@ -787,6 +808,7 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
     if (pathUpdate !== undefined)
       result.pathUpdate = pathUpdate as CRDTSyncMessage<BinaryChange[], CryptoKey>['pathUpdate'];
     if (pathUpdateEpochId !== undefined) result.pathUpdateEpochId = pathUpdateEpochId;
+    if (tipsHash !== undefined) result.tipsHash = tipsHash;
     if (snapshot !== undefined) result.snapshot = snapshot;
     return result;
   }

--- a/packages/collabswarm-automerge/src/collabswarm-automerge.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.ts
@@ -28,6 +28,7 @@ import {
   KeychainProvider,
   LRUCache,
   serializeChangeNodeForJSON,
+  TIPS_HASH_LENGTH,
 } from '@collabswarm/collabswarm';
 import { validateChangeBlockMetadata } from '@collabswarm/collabswarm';
 import { Base64 } from 'js-base64';
@@ -772,7 +773,13 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
     }
     // Initial-load quorum tip-set hash (#189 §5.4.2). Decoded from base64
     // on the way back to Uint8Array; mirrors the serializer above.
-    // Untrusted input -- reject anything that isn't a string.
+    // Untrusted input -- reject anything that isn't a string AND enforce
+    // the fixed-width SHA-256 digest length (32 bytes) at the wire
+    // boundary so malformed values never reach the quorum decision
+    // logic. `tipsHash` is used as a Map key in `decideLoadQuorum`; a
+    // wrong-length value could either silently mis-bucket against
+    // legitimate votes or produce a partial-hash collision under a
+    // hostile peer. Reject on the way in. See PR #284 r24 Copilot review.
     let tipsHash: Uint8Array | undefined;
     if (raw.tipsHash !== undefined) {
       if (typeof raw.tipsHash !== 'string') {
@@ -783,6 +790,12 @@ export class AutomergeJSONSerializer extends JSONSerializer<BinaryChange[]> {
         );
       }
       tipsHash = Base64.toUint8Array(raw.tipsHash);
+      if (tipsHash.length !== TIPS_HASH_LENGTH) {
+        throw new Error(
+          `Invalid sync message: 'tipsHash' must decode to exactly ` +
+            `${TIPS_HASH_LENGTH} bytes (SHA-256 digest); got ${tipsHash.length} bytes`,
+        );
+      }
     }
     // Initial-load quorum frontier binding (#186 / #189 §5.4.2). Untrusted
     // input -- reject non-arrays or arrays containing non-strings up front

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.test.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from '@jest/globals';
 import { Doc } from 'yjs';
 import { Base64 } from 'js-base64';
+import { YjsJSONSerializer } from './collabswarm-yjs';
 
 // Test the core Yjs functionality that YjsProvider wraps
 describe('Yjs Core Functionality', () => {
@@ -65,12 +66,47 @@ describe('Yjs Core Functionality', () => {
   test('should handle nested structures', () => {
     const doc = new Doc();
     const map = doc.getMap('root');
-    
+
     map.set('nested', 'value');
     map.set('another', 'data');
-    
+
     expect(map.get('nested')).toBe('value');
     expect(map.get('another')).toBe('data');
+  });
+});
+
+// Initial-load quorum tip-set hash wire-encoding (#189 §5.4.2). Parity with
+// the equivalent tests under collabswarm-automerge so both serializers stay
+// in lockstep on the new optional field.
+describe('YjsJSONSerializer tipsHash round-trip (quorum)', () => {
+  const serializer = new YjsJSONSerializer();
+
+  test('serializeSyncMessage/deserializeSyncMessage preserves tipsHash', () => {
+    const hash = new Uint8Array(32);
+    for (let i = 0; i < hash.length; i++) hash[i] = (i * 7 + 3) & 0xff;
+    const message = {
+      documentId: 'quorum-doc',
+      tipsHash: hash,
+    };
+    const wire = serializer.serializeSyncMessage(message);
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.tipsHash).toEqual(hash);
+  });
+
+  test('deserializeSyncMessage omits tipsHash when absent on wire', () => {
+    const message = { documentId: 'no-quorum-doc' };
+    const wire = serializer.serializeSyncMessage(message);
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.tipsHash).toBeUndefined();
+  });
+
+  test('deserializeSyncMessage rejects non-string tipsHash', () => {
+    // Build a malformed wire payload directly; bypasses serializeSyncMessage's
+    // type-safety so we can exercise the deserialize-side validator.
+    const wire = new TextEncoder().encode(
+      JSON.stringify({ documentId: 'doc', tipsHash: 42 }),
+    );
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(/tipsHash/);
   });
 });
 

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.test.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.test.ts
@@ -81,17 +81,31 @@ describe('Yjs Core Functionality', () => {
 describe('YjsJSONSerializer tipsHash round-trip (quorum)', () => {
   const serializer = new YjsJSONSerializer();
 
-  test('serializeSyncMessage/deserializeSyncMessage preserves tipsHash', () => {
-    const hash = new Uint8Array(32);
-    for (let i = 0; i < hash.length; i++) hash[i] = (i * 7 + 3) & 0xff;
-    const message = {
-      documentId: 'quorum-doc',
-      tipsHash: hash,
-    };
-    const wire = serializer.serializeSyncMessage(message);
-    const deserialized = serializer.deserializeSyncMessage(wire);
-    expect(deserialized.tipsHash).toEqual(hash);
-  });
+  // Table-driven round-trip cases. Each entry asserts that a populated
+  // `tipsHash` survives serialize/deserialize unchanged. We exercise both
+  // the deterministic-pattern hash and the all-zeros boundary because the
+  // base64 encoder's leading-zero handling is a common source of regressions.
+  test.each([
+    [
+      'deterministic-pattern',
+      (() => {
+        const h = new Uint8Array(32);
+        for (let i = 0; i < h.length; i++) h[i] = (i * 7 + 3) & 0xff;
+        return h;
+      })(),
+    ],
+    ['all-zeros', new Uint8Array(32)],
+  ])(
+    'serializeSyncMessage/deserializeSyncMessage preserves tipsHash (%s)',
+    (_label, hash) => {
+      const wire = serializer.serializeSyncMessage({
+        documentId: 'quorum-doc',
+        tipsHash: hash,
+      });
+      const deserialized = serializer.deserializeSyncMessage(wire);
+      expect(deserialized.tipsHash).toEqual(hash);
+    },
+  );
 
   test('deserializeSyncMessage omits tipsHash when absent on wire', () => {
     const message = { documentId: 'no-quorum-doc' };
@@ -100,13 +114,61 @@ describe('YjsJSONSerializer tipsHash round-trip (quorum)', () => {
     expect(deserialized.tipsHash).toBeUndefined();
   });
 
+  // Left as a standalone `test` (not folded into the round-trip table)
+  // because it builds a malformed wire payload directly to exercise the
+  // deserialize-side validator -- the setup (TextEncoder + handcrafted JSON)
+  // does not fit the round-trip `serialize -> deserialize` shape that the
+  // table cases share.
   test('deserializeSyncMessage rejects non-string tipsHash', () => {
-    // Build a malformed wire payload directly; bypasses serializeSyncMessage's
-    // type-safety so we can exercise the deserialize-side validator.
     const wire = new TextEncoder().encode(
       JSON.stringify({ documentId: 'doc', tipsHash: 42 }),
     );
     expect(() => serializer.deserializeSyncMessage(wire)).toThrow(/tipsHash/);
+  });
+});
+
+// Quorum frontier binding wire-encoding (#186 / #189 §5.4.2). The `tips`
+// field carries an explicit string[] of CIDs on load responses so the loader
+// can bind the served state to the responder's frontier hash.
+describe('YjsJSONSerializer tips round-trip (quorum frontier)', () => {
+  const serializer = new YjsJSONSerializer();
+
+  test.each([
+    ['typical', ['bafy1', 'bafy2', 'bafy3']],
+    ['single-tip', ['bafyOnly']],
+    ['empty-frontier', [] as string[]],
+  ])(
+    'serializeSyncMessage/deserializeSyncMessage preserves tips (%s)',
+    (_label, tips) => {
+      const wire = serializer.serializeSyncMessage({
+        documentId: 'frontier-doc',
+        tips,
+      });
+      const deserialized = serializer.deserializeSyncMessage(wire);
+      expect(deserialized.tips).toEqual(tips);
+    },
+  );
+
+  test('deserializeSyncMessage omits tips when absent on wire', () => {
+    const wire = serializer.serializeSyncMessage({
+      documentId: 'no-frontier-doc',
+    });
+    const deserialized = serializer.deserializeSyncMessage(wire);
+    expect(deserialized.tips).toBeUndefined();
+  });
+
+  test('deserializeSyncMessage rejects non-array tips', () => {
+    const wire = new TextEncoder().encode(
+      JSON.stringify({ documentId: 'doc', tips: 'not-an-array' }),
+    );
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(/tips/);
+  });
+
+  test('deserializeSyncMessage rejects non-string tips entries', () => {
+    const wire = new TextEncoder().encode(
+      JSON.stringify({ documentId: 'doc', tips: ['ok', 42] }),
+    );
+    expect(() => serializer.deserializeSyncMessage(wire)).toThrow(/tips/);
   });
 });
 

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.test.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.test.ts
@@ -125,6 +125,29 @@ describe('YjsJSONSerializer tipsHash round-trip (quorum)', () => {
     );
     expect(() => serializer.deserializeSyncMessage(wire)).toThrow(/tipsHash/);
   });
+
+  // PR #284 r24 Copilot review: `tipsHash` is defined as a fixed 32-byte
+  // SHA-256 digest; the deserializer previously accepted any base64-decoded
+  // length and let downstream quorum logic mis-bucket the value. Reject
+  // wrong-length payloads at the wire boundary.
+  test.each([
+    ['empty', new Uint8Array(0)],
+    ['short (16 bytes)', new Uint8Array(16)],
+    ['long (64 bytes)', new Uint8Array(64)],
+  ])(
+    'deserializeSyncMessage rejects tipsHash that is not exactly 32 bytes (%s)',
+    (_label, malformedHash) => {
+      // Hand-encode the base64 directly so we exercise the deserialize-side
+      // validator (the serializer's encoder pre-validation is not in play).
+      const b64 = Buffer.from(malformedHash).toString('base64');
+      const wire = new TextEncoder().encode(
+        JSON.stringify({ documentId: 'doc', tipsHash: b64 }),
+      );
+      expect(() => serializer.deserializeSyncMessage(wire)).toThrow(
+        /tipsHash.*32 bytes/,
+      );
+    },
+  );
 });
 
 // Quorum frontier binding wire-encoding (#186 / #189 §5.4.2). The `tips`

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -106,6 +106,13 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
         pathUpdateEpochId:
           message.pathUpdateEpochId &&
           Base64.fromUint8Array(message.pathUpdateEpochId),
+        // Initial-load quorum tip-set hash (#189 §5.4.2). Base64-encoded for
+        // JSON-safe transport, same pattern as `welcomeEpochId`. Only
+        // populated on tip-advertise responses; absent on regular sync
+        // traffic. The deserializer below mirrors this encoding.
+        tipsHash:
+          message.tipsHash &&
+          Base64.fromUint8Array(message.tipsHash),
         snapshot: snapshotForWire,
       }),
     );
@@ -134,6 +141,7 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
       eciesSealed?: unknown;
       pathUpdate?: unknown;
       pathUpdateEpochId?: unknown;
+      tipsHash?: unknown;
       snapshot?: unknown;
       signature?: unknown;
     };
@@ -278,6 +286,20 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
       }
       pathUpdateEpochId = Base64.toUint8Array(raw.pathUpdateEpochId);
     }
+    // Initial-load quorum tip-set hash (#189 §5.4.2). Decoded base64 on the
+    // way back to Uint8Array; mirrors the encoding in `serializeSyncMessage`
+    // above. Untrusted input -- reject anything that isn't a string.
+    let tipsHash: Uint8Array | undefined;
+    if (raw.tipsHash !== undefined) {
+      if (typeof raw.tipsHash !== 'string') {
+        throw new Error(
+          `Invalid sync message: 'tipsHash' must be a string when present (got ${describeValue(
+            raw.tipsHash,
+          )})`,
+        );
+      }
+      tipsHash = Base64.toUint8Array(raw.tipsHash);
+    }
     // Build the returned object explicitly rather than spreading `...raw` so
     // that peer-supplied junk keys don't leak into the deserialized sync
     // message. Only fields declared on `CRDTSyncMessage` are propagated.
@@ -306,6 +328,7 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
     if (pathUpdate !== undefined)
       result.pathUpdate = pathUpdate as CRDTSyncMessage<Uint8Array>['pathUpdate'];
     if (pathUpdateEpochId !== undefined) result.pathUpdateEpochId = pathUpdateEpochId;
+    if (tipsHash !== undefined) result.tipsHash = tipsHash;
     if (snapshot !== undefined) result.snapshot = snapshot;
     return result;
   }

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -13,6 +13,7 @@ import {
   KeychainProvider,
   LRUCache,
   serializeChangeNodeForJSON,
+  TIPS_HASH_LENGTH,
 } from '@collabswarm/collabswarm';
 import { validateChangeBlockMetadata } from '@collabswarm/collabswarm';
 import { applyUpdateV2, Doc, encodeStateAsUpdateV2, encodeStateVector } from 'yjs';
@@ -294,7 +295,14 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
     }
     // Initial-load quorum tip-set hash (#189 §5.4.2). Decoded base64 on the
     // way back to Uint8Array; mirrors the encoding in `serializeSyncMessage`
-    // above. Untrusted input -- reject anything that isn't a string.
+    // above. Untrusted input -- reject anything that isn't a string AND
+    // enforce the fixed-width SHA-256 digest length (32 bytes) at the
+    // wire boundary so malformed values never reach the quorum decision
+    // logic. `tipsHash` is defined as `SHA-256(sorted CID list)` and is
+    // used as a Map key in `decideLoadQuorum`; a wrong-length value could
+    // either silently mis-bucket against legitimate votes or produce a
+    // partial-hash collision under a hostile peer. Reject on the way in.
+    // See PR #284 r24 Copilot review.
     let tipsHash: Uint8Array | undefined;
     if (raw.tipsHash !== undefined) {
       if (typeof raw.tipsHash !== 'string') {
@@ -305,6 +313,12 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
         );
       }
       tipsHash = Base64.toUint8Array(raw.tipsHash);
+      if (tipsHash.length !== TIPS_HASH_LENGTH) {
+        throw new Error(
+          `Invalid sync message: 'tipsHash' must decode to exactly ` +
+            `${TIPS_HASH_LENGTH} bytes (SHA-256 digest); got ${tipsHash.length} bytes`,
+        );
+      }
     }
     // Initial-load quorum frontier binding (#186 / #189 §5.4.2). Untrusted
     // input -- reject non-arrays or arrays containing non-strings up front

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.ts
@@ -113,6 +113,11 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
         tipsHash:
           message.tipsHash &&
           Base64.fromUint8Array(message.tipsHash),
+        // Explicit tip-set advertisement populated on load responses to
+        // bind the served state to the responder's frontier (see
+        // `CRDTSyncMessage.tips`). Plain string[] of CIDs; passes through
+        // JSON verbatim. Absent on traffic that does not need binding.
+        tips: message.tips,
         snapshot: snapshotForWire,
       }),
     );
@@ -142,6 +147,7 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
       pathUpdate?: unknown;
       pathUpdateEpochId?: unknown;
       tipsHash?: unknown;
+      tips?: unknown;
       snapshot?: unknown;
       signature?: unknown;
     };
@@ -300,6 +306,29 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
       }
       tipsHash = Base64.toUint8Array(raw.tipsHash);
     }
+    // Initial-load quorum frontier binding (#186 / #189 §5.4.2). Untrusted
+    // input -- reject non-arrays or arrays containing non-strings up front
+    // so the loader's binding check never has to defensively coerce.
+    let tips: string[] | undefined;
+    if (raw.tips !== undefined) {
+      if (!Array.isArray(raw.tips)) {
+        throw new Error(
+          `Invalid sync message: 'tips' must be an array when present (got ${describeValue(
+            raw.tips,
+          )})`,
+        );
+      }
+      for (const entry of raw.tips) {
+        if (typeof entry !== 'string') {
+          throw new Error(
+            `Invalid sync message: 'tips' entries must be strings (got ${describeValue(
+              entry,
+            )})`,
+          );
+        }
+      }
+      tips = raw.tips as string[];
+    }
     // Build the returned object explicitly rather than spreading `...raw` so
     // that peer-supplied junk keys don't leak into the deserialized sync
     // message. Only fields declared on `CRDTSyncMessage` are propagated.
@@ -329,6 +358,7 @@ export class YjsJSONSerializer extends JSONSerializer<Uint8Array> {
       result.pathUpdate = pathUpdate as CRDTSyncMessage<Uint8Array>['pathUpdate'];
     if (pathUpdateEpochId !== undefined) result.pathUpdateEpochId = pathUpdateEpochId;
     if (tipsHash !== undefined) result.tipsHash = tipsHash;
+    if (tips !== undefined) result.tips = tips;
     if (snapshot !== undefined) result.snapshot = snapshot;
     return result;
   }

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -331,6 +331,105 @@ export interface CollabswarmConfig {
   webrtcIceServers?: ReadonlyArray<Readonly<IceServer>>;
 
   /**
+   * Enable the initial-load quorum gate.
+   *
+   * When `true` (the default), `CollabswarmDocument.load()` queries up to
+   * {@link loadQuorumK} peers in parallel via the `tipAdvertiseV1` protocol
+   * for a lightweight tip-set hash before accepting any one peer's full
+   * document state. The full load proceeds only if at least
+   * {@link loadQuorumQ} peers returned the same hash. If quorum is not
+   * met, `load()` rejects with a `LoadQuorumFailedError` and the open
+   * sequence fails -- the application can catch the error and decide how
+   * to recover.
+   *
+   * Closes the gap tracked under issue #189 §5.4 item 2 (also bulleted in
+   * #186). Defends against a single malicious or partitioned peer
+   * unilaterally serving a stale or maliciously-crafted initial state.
+   *
+   * Setting this to `false` reverts to the legacy single-peer load: any
+   * one peer's response is accepted on the strength of its outer
+   * writer-signature alone. This is appropriate for solo-peer dev,
+   * single-node tests, and small-mesh dev scenarios where no second peer
+   * is reachable, but **weakens the trust assumptions** of an open mesh
+   * (the loader has no defence-in-depth against an actively malicious
+   * peer that holds a valid writer key but advertises a forged tip set).
+   *
+   * @default true
+   */
+  loadQuorumEnabled?: boolean;
+
+  /**
+   * Maximum number of peers to probe in parallel for the initial-load
+   * quorum tip-advertise step. The effective K is
+   * `min(loadQuorumK, knownPeers.length)` so the loader never blocks on a
+   * peer that does not exist.
+   *
+   * The default of 3 is a deliberately small number: it gives the gate
+   * defence against a single dishonest peer (Q=2 majority of 3) without
+   * fanning out enough requests to noticeably impact open latency or
+   * bandwidth.
+   *
+   * @default 3
+   */
+  loadQuorumK?: number;
+
+  /**
+   * Minimum number of peers that must agree on the same tip-set hash to
+   * pass the initial-load quorum gate. Clamped at runtime to
+   * `[1, effectiveK]` so `Q > K` never makes quorum unreachable.
+   *
+   * Default formula: `Math.ceil(K / 2) + 1`, which yields:
+   *   - K=1 -> Q=1 (single-peer pass-through; requires `loadQuorumAllowSinglePeer: true`)
+   *   - K=2 -> Q=2 (both peers must agree)
+   *   - K=3 -> Q=2 (a single dishonest peer cannot win the vote)
+   *   - K=4 -> Q=3
+   *   - K=5 -> Q=3
+   * This is the standard "strictly more than half" Byzantine-fault-
+   * tolerant threshold and matches the design note in #189 §5.4.2.
+   *
+   * @default Math.ceil(loadQuorumK / 2) + 1, clamped to [1, loadQuorumK]
+   */
+  loadQuorumQ?: number;
+
+  /**
+   * Per-peer timeout (milliseconds) for the initial-load quorum
+   * tip-advertise probes. A peer that does not respond within this window
+   * is recorded as a non-vote (NOT a disagreement); see
+   * `load-quorum.ts::decideLoadQuorum` for the distinction.
+   *
+   * Default chosen to be larger than typical RTT + protocol-negotiation
+   * latency on a wide-area mesh, but small enough that a partitioned peer
+   * does not stall document open by more than ~5 seconds.
+   *
+   * @default 5000
+   */
+  loadQuorumTimeoutMs?: number;
+
+  /**
+   * Allow the initial-load quorum gate to pass with a single responding
+   * peer when no other peers are reachable.
+   *
+   * When `true` and the effective K resolves to 1 (only one known peer),
+   * the loader accepts that peer's tip-advertise response and proceeds
+   * with the full load. Useful for small private swarms or development
+   * scenarios where running multiple peers is impractical.
+   *
+   * **Trust caveat:** with K=1 there is no second opinion, so this flag
+   * weakens the gate's protection back to legacy single-peer trust
+   * semantics in exactly the case it was designed to defend. A warning
+   * is logged when the single-peer path is taken so operators can spot
+   * the regression in their environment.
+   *
+   * When `false` (the default), a single-peer mesh forces a
+   * `LoadQuorumFailedError`. Callers that genuinely run solo (e.g.
+   * brand-new documents, founding member) should either set
+   * `loadQuorumEnabled: false` or set this flag and accept the warning.
+   *
+   * @default false
+   */
+  loadQuorumAllowSinglePeer?: boolean;
+
+  /**
    * Optional callback to validate document paths before creation.
    *
    * Called when `open()` determines the document is new (i.e., `load()` returned

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -378,19 +378,35 @@ export interface CollabswarmConfig {
    * pass the initial-load quorum gate. Clamped at runtime to
    * `[1, effectiveK]` so `Q > K` never makes quorum unreachable.
    *
-   * Default formula: `Math.floor(K / 2) + 1` (strict majority), which yields:
-   *   - K=1 -> Q=1 (single-peer pass-through; requires `loadQuorumAllowSinglePeer: true`)
-   *   - K=2 -> Q=2 (both peers must agree)
-   *   - K=3 -> Q=2 (a single dishonest peer cannot win the vote)
-   *   - K=4 -> Q=3
-   *   - K=5 -> Q=3
-   *   - K=7 -> Q=4
+   * Default formula: `Math.floor(effectiveK / 2) + 1` (strict majority).
+   * IMPORTANT: the default Q is derived from the EFFECTIVE K (i.e.
+   * `min(loadQuorumK, knownPeersCount)`), NOT from the configured
+   * `loadQuorumK`. This matters when fewer than `loadQuorumK` peers are
+   * reachable: with `loadQuorumK=7` but only 3 peers in the mesh,
+   * `defaultQuorumQ(7) = 4` would require ALL 3 reachable peers to
+   * agree -- losing the one-fault tolerance the formula is meant to
+   * provide. Deriving from effective K instead gives `defaultQuorumQ(3) =
+   * 2`, which tolerates one non-vote among the 3 reachable peers. See
+   * `load-quorum-orchestrator.ts` and PR #284 r7 / r23 reviews.
+   *
+   * Worked examples (`effectiveK -> default Q`):
+   *   - effectiveK=1 -> Q=1 (single-peer pass-through; requires
+   *     `loadQuorumAllowSinglePeer: true`)
+   *   - effectiveK=2 -> Q=2 (both peers must agree)
+   *   - effectiveK=3 -> Q=2 (a single dishonest peer cannot win the vote)
+   *   - effectiveK=4 -> Q=3
+   *   - effectiveK=5 -> Q=3
+   *   - effectiveK=7 -> Q=4
    * This is the standard "strictly more than half" Byzantine-fault-
    * tolerant threshold and matches the design note in #189 §5.4.2.
-   * Using `floor + 1` rather than `ceil + 1` tolerates one fault at K=3
-   * (Q=2, not Q=3) as the PR description requires.
+   * Using `floor + 1` rather than `ceil + 1` tolerates one fault at
+   * effectiveK=3 (Q=2, not Q=3) as the PR description requires.
    *
-   * @default Math.floor(loadQuorumK / 2) + 1, clamped to [1, loadQuorumK]
+   * When the operator explicitly sets `loadQuorumQ`, this default is a
+   * no-op and the explicit value flows through `effectiveQ`'s `[1, k]`
+   * clamp instead.
+   *
+   * @default Math.floor(effectiveK / 2) + 1, clamped to [1, effectiveK]
    */
   loadQuorumQ?: number;
 

--- a/packages/collabswarm/src/collabswarm-config.ts
+++ b/packages/collabswarm/src/collabswarm-config.ts
@@ -378,16 +378,19 @@ export interface CollabswarmConfig {
    * pass the initial-load quorum gate. Clamped at runtime to
    * `[1, effectiveK]` so `Q > K` never makes quorum unreachable.
    *
-   * Default formula: `Math.ceil(K / 2) + 1`, which yields:
+   * Default formula: `Math.floor(K / 2) + 1` (strict majority), which yields:
    *   - K=1 -> Q=1 (single-peer pass-through; requires `loadQuorumAllowSinglePeer: true`)
    *   - K=2 -> Q=2 (both peers must agree)
    *   - K=3 -> Q=2 (a single dishonest peer cannot win the vote)
    *   - K=4 -> Q=3
    *   - K=5 -> Q=3
+   *   - K=7 -> Q=4
    * This is the standard "strictly more than half" Byzantine-fault-
    * tolerant threshold and matches the design note in #189 §5.4.2.
+   * Using `floor + 1` rather than `ceil + 1` tolerates one fault at K=3
+   * (Q=2, not Q=3) as the PR description requires.
    *
-   * @default Math.ceil(loadQuorumK / 2) + 1, clamped to [1, loadQuorumK]
+   * @default Math.floor(loadQuorumK / 2) + 1, clamped to [1, loadQuorumK]
    */
   loadQuorumQ?: number;
 

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -34,6 +34,7 @@ import {
   RecentTip,
   selectCrossLinks,
   trackTipInList,
+  treeContainsCid,
 } from './merkle-cross-links';
 import { CRDTSyncMessage } from './crdt-sync-message';
 import { ChangesSerializer } from './changes-serializer';
@@ -933,13 +934,16 @@ export class CollabswarmDocument<
    * should I advertise in a `tipAdvertiseV1` probe?".
    *
    * A load response only carries ONE change tree (rooted at
-   * `_lastSyncMessage.changeId`), plus optionally `_latestSnapshot` --
-   * `_lastSyncMessage` is only refreshed by `_makeChange()`, so its tree
-   * is rooted at *this peer's* last locally-produced change. Remote
-   * changes broadcast over GossipSub are applied to local CRDT state and
-   * recorded in `_hashes`, but they do NOT become roots of
-   * `_lastSyncMessage.changes` until this peer makes its next local
-   * change (which cross-links them via `selectCrossLinks`).
+   * `_lastSyncMessage.changeId`), plus optionally `_latestSnapshot`.
+   * `_lastSyncMessage` is refreshed by `_makeChange()` (its tree is
+   * rooted at *this peer's* last locally-produced change) AND by
+   * `_syncDocumentChanges()` (when an incoming remote tree subsumes the
+   * cached root -- the round-14 fix for relay peers that never make
+   * local changes; see `_refreshLastSyncMessageFromSync()`). When the
+   * incoming root is concurrent with the cached root, the cache is left
+   * alone so served-frontier coverage cannot shrink; the next local
+   * change re-bundles concurrent heads via cross-links from
+   * `_recentTips` (`selectCrossLinks`).
    *
    * So when a peer has multiple concurrent heads (e.g. its own last local
    * change H1 plus remotely-applied changes H2, H3 that aren't yet
@@ -1164,7 +1168,115 @@ export class CollabswarmDocument<
     if (fetchPromises.length > 0) {
       await Promise.all(fetchPromises);
     }
+
+    // Refresh `_lastSyncMessage` so the served frontier reflects what we now
+    // hold. Without this, a relay peer that joined via `load()` (or that has
+    // only ever applied remote changes via GossipSub) would keep
+    // `_lastSyncMessage` undefined and `_servedFrontier()` would return `[]`,
+    // making the peer advertise `tipsHash([])` in the initial-load quorum
+    // probe AND ship an empty load response. Two such relay peers would
+    // agree on the empty-set hash, satisfying quorum, and an honest newcomer
+    // would accept an empty document while the mesh actually had data
+    // (#284 r14 Copilot review).
+    //
+    // We update only when the incoming tree subsumes our prior root --
+    // i.e., `_lastSyncMessage.changeId` appears as a CID somewhere in the
+    // received tree -- so the served-frontier coverage never shrinks. The
+    // undefined-prior and same-root cases are also "subsumes" (vacuously
+    // and trivially); concurrent independent roots are intentionally left
+    // alone (matches the existing single-tree load semantics documented on
+    // `_servedFrontier()`). The next local `_makeChange()` cross-links
+    // through `_recentTips` regardless, so concurrent heads are recovered
+    // on the next local write.
+    this._refreshLastSyncMessageFromSync(changeId, changes);
+
     await this._maybeCompact();
+  }
+
+  /**
+   * Update `_lastSyncMessage` so it reflects the served frontier of a
+   * just-applied remote sync tree. Called by `_syncDocumentChanges()`
+   * after the merge has succeeded.
+   *
+   * Replacement policy: only swap the cached message when the incoming
+   * tree *subsumes* the prior cached root, so the served frontier the
+   * loader binds against can only grow, never shrink:
+   *   - `_lastSyncMessage` is `undefined` (relay peer, no local change
+   *     yet): adopt the incoming directly. This is the round-14 bug case
+   *     -- prior to the fix the relay peer's served frontier was empty.
+   *   - prior `changeId` appears anywhere in the incoming tree (root or
+   *     descendant): the incoming tree includes the prior root's coverage
+   *     by construction, so it is safe to replace.
+   *   - prior `changeId` is independent of the incoming tree (concurrent
+   *     heads, neither subsumes the other): leave the cached message in
+   *     place. The next local `_makeChange()` will bundle both heads via
+   *     cross-links from `_recentTips`. This matches the trade-off
+   *     documented on `_servedFrontier()` -- a load response only ever
+   *     carries one tree, so accepting a single root is the existing
+   *     contract.
+   *
+   * The cached message's `documentId` / `keychainChanges` fields are
+   * preserved across the swap. Response-specific fields
+   * (`signature`, `tips`, `tipsHash`) are dropped because they are
+   * regenerated per-response by the load / tip-advertise handlers; leaving
+   * a stale value would be misleading at best, a wire-protocol violation
+   * at worst.
+   *
+   * Idempotent and inexpensive: the subsumption check walks the incoming
+   * tree once (bounded by sender compaction config); the field-level
+   * replacement is O(1) reference swaps.
+   *
+   * @internal
+   */
+  private _refreshLastSyncMessageFromSync(
+    receivedChangeId: string | undefined,
+    receivedChanges: CRDTChangeNode<ChangesType>,
+  ): void {
+    // Defensive: if the incoming carries no root CID we cannot meaningfully
+    // refresh the served frontier with it. (`computeServedFrontier` will
+    // produce `[]` for the resulting `_lastSyncMessage` and we would simply
+    // re-introduce the empty-served-frontier bug.)
+    if (!receivedChangeId) return;
+
+    const priorChangeId = this._lastSyncMessage?.changeId;
+
+    // Case 1: no prior cached message -- adopt the incoming. This is the
+    // round-14 fix path: a relay peer with no local changes was previously
+    // serving an empty payload because `_lastSyncMessage` was `undefined`.
+    if (!priorChangeId) {
+      this._lastSyncMessage = {
+        ...(this._lastSyncMessage || { documentId: this.documentPath }),
+        changeId: receivedChangeId,
+        changes: receivedChanges,
+        // Drop response-specific fields; they are regenerated per-response.
+        signature: undefined,
+        tips: undefined,
+        tipsHash: undefined,
+      };
+      return;
+    }
+
+    // Case 2: same root -- already up to date, nothing to do. (CIDs are
+    // content-addressed so equal `changeId` implies the same subtree.)
+    if (priorChangeId === receivedChangeId) return;
+
+    // Case 3: prior root is embedded in the incoming tree -- the incoming
+    // subsumes the prior. Replace.
+    if (treeContainsCid(receivedChangeId, receivedChanges, priorChangeId)) {
+      this._lastSyncMessage = {
+        ...this._lastSyncMessage!,
+        changeId: receivedChangeId,
+        changes: receivedChanges,
+        signature: undefined,
+        tips: undefined,
+        tipsHash: undefined,
+      };
+      return;
+    }
+
+    // Case 4: concurrent / independent roots. Leave the cached message
+    // alone so we do not shrink served-frontier coverage. The next local
+    // `_makeChange()` cross-links via `_recentTips`, recovering both heads.
   }
 
   /**

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -2690,10 +2690,14 @@ export class CollabswarmDocument<
    * advertise responses with an unknown encryption key, missing/invalid
    * writer signature, document-id mismatch, or short/missing tip hash are
    * recorded as non-votes (NOT disagreements) so a stale peer cache does
-   * not flip a partition into a Byzantine-failure verdict. Peers are
-   * deduped by libp2p PeerId before the probe so a single peer with
-   * multiple open connections cannot cast multiple votes. After quorum
-   * passes, the served full state is bound to the agreed hash via the
+   * not flip a partition into a Byzantine-failure verdict. The probe
+   * round dedupes peers by libp2p PeerId so a single peer with multiple
+   * open connections cannot cast multiple votes. The legacy load loop
+   * (when `loadQuorumEnabled: false`) keeps the ORIGINAL un-deduped
+   * peer list so it can retry across multiple multiaddrs for the same
+   * peer id (e.g. a direct connection + a relay-circuit fallback). See
+   * PR #284 r7 Copilot review for the dedup-scope rationale. After
+   * quorum passes, the served full state is bound to the agreed hash via the
    * responder-supplied `tips` array on the load response: the loader
    * computes `tipsHash(message.tips)` and verifies it equals the quorum
    * `winningHashHex` BEFORE applying the response. Hashing the
@@ -2790,21 +2794,29 @@ export class CollabswarmDocument<
     };
     const serializedRequest = this._loadMessageSerializer.serializeLoadRequest(loadRequest);
 
-    // Dedupe `orderedPeers` by peer id BEFORE the quorum probe. `getConnections()`
-    // returns one entry per OPEN connection, and libp2p maintains separate
-    // connections per multiaddr / per transport — so a single remote peer with
-    // two open connections (e.g. direct + relay-circuit) shows up twice. Without
-    // this dedup, that peer would cast two votes in the quorum tally, allowing a
-    // single malicious peer with multiple connections to dominate the agreement
-    // count. Dedup by `_peerIdOf` (which extracts the LAST `/p2p/<id>` segment,
-    // i.e. the remote peer's libp2p PeerId for both direct and circuit-relay
-    // multiaddrs). Preserves first-seen order so the preferredPeer (placed at
-    // index 0 above) remains first.
-    {
-      const deduped = dedupePeersByPeerId(orderedPeers, (p) => this._peerIdOf(p));
-      orderedPeers.length = 0;
-      orderedPeers.push(...deduped);
-    }
+    // Dedupe peers by peer id ONLY for the quorum probe round.
+    // `getConnections()` returns one entry per OPEN connection, and libp2p
+    // maintains separate connections per multiaddr / per transport — so a
+    // single remote peer with two open connections (e.g. direct +
+    // relay-circuit) shows up twice. Without dedup, that peer would cast
+    // two votes in the quorum tally, allowing a single malicious peer with
+    // multiple connections to dominate the agreement count. Dedup by
+    // `_peerIdOf` (which extracts the LAST `/p2p/<id>` segment, i.e. the
+    // remote peer's libp2p PeerId for both direct and circuit-relay
+    // multiaddrs). Preserves first-seen order so the preferredPeer (placed
+    // at index 0 above) remains first.
+    //
+    // IMPORTANT: dedup applies only to `quorumPeers`. The legacy
+    // single-peer load path (when `loadQuorumEnabled: false`) keeps the
+    // ORIGINAL `orderedPeers` so it can retry across multiple multiaddrs
+    // for the same peer id -- e.g. a direct connection + a relay-circuit
+    // fallback. Collapsing those to one entry pre-quorum would silently
+    // break the legacy fallback even when the quorum gate is off. See PR
+    // #284 r7 Copilot review.
+    const quorumPeers = dedupePeersByPeerId(
+      orderedPeers,
+      (p) => this._peerIdOf(p),
+    );
 
     // Initial-load quorum gate (#189 §5.4.2 / #186).
     //
@@ -2840,7 +2852,7 @@ export class CollabswarmDocument<
     // test-coverage rationale.
     const timeoutMs = this.swarm.config?.loadQuorumTimeoutMs ?? 5000;
     const quorumResult = await runLoadQuorum({
-      peers: orderedPeers,
+      peers: quorumPeers,
       peerIdOf: (p) => this._peerIdOf(p),
       probeFn: (peer) =>
         this._raceTipAdvertiseProbe(peer, serializedRequest, timeoutMs),
@@ -2860,12 +2872,15 @@ export class CollabswarmDocument<
       // `runLoadQuorum` returns `{ skipped: true }` in two cases: (a) the
       // gate is disabled wholesale (`loadQuorumEnabled: false`), or (b) the
       // effective K resolved to 0 because no peers were known. For (a) we
-      // fall through to the legacy single-peer load loop unchanged (no
-      // narrowing, no winningHashHex). For (b) there is nothing to load
-      // against — treat as new document. The peer-list empty short-circuit
-      // at the top of `load()` already covers the trivial "no peers" path;
-      // this branch is reached when quorum is enabled with a valid K but
-      // the post-dedup `orderedPeers` happens to be empty.
+      // fall through to the legacy single-peer load loop unchanged --
+      // `orderedPeers` is intentionally NOT deduped here so the loop can
+      // retry across multiple multiaddrs for the same peer id (e.g. a
+      // direct connection + a relay-circuit fallback). For (b) there is
+      // nothing to load against — treat as new document. The peer-list
+      // empty short-circuit at the top of `load()` already covers the
+      // trivial "no peers" path; this branch is reached when quorum is
+      // enabled with a valid K but the post-dedup `quorumPeers` happens
+      // to be empty.
       //
       // Note: a misconfigured `loadQuorumK <= 0` no longer reaches this
       // branch — `runLoadQuorum` throws `LoadQuorumFailedError(invalid-
@@ -2873,12 +2888,16 @@ export class CollabswarmDocument<
       // `open()` time instead of silently forking the document. See PR
       // #284 r5 Copilot review.
       const quorumWasEnabled = this.swarm.config?.loadQuorumEnabled ?? true;
-      if (quorumWasEnabled && orderedPeers.length === 0) {
+      if (quorumWasEnabled && quorumPeers.length === 0) {
         return false;
       }
-      // Else: gate disabled. Fall through.
+      // Else: gate disabled. Fall through with the original (un-deduped)
+      // `orderedPeers` so the legacy loop can retry per-multiaddr.
     } else {
       winningHashHex = quorumResult.winningHashHex;
+      // Quorum succeeded: narrow the load loop to the agreeing cohort.
+      // The narrowed list is already deduped (it is a filter of
+      // `quorumPeers`), so we replace `orderedPeers` wholesale.
       orderedPeers.length = 0;
       orderedPeers.push(...quorumResult.narrowedPeers);
     }

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -2803,6 +2803,69 @@ export class CollabswarmDocument<
             );
           }
 
+          // PRE-FETCH gate (PR #284 r20 Copilot review).
+          //
+          // Round 19 added a POST-sync `_hashes`-coverage check, but
+          // `sync()` mutates the document as each fetched block lands
+          // -- so a missing CID would still leave the document
+          // partially mutated by the time the post-check threw a bind
+          // failure. To keep a failed quorum-bound load from altering
+          // local state at all, pull every required block from Helia
+          // here (BEFORE `sync()` is allowed to mutate). Helia's
+          // blockstore content-validates each fetch against its CID
+          // intrinsically; bitswap retrieves from any peer in the swarm
+          // that holds the legitimate block. If ANY fetch fails (CID
+          // not retrievable from any peer, content/CID mismatch, or
+          // timeout inside Helia), throw a per-peer bind failure with
+          // ZERO state mutation -- the load loop can cleanly retry the
+          // next peer in the agreeing cohort, or escalate to
+          // `bind-check-failed-all-agreeing-peers` if every peer
+          // exhausts.
+          //
+          // Run in parallel via `Promise.allSettled` so a single slow
+          // peer cannot pessimize the load. Block bytes are cached
+          // locally on success; the subsequent `sync()` call only does
+          // local lookups for those CIDs and applies them.
+          if (expectedCids.length > 0) {
+            const prefetchResults = await Promise.allSettled(
+              expectedCids.map(async (cidStr) => {
+                const cid = CID.parse(cidStr);
+                // Force the blockstore to retrieve the block. Helia
+                // validates content vs CID on `get`; the read of the
+                // returned async-iterable triggers the actual fetch.
+                await readUint8Iterable(
+                  this.swarm.heliaNode.blockstore.get(cid),
+                );
+              }),
+            );
+            const missingCids: string[] = [];
+            for (let i = 0; i < prefetchResults.length; i++) {
+              if (prefetchResults[i]!.status === 'rejected') {
+                missingCids.push(expectedCids[i]!);
+              }
+            }
+            if (missingCids.length > 0) {
+              console.warn(
+                `[${this.documentPath}] Quorum-bound load pre-fetch ` +
+                  `failed: ${missingCids.length} of ${expectedCids.length} ` +
+                  `expected CIDs were not retrievable from Helia (e.g. ` +
+                  `${missingCids
+                    .slice(0, 3)
+                    .map((c) => c.slice(0, 12) + '...')
+                    .join(', ')}). Recording peer as bind-failed BEFORE ` +
+                  `any state mutation; the loader will try the next ` +
+                  `agreeing peer with a clean document.`,
+              );
+              throw new _QuorumBindCheckFailedError(
+                '(prefetch-missing-blocks)',
+                `Quorum-bound load pre-fetch could not retrieve ` +
+                  `${missingCids.length} of ${expectedCids.length} expected ` +
+                  `CIDs from Helia; aborting before sync() so document ` +
+                  `state is unchanged.`,
+              );
+            }
+          }
+
           const syncResult = await this.sync(message, false);
           if (!syncResult) {
             console.warn(

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -769,6 +769,26 @@ export class CollabswarmDocument<
   }
 
   /**
+   * Returns this peer's current frontier as a plain string[] of CIDs —
+   * "what tips would I advertise to a fresh `tipAdvertiseV1` probe right
+   * now". Drawn from `this._hashes`, which is the same source the
+   * tip-advertise hash is computed from, so the advertised hash and the
+   * load-response `tips` field stay in lockstep across the two streams
+   * the loader uses (probe + full load).
+   *
+   * Wrapped in a helper so the load-response handlers, the tip-advertise
+   * handler, and (if reused later) any internal callers all hit the same
+   * canonical primitive. Returns a fresh array so callers can't mutate
+   * `_hashes` through the returned reference; the array is later sorted
+   * by `tipsHash` independently, so we don't sort here.
+   *
+   * @internal
+   */
+  private _currentFrontier(): string[] {
+    return Array.from(this._hashes);
+  }
+
+  /**
    * Record a CID as a recently-known tip for Merkle-CRDT cross-linking
    * (paper §VI.B.e). Called for both locally-generated and remote-applied
    * change nodes -- a peer A that just received B's change can cross-link
@@ -1676,6 +1696,20 @@ export class CollabswarmDocument<
         loadMessage.snapshot = this._latestSnapshot;
       }
 
+      // Attach an explicit tip-set advertisement so the loader can bind the
+      // served state to this responder's current frontier (issue #186 /
+      // #189 §5.4.2). The loader recomputes `tipsHash(tips)` and compares
+      // against the quorum-agreed `winningHashHex`; using the responder's
+      // own `_hashes` here keeps the binding source identical to the one
+      // used by the `tipAdvertiseV1` probe response so a peer that voted
+      // for hash X but serves a load whose `tips` hash to Y is caught.
+      // Drawn from the same `_hashes` set so a peer that loaded from a
+      // snapshot (and therefore has a pruned `_hashes`) still produces a
+      // self-consistent advertisement; the responder is attesting to
+      // "what tip-advertise would I respond with right now", not "what
+      // full history did I once have".
+      loadMessage.tips = this._currentFrontier();
+
       // Sign new message.
       loadMessage.signature = await this._signAsWriter(loadMessage);
 
@@ -1793,6 +1827,15 @@ export class CollabswarmDocument<
       const snapshotMessage = this._createSyncMessage();
       snapshotMessage.snapshot = this._latestSnapshot;
       snapshotMessage.keychainChanges = await this._keychainChangesForVisibility();
+      // Tip-set advertisement for the post-load binding check (see the
+      // doc-load handler above and the in-line check in
+      // `_sendLoadRequestAndSync` for the rationale). On a snapshot-load
+      // the loader's post-sync `_hashes`
+      // does NOT include ancestor CIDs that were compacted into the
+      // snapshot, so a `tipsHash(loader._hashes)` recomputation would
+      // never match a responder whose `_hashes` retains full history.
+      // The responder's `tips` is the canonical source of truth here.
+      snapshotMessage.tips = this._currentFrontier();
       snapshotMessage.signature = await this._signAsWriter(snapshotMessage);
 
       const serialized =
@@ -1911,10 +1954,13 @@ export class CollabswarmDocument<
       }
 
       // Compute the canonical tip-set hash from the document's current
-      // `_hashes` set. Two peers with the same view produce byte-identical
-      // hashes; see `tips-hash.ts` for the canonicalization (sort + `\n`
-      // separator + SHA-256).
-      const hash = await tipsHash(this._hashes);
+      // frontier — the same source load responses use for the `tips` field
+      // (see `handleLoadRequestData` / `handleSnapshotLoadRequestData`),
+      // so a probe-then-load round-trip from this responder always binds
+      // against a consistent advertisement. Two peers with the same view
+      // produce byte-identical hashes; see `tips-hash.ts` for the
+      // canonicalization (sort + `\n` separator + SHA-256).
+      const hash = await tipsHash(this._currentFrontier());
 
       const advertisement: CRDTSyncMessage<ChangesType, PublicKey> = {
         documentId: this.documentPath,
@@ -2056,6 +2102,7 @@ export class CollabswarmDocument<
   private async _sendLoadRequestAndSync(
     stream: { sink: (data: Iterable<Uint8Array>) => Promise<void>; source: AsyncIterable<Uint8ArrayList | Uint8Array> },
     serializedRequest: Uint8Array,
+    expectedTipsHashHex: string | null = null,
   ): Promise<boolean> {
     await pipe([serializedRequest], stream.sink);
     return await pipe(
@@ -2157,6 +2204,55 @@ export class CollabswarmDocument<
           }
         }
 
+        // Quorum frontier binding (#186 / #189 §5.4.2). When the loader
+        // ran a quorum probe round, the responder must have included its
+        // current frontier in `message.tips`; we hash that and require it
+        // to match the quorum-agreed `winningHashHex`. Done BEFORE
+        // `this.sync(...)` so a Byzantine peer that voted hash X but
+        // serves a load with a different frontier never gets to mutate
+        // the in-memory document. Recomputing the hash from
+        // `tipsHash(this._hashes)` post-sync (the prior behaviour) is
+        // unreliable because snapshot-loads don't restore ancestor CIDs
+        // and the loader's pre-existing local CIDs (if any) inflate the
+        // recomputed set.
+        if (expectedTipsHashHex !== null) {
+          if (!Array.isArray(message.tips)) {
+            console.warn(
+              `[${this.documentPath}] Quorum frontier binding: responder ` +
+                `omitted 'tips' on load response; refusing to apply state ` +
+                `from an un-attesting peer.`,
+            );
+            throw new LoadQuorumFailedError({
+              documentPath: this.documentPath,
+              reason: 'no-majority',
+              respondingCount: 0,
+              requiredQ: 0,
+              agreement: new Map([[expectedTipsHashHex, 0]]),
+            });
+          }
+          const advertisedBytes = await tipsHash(message.tips);
+          const advertisedHex = tipsHashToHex(advertisedBytes);
+          if (!constantTimeHexEquals(expectedTipsHashHex, advertisedHex)) {
+            console.warn(
+              `[${this.documentPath}] Quorum frontier binding FAILED: ` +
+                `expected tipsHash=${expectedTipsHashHex.slice(0, 12)}... but ` +
+                `responder advertised tips that hash to ${advertisedHex.slice(0, 12)}.... ` +
+                `An agreeing peer voted for one tip set and served a ` +
+                `different one; treating as Byzantine equivocation.`,
+            );
+            throw new LoadQuorumFailedError({
+              documentPath: this.documentPath,
+              reason: 'no-majority',
+              respondingCount: 0,
+              requiredQ: 0,
+              agreement: new Map([
+                [expectedTipsHashHex, 0],
+                [advertisedHex, 0],
+              ]),
+            });
+          }
+        }
+
         const syncResult = await this.sync(message, false);
         if (!syncResult) {
           console.warn(
@@ -2189,13 +2285,49 @@ export class CollabswarmDocument<
   private async _probeTipAdvertise(
     peer: import('@multiformats/multiaddr').Multiaddr,
     serializedRequest: Uint8Array,
+    signal?: AbortSignal,
   ): Promise<Uint8Array | null> {
+    // Capture the underlying v3 Stream so the abort path below can call
+    // `abort()` on it directly (the wrapped DuplexStream only exposes the
+    // write-side half-close via `close()`, not a full bidirectional tear-
+    // down). Without this, a probe that loses the Promise.race to the
+    // timeout would leak its stream until the libp2p connection itself
+    // closed -- on partitioned/slow peers, each `load()` could leak K
+    // streams, exhausting per-connection stream quotas. See PR #284 r2
+    // CodeRabbit comment on this method.
+    let rawStream: import('@libp2p/interface').Stream;
     let stream: { sink: (data: Iterable<Uint8Array>) => Promise<void>; source: AsyncIterable<Uint8ArrayList | Uint8Array> };
     try {
-      stream = wrapStream(await this.libp2p.dialProtocol(peer, [tipAdvertiseV1]));
+      rawStream = await this.libp2p.dialProtocol(peer, [tipAdvertiseV1]);
+      stream = wrapStream(rawStream);
     } catch {
       // Peer doesn't support tip-advertise or dial failed -- treat as non-vote.
       return null;
+    }
+    // Abort handler: tear down the v3 stream bidirectionally so a timed-out
+    // probe doesn't strand the libp2p resource. `abort()` is the v3 full
+    // teardown ("close stream for reading and writing"); `close()` would
+    // only half-close the write side. Re-checking `signal?.aborted` after
+    // attaching handles the race where the signal fired between dial and
+    // listener attach. The handler also resolves `pipe()` / read promises
+    // below with `AbortError`, which we swallow in the outer catch.
+    const onAbort = () => {
+      try {
+        rawStream.abort(new Error('tip-advertise probe aborted'));
+      } catch {
+        // Already torn down -- nothing to do.
+      }
+    };
+    if (signal) {
+      if (signal.aborted) {
+        try {
+          rawStream.abort(new Error('tip-advertise probe aborted'));
+        } catch {
+          /* already torn down */
+        }
+        return null;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
     }
     try {
       await pipe([serializedRequest], stream.sink);
@@ -2269,6 +2401,22 @@ export class CollabswarmDocument<
       return message.tipsHash;
     } catch {
       return null;
+    } finally {
+      // Always detach the abort listener and release the libp2p stream.
+      // The normal success path drops through to here after `return` runs,
+      // so we still need to close the stream to release per-connection
+      // stream quota (the response read consumed the read side but the
+      // write side is half-open until close() runs). On the abort path
+      // `rawStream.abort()` has already been called by `onAbort`; calling
+      // `close()` again is a no-op the libp2p impls tolerate.
+      if (signal) {
+        signal.removeEventListener('abort', onAbort);
+      }
+      try {
+        await rawStream.close();
+      } catch {
+        /* already torn down */
+      }
     }
   }
 
@@ -2276,9 +2424,14 @@ export class CollabswarmDocument<
    * Run a single tip-advertise probe with a hard timeout. The probe itself
    * never throws (`_probeTipAdvertise` returns `null` on any failure
    * mode); a timeout also resolves to `null` so the caller can treat the
-   * peer as a non-vote rather than a disagreement. The pending probe
-   * keeps running on the background event loop after timeout, but its
-   * resolution is discarded by Promise.race.
+   * peer as a non-vote rather than a disagreement.
+   *
+   * Stream cancellation: when the timeout wins the race, the underlying
+   * probe's libp2p stream is torn down via an AbortController so the
+   * pending probe doesn't keep the resource alive in the background. Prior
+   * to this fix, every timed-out probe leaked one libp2p stream per
+   * `load()` call; under partitions or slow peers, K such leaks per load
+   * could exhaust per-connection stream quotas. See PR #284 r2 review.
    *
    * @internal
    */
@@ -2287,17 +2440,24 @@ export class CollabswarmDocument<
     serializedRequest: Uint8Array,
     timeoutMs: number,
   ): Promise<Uint8Array | null> {
+    const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<null>((resolve) => {
       timer = setTimeout(() => resolve(null), timeoutMs);
     });
     try {
       return await Promise.race([
-        this._probeTipAdvertise(peer, serializedRequest),
+        this._probeTipAdvertise(peer, serializedRequest, controller.signal),
         timeout,
       ]);
     } finally {
       if (timer !== undefined) clearTimeout(timer);
+      // Whether the probe won or the timeout won, abort the controller so
+      // any in-flight probe (loser of the race, still pending on the event
+      // loop) tears down its stream. Aborting AFTER the probe has already
+      // resolved is a no-op: the probe's finally block will have already
+      // detached the listener and closed the stream itself.
+      controller.abort();
     }
   }
 
@@ -2315,58 +2475,6 @@ export class CollabswarmDocument<
     const str = peer.toString();
     const matches = [...str.matchAll(/\/p2p\/([^/]+)/g)];
     return matches.length > 0 ? matches[matches.length - 1][1] : str;
-  }
-
-  /**
-   * Verify that the just-applied load response matches the tip-set hash the
-   * quorum agreed on. Called after `_sendLoadRequestAndSync` returns `true`
-   * and `_hashes` has been populated with the served state's CIDs. The
-   * recomputed `tipsHash(this._hashes)` MUST equal `expectedHex` (the
-   * quorum's `winningHashHex`), otherwise a peer in the agreeing cohort
-   * voted for one tip set and served a different one (Byzantine
-   * equivocation: cheap to do because the tip-advertise probe and the
-   * full-state load happen on separate streams). On mismatch we throw
-   * `LoadQuorumFailedError`; the in-memory document is already partially
-   * mutated at that point, so the caller MUST treat the document instance
-   * as poisoned and construct a fresh one (this is acceptable because the
-   * gate runs during `open()`, before the document is exposed to
-   * application code or subscribed to pubsub).
-   *
-   * Constant-time comparison: the two hex strings are always 64 chars
-   * (SHA-256 lowercase hex). An early-exit `===` would leak which prefix
-   * matched; a brute-force timing attacker can amplify that into "I know
-   * which agreeing peer you'd accept", which while not catastrophic is
-   * also free to avoid.
-   *
-   * When `expectedHex` is `null` (quorum disabled), this is a no-op.
-   *
-   * @internal
-   */
-  private async _enforceQuorumHashBinding(
-    expectedHex: string | null,
-  ): Promise<void> {
-    if (expectedHex === null) return;
-    const actualBytes = await tipsHash(this._hashes);
-    const actualHex = tipsHashToHex(actualBytes);
-    if (!constantTimeHexEquals(expectedHex, actualHex)) {
-      console.warn(
-        `[${this.documentPath}] Initial-load quorum hash binding FAILED: ` +
-          `expected tipsHash=${expectedHex.slice(0, 12)}... but loaded ` +
-          `state hashed to ${actualHex.slice(0, 12)}.... An agreeing peer ` +
-          `served a state that does not match its tip-advertise vote; ` +
-          `treating as Byzantine equivocation.`,
-      );
-      throw new LoadQuorumFailedError({
-        documentPath: this.documentPath,
-        reason: 'no-majority',
-        respondingCount: 0,
-        requiredQ: 0,
-        agreement: new Map([
-          [expectedHex, 0],
-          [actualHex, 0],
-        ]),
-      });
-    }
   }
 
   // API Methods --------------------------------------------------------------
@@ -2404,11 +2512,19 @@ export class CollabswarmDocument<
    * not flip a partition into a Byzantine-failure verdict. Peers are
    * deduped by libp2p PeerId before the probe so a single peer with
    * multiple open connections cannot cast multiple votes. After quorum
-   * passes, the served full state is bound to the agreed hash: the
-   * recomputed `tipsHash(this._hashes)` post-sync must equal the quorum
-   * `winningHashHex`, otherwise an agreeing peer equivocated between its
-   * advertise vote and its served state and the load is rejected. Closes
-   * the gap tracked under issue #189 §5.4 item 2 (and bulleted in #186).
+   * passes, the served full state is bound to the agreed hash via the
+   * responder-supplied `tips` array on the load response: the loader
+   * computes `tipsHash(message.tips)` and verifies it equals the quorum
+   * `winningHashHex` BEFORE applying the response. Hashing the
+   * responder's own attestation (rather than recomputing
+   * `tipsHash(this._hashes)` post-sync) keeps the binding correct under
+   * snapshot-load (which doesn't restore ancestor CIDs to `_hashes`),
+   * history compaction, and pre-existing local CIDs — the prior
+   * recompute-locally approach would fail-open or fail-closed in those
+   * cases. An agreeing peer that voted hash X but serves a load whose
+   * `tips` hash to Y is caught and the load is rejected before any
+   * in-memory document state is mutated. Closes the gap tracked under
+   * issue #189 §5.4 item 2 (and bulleted in #186).
    *
    * @returns `true` if the document was successfully loaded from a peer.
    *   `false` if no peer could provide the document -- this is ambiguous: it
@@ -2572,8 +2688,9 @@ export class CollabswarmDocument<
             `degraded back to single-peer load). Configure additional peers ` +
             `to restore Byzantine-fault-tolerant quorum semantics.`,
         );
+        const probedPeer = orderedPeers[0];
         const probe = await this._raceTipAdvertiseProbe(
-          orderedPeers[0],
+          probedPeer,
           serializedRequest,
           timeoutMs,
         );
@@ -2591,8 +2708,18 @@ export class CollabswarmDocument<
         // advertised (defends against a malicious peer that decides what
         // to serve only after seeing the advertise round-trip).
         winningHashHex = tipsHashToHex(probe);
-        // Proceed with `orderedPeers` unchanged (preferred-peer order
-        // preserved). Fall through to the legacy snapshot/doc-load loop.
+        // Narrow `orderedPeers` to ONLY the probed peer. Without this,
+        // the subsequent snapshot/doc-load loop would also try the other
+        // peers in `orderedPeers` (which were never probed) and bind
+        // their served state against THIS peer's hash — a non-sequitur
+        // that could either: (a) pass the binding by coincidence and
+        // accept state from a peer that never voted for it, or (b) fail
+        // the binding and abort the load even though the single-peer
+        // path explicitly opted into single-peer trust. Restrict the
+        // load loop to the one peer whose hash we accepted. See PR #284
+        // r2 CodeRabbit comment on this block.
+        orderedPeers.length = 0;
+        orderedPeers.push(probedPeer);
       } else {
         // Standard K-of-Q quorum path. Take the first K peers from the
         // already-ordered list (preferredPeer is at index 0, so it is
@@ -2654,15 +2781,16 @@ export class CollabswarmDocument<
     // If the peer returns an empty response (no snapshot available),
     // fall back to the regular doc-load protocol.
     //
-    // After a successful load we verify `tipsHash(this._hashes)` equals the
-    // quorum-agreed `winningHashHex` (when quorum is enabled). This binds the
-    // served full state to what the peer advertised during the probe round.
-    // Without this binding, a peer in the agreeing cohort could vote for
-    // hash X and then serve a different state, defeating the gate's whole
-    // purpose. On mismatch the load is rejected and `LoadQuorumFailedError`
-    // is thrown; the in-memory document state is poisoned at that point so
-    // we cannot transparently retry the next peer — the caller must
-    // construct a fresh document instance.
+    // Quorum frontier binding: when `winningHashHex` is non-null,
+    // `_sendLoadRequestAndSync` requires the responder to include its
+    // current frontier in `message.tips` and verifies
+    // `tipsHash(message.tips) === winningHashHex` BEFORE applying the
+    // sync, so a Byzantine peer that voted for one tip set and serves a
+    // different one never gets to mutate in-memory document state. On
+    // mismatch the load is rejected via `LoadQuorumFailedError` and the
+    // caller must construct a fresh document instance (the gate runs
+    // during `open()`, so no application code has observed the document
+    // yet).
     for (const peer of orderedPeers) {
       try {
         console.log('Trying snapshot-load from peer:', peer.toString());
@@ -2673,9 +2801,12 @@ export class CollabswarmDocument<
         const snapshotStream = wrapStream(await this.libp2p.dialProtocol(peer, [
           snapshotLoadV2,
         ]));
-        const loaded = await this._sendLoadRequestAndSync(snapshotStream, serializedRequest);
+        const loaded = await this._sendLoadRequestAndSync(
+          snapshotStream,
+          serializedRequest,
+          winningHashHex,
+        );
         if (loaded) {
-          await this._enforceQuorumHashBinding(winningHashHex);
           return true;
         }
         // Empty response -- peer has no snapshot, try doc-load below.
@@ -2690,9 +2821,12 @@ export class CollabswarmDocument<
         const docStream = wrapStream(await this.libp2p.dialProtocol(peer, [
           documentLoadV2,
         ]));
-        const loaded = await this._sendLoadRequestAndSync(docStream, serializedRequest);
+        const loaded = await this._sendLoadRequestAndSync(
+          docStream,
+          serializedRequest,
+          winningHashHex,
+        );
         if (loaded) {
-          await this._enforceQuorumHashBinding(winningHashHex);
           return true;
         }
       } catch (err) {

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -188,15 +188,30 @@ export type CollabswarmDocumentChangeHandler<DocType, PublicKey> = (
 /**
  * Maximum size (in bytes) of a `tipAdvertiseV1` probe response read. A
  * legitimate response is a single encrypted `CRDTSyncMessage` carrying
- * only `documentId`, a 32-byte `tipsHash`, and an optional writer
- * signature — a few hundred bytes at most after JSON framing plus the
- * AES-GCM header/tag. 2 KiB is generous for honest peers (well above the
- * realistic upper bound, even with longer document paths or larger
- * signatures) while bounding what a malicious peer can force the loader
- * to buffer before being rejected as a non-vote. See PR #284 r4 Copilot
- * review.
+ * the `documentId` (pre-encryption path of up to `MAX_DOCUMENT_PATH_LENGTH`
+ * bytes; this is BIGGER than the tipsHash + signature payload combined),
+ * a 32-byte `tipsHash`, and an optional writer signature.
+ *
+ * Bound derivation:
+ *   - documentId: up to `MAX_DOCUMENT_PATH_LENGTH` bytes UTF-8.
+ *   - JSON framing + Base64 expansion of the encrypted body: ~256 bytes.
+ *   - Writer signature: ECDSA P-384 ≈ 96 raw bytes, Base64 ≈ 128 bytes,
+ *     plus the field's JSON key/quotes — round to 256 bytes.
+ *   - tipsHash: 32 raw bytes → Base64 ≈ 44 bytes.
+ *   - AES-GCM nonce: 12 raw bytes → Base64 ≈ 16 bytes.
+ *   - AES-GCM auth tag: 16 bytes.
+ *   - Plus slack for the encrypted-payload header (keyID prefix) and any
+ *     additional JSON overhead.
+ *
+ * The previous 2 KiB cap was tighter than `MAX_DOCUMENT_PATH_LENGTH`
+ * alone, so a document opened at a maximal path would always blow the cap
+ * and be recorded as a non-vote — quorum would never pass for such
+ * documents. 6 KiB comfortably covers a maximum-length path plus all of
+ * the overheads above while still bounding what a malicious peer can
+ * force the loader to buffer before being rejected as a non-vote.
+ * See PR #284 r4/r5 Copilot review.
  */
-const MAX_TIP_ADVERTISE_RESPONSE_SIZE = 2 * 1024;
+const MAX_TIP_ADVERTISE_RESPONSE_SIZE = 6 * 1024;
 
 export class CollabswarmDocument<
   DocType,
@@ -2437,17 +2452,23 @@ export class CollabswarmDocument<
     }
     try {
       await pipe([serializedRequest], stream.sink);
-      // Size-bound the tip-advertise response read. A `tipAdvertiseV1` body
-      // is an encrypted `CRDTSyncMessage` carrying only `documentId`, a
-      // 32-byte `tipsHash`, and (optionally) a writer signature — a few
-      // hundred bytes at most after JSON framing + AES-GCM header/tag. A
-      // 2 KiB cap is generous for legitimate peers but prevents a
-      // malicious peer from streaming an unbounded payload to force
-      // `load()` to buffer it all before returning a non-vote. If the
-      // read overruns the cap, `readUint8Iterable` throws a `RangeError`
-      // that is caught by the surrounding `try { ... } catch { return
-      // null; }` — surfacing as a non-vote (same outcome as a timeout),
-      // NOT a quorum disagreement. See PR #284 r4 Copilot review.
+      // Size-bound the tip-advertise response read. A `tipAdvertiseV1`
+      // body is an encrypted `CRDTSyncMessage` carrying the `documentId`
+      // (up to `MAX_DOCUMENT_PATH_LENGTH` bytes BEFORE encryption — this
+      // dominates the size), a 32-byte `tipsHash`, and (optionally) a
+      // writer signature. The cap is derived from
+      // `MAX_DOCUMENT_PATH_LENGTH` plus JSON / Base64 / AES-GCM / signature
+      // overheads (see `MAX_TIP_ADVERTISE_RESPONSE_SIZE` docstring above
+      // for the breakdown). The previous 2 KiB cap was smaller than the
+      // `documentId` field alone, so any document with a maximal path was
+      // surfaced as a non-vote and quorum could never pass for it. 6 KiB
+      // is generous for legitimate peers but prevents a malicious peer
+      // from streaming an unbounded payload to force `load()` to buffer
+      // it all before returning a non-vote. If the read overruns the cap,
+      // `readUint8Iterable` throws a `RangeError` that is caught by the
+      // surrounding `try { ... } catch { return null; }` — surfacing as a
+      // non-vote (same outcome as a timeout), NOT a quorum disagreement.
+      // See PR #284 r4/r5 Copilot review.
       const assembled = await readUint8Iterable(
         stream.source,
         MAX_TIP_ADVERTISE_RESPONSE_SIZE,
@@ -2789,26 +2810,24 @@ export class CollabswarmDocument<
     if ('skipped' in quorumResult) {
       // `runLoadQuorum` returns `{ skipped: true }` in two cases: (a) the
       // gate is disabled wholesale (`loadQuorumEnabled: false`), or (b) the
-      // effective K resolved to 0 (no peers OR misconfigured `loadQuorumK
-      // <= 0`). For (a) we want to fall through to the legacy single-peer
-      // load loop unchanged (no narrowing, no winningHashHex). For (b)
-      // there is nothing to load against — treat as new document. The
-      // peer-list empty short-circuit at the top of `load()` already
-      // covers the trivial "no peers" path; this branch handles the
-      // configuredK<=0 edge case so a misconfiguration cannot silently
-      // skip the gate against a populated peer list.
+      // effective K resolved to 0 because no peers were known. For (a) we
+      // fall through to the legacy single-peer load loop unchanged (no
+      // narrowing, no winningHashHex). For (b) there is nothing to load
+      // against — treat as new document. The peer-list empty short-circuit
+      // at the top of `load()` already covers the trivial "no peers" path;
+      // this branch is reached when quorum is enabled with a valid K but
+      // the post-dedup `orderedPeers` happens to be empty.
+      //
+      // Note: a misconfigured `loadQuorumK <= 0` no longer reaches this
+      // branch — `runLoadQuorum` throws `LoadQuorumFailedError(invalid-
+      // config)` for that case so the misconfiguration is loud at
+      // `open()` time instead of silently forking the document. See PR
+      // #284 r5 Copilot review.
       const quorumWasEnabled = this.swarm.config?.loadQuorumEnabled ?? true;
-      const configuredK = this.swarm.config?.loadQuorumK ?? 3;
-      if (quorumWasEnabled && configuredK > 0 && orderedPeers.length === 0) {
+      if (quorumWasEnabled && orderedPeers.length === 0) {
         return false;
       }
-      if (quorumWasEnabled && configuredK <= 0) {
-        // Defensive: misconfigured K. Honour the original behaviour
-        // (return false → caller treats as new document) rather than
-        // silently bypassing the gate against a populated peer list.
-        return false;
-      }
-      // Else: gate disabled OR peers list empty. Either way fall through.
+      // Else: gate disabled. Fall through.
     } else {
       winningHashHex = quorumResult.winningHashHex;
       orderedPeers.length = 0;

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -50,6 +50,7 @@ import {
   documentKeyUpdateV2,
   documentLoadV2,
   snapshotLoadV2,
+  tipAdvertiseV1,
 } from './wire-protocols';
 import { BeeKEM } from './beekem/beekem';
 import { BeeKEMWelcome, PathUpdate } from './beekem/types';
@@ -65,6 +66,14 @@ import {
   deriveDocumentKeyFromRootSecret,
   deriveEpochIdFromRootSecret,
 } from './derive-doc-key';
+import { tipsHash, TIPS_HASH_LENGTH } from './tips-hash';
+import {
+  decideLoadQuorum,
+  effectiveK,
+  effectiveQ,
+  LoadQuorumFailedError,
+  PeerTipAdvertisement,
+} from './load-quorum';
 import { CRDTSnapshotNode } from './snapshot-node';
 import { CompactionConfig, defaultCompactionConfig } from './compaction-config';
 import {
@@ -1815,6 +1824,141 @@ export class CollabswarmDocument<
   }
 
   /**
+   * Handles an initial-load quorum tip-advertise request with pre-read
+   * stream data. Called by the shared protocol handler in Collabswarm
+   * after reading and routing.
+   *
+   * Closes the "no quorum protocol for verifying initial document state"
+   * gap tracked under issue #189 §5.4 item 2 (also bulleted in #186).
+   * The wire protocol is `tipAdvertiseV1` (see `wire-protocols.ts`);
+   * this method returns either an empty payload (decline) or an
+   * encrypted `CRDTSyncMessage` whose only populated payload field is
+   * `tipsHash`. The loader on the other side compares hashes across
+   * multiple peers and requires Q-of-K agreement before accepting any
+   * peer's full document state. See `load-quorum.ts` for the decision
+   * logic.
+   *
+   * Authorization mirrors the doc-load / snapshot-load handlers: when
+   * signing is enabled the requester must sign the document path with
+   * a key that appears in the readers or writers ACL. The response is
+   * encrypted under the document's current key so a peer that does
+   * not already possess the key cannot use the tip hash as an oracle
+   * (key delivery is handled by the BeeKEM Welcome path).
+   *
+   * @internal
+   * @param message The deserialized load request (already parsed by the shared handler).
+   * @param stream The stream object for sending the response.
+   */
+  public async handleTipAdvertiseRequestData(
+    message: CRDTLoadRequest,
+    stream: { sink: (data: Iterable<Uint8Array>) => Promise<void> },
+  ): Promise<void> {
+    try {
+      console.log(
+        `received tip-advertise request for ${this.documentPath}:`,
+        message,
+      );
+
+      if (message.documentId !== this.documentPath) {
+        console.warn(
+          `Received a tip-advertise request for the wrong document (${message.documentId} !== ${this.documentPath})`,
+        );
+        await stream.sink([] as Iterable<Uint8Array>);
+        return;
+      }
+
+      // Authorize the requestor. When signing is disabled, skip ACL/signature
+      // checks entirely -- any peer is treated as authorized. Mirrors the
+      // load handlers above so the gate is symmetrical: a deployment that
+      // disables signing keeps the same trust posture across all protocols.
+      let authorized = false;
+      if (!this._isSigningEnabled()) {
+        authorized = true;
+      } else {
+        if (!message.signature) {
+          console.warn(
+            `Rejected tip-advertise request for ${message.documentId}: missing signature`,
+          );
+          await stream.sink([] as Iterable<Uint8Array>);
+          return;
+        }
+        const readers = (
+          await Promise.all([this._readers.users(), this._writers.users()])
+        ).flat();
+        for (const reader of readers) {
+          if (
+            await this._authProvider.verify(
+              this._encoder.encode(message.documentId),
+              reader,
+              this._deserializeSignature(message.signature),
+            )
+          ) {
+            authorized = true;
+            break;
+          }
+        }
+      }
+
+      if (!authorized) {
+        console.warn(
+          `Detected an unauthorized tip-advertise request for ${message.documentId}`,
+        );
+        await stream.sink([] as Iterable<Uint8Array>);
+        return;
+      }
+
+      // Compute the canonical tip-set hash from the document's current
+      // `_hashes` set. Two peers with the same view produce byte-identical
+      // hashes; see `tips-hash.ts` for the canonicalization (sort + `\n`
+      // separator + SHA-256).
+      const hash = await tipsHash(this._hashes);
+
+      const advertisement: CRDTSyncMessage<ChangesType, PublicKey> = {
+        documentId: this.documentPath,
+        tipsHash: hash,
+      };
+
+      // Sign the advertisement so the loader can verify the responder is
+      // an authorized writer (the same trust bar applied to load responses
+      // above). `_signAsWriter` returns '' when signing is disabled, in
+      // which case the loader's pre-load verification block is also a
+      // no-op -- mirrors the doc-load / snapshot-load handlers' pattern.
+      advertisement.signature = await this._signAsWriter(advertisement);
+
+      const serialized =
+        this._syncMessageSerializer.serializeSyncMessage(advertisement);
+
+      // Encrypt the response with the document's current key so that an
+      // unauthorized peer that managed to connect to us but does not have
+      // the key cannot read (or use as an oracle) the tip hash.
+      const [documentKeyID, documentKey] = await this._keychain.current();
+      if (!documentKey) {
+        throw new Error(`Document ${this.documentPath} has an empty keychain!`);
+      }
+      const { nonce, data } = await this._authProvider.encrypt(
+        serialized,
+        documentKey,
+      );
+      if (!nonce) {
+        throw new Error(`Failed to encrypt tip-advertise response! Nonce cannot be empty`);
+      }
+      const assembled = concatUint8Arrays(documentKeyID, nonce, data);
+      console.log(
+        `sending tip-advertise response (encrypted) for ${this.documentPath}`,
+      );
+
+      await stream.sink([assembled] as Iterable<Uint8Array>);
+    } catch (err: unknown) {
+      console.error(
+        `Error handling tip-advertise request for ${this.documentPath}:`,
+        err,
+      );
+      // Ensure the stream is closed so the requester doesn't hang.
+      try { await stream.sink([] as Iterable<Uint8Array>); } catch { /* already closed */ }
+    }
+  }
+
+  /**
    * Build the deterministic binary payload used for snapshot signing/verification.
    *
    * Binary layout (big-endian integers):
@@ -2023,6 +2167,153 @@ export class CollabswarmDocument<
     );
   }
 
+  /**
+   * Send a single `tipAdvertiseV1` probe to one peer and decrypt the
+   * response to extract the peer's `tipsHash`. Returns `null` for any
+   * non-vote outcome: empty/declined response, decryption failure with an
+   * unknown key (peer has a different keychain), missing/invalid signature,
+   * deserialization failure, document-id mismatch, missing/short tip hash,
+   * or thrown errors. Timeouts are handled at the caller level via
+   * Promise.race.
+   *
+   * Returns `null` rather than throwing so the caller can record this
+   * peer as a non-vote (NOT a disagreement) and `decideLoadQuorum` can
+   * apply the correct quorum semantics. See `load-quorum.ts` for the
+   * timeout-vs-disagreement distinction.
+   *
+   * @internal
+   */
+  private async _probeTipAdvertise(
+    peer: import('@multiformats/multiaddr').Multiaddr,
+    serializedRequest: Uint8Array,
+  ): Promise<Uint8Array | null> {
+    let stream: { sink: (data: Iterable<Uint8Array>) => Promise<void>; source: AsyncIterable<Uint8ArrayList | Uint8Array> };
+    try {
+      stream = wrapStream(await this.libp2p.dialProtocol(peer, [tipAdvertiseV1]));
+    } catch {
+      // Peer doesn't support tip-advertise or dial failed -- treat as non-vote.
+      return null;
+    }
+    try {
+      await pipe([serializedRequest], stream.sink);
+      const assembled = await readUint8Iterable(stream.source);
+      if (assembled.length === 0) {
+        // Peer declined (unknown doc, unauthorized, etc.).
+        return null;
+      }
+      const headerLength = this._keychainProvider.keyIDLength + this._authProvider.nonceBits;
+      if (assembled.length <= headerLength) {
+        // Too short to be a valid encrypted payload.
+        return null;
+      }
+      const blockKeyID = assembled.slice(0, this._keychainProvider.keyIDLength);
+      const key = this._keychain.getKey(blockKeyID);
+      if (!key) {
+        // Responder used a key we don't have. Treat as non-vote rather than
+        // an attack: a freshly-onboarded reader may legitimately not have
+        // every historical key yet. The decryption-side check on the full
+        // load that follows will still gate trust on the actual state.
+        return null;
+      }
+      const blockNonce = assembled.slice(this._keychainProvider.keyIDLength, headerLength);
+      const blockData = assembled.slice(headerLength);
+      const decrypted = await this._authProvider.decrypt(blockData, key, blockNonce);
+      if (!decrypted) {
+        return null;
+      }
+      let message: CRDTSyncMessage<ChangesType, PublicKey>;
+      try {
+        message = this._syncMessageSerializer.deserializeSyncMessage(decrypted);
+      } catch {
+        return null;
+      }
+      if (message.documentId !== this.documentPath) {
+        return null;
+      }
+      // Verify the writer signature on the advertisement when possible.
+      // On first load (_writers empty) we cannot verify -- trust falls
+      // back to the encryption envelope (only a peer that already holds
+      // the current key could produce this response) plus the quorum
+      // requirement that multiple such peers agree. This matches the
+      // bootstrapping behaviour of `_sendLoadRequestAndSync`.
+      if (this._isSigningEnabled()) {
+        const preLoadWriters = await this._getWriterKeys();
+        if (preLoadWriters.length > 0) {
+          if (!message.signature) {
+            return null;
+          }
+          const { signature, ...messageWithoutSignature } = message;
+          const raw = this._syncMessageSerializer.serializeSyncMessage(
+            messageWithoutSignature,
+          );
+          let signatureBytes: Uint8Array;
+          try {
+            signatureBytes = this._deserializeSignature(signature);
+          } catch {
+            return null;
+          }
+          const verifyTasks = preLoadWriters.map((writerKey) =>
+            this._authProvider.verify(raw, writerKey, signatureBytes),
+          );
+          if (!(await firstTrue(verifyTasks))) {
+            return null;
+          }
+        }
+      }
+      if (!(message.tipsHash instanceof Uint8Array) || message.tipsHash.length !== TIPS_HASH_LENGTH) {
+        return null;
+      }
+      return message.tipsHash;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Run a single tip-advertise probe with a hard timeout. The probe itself
+   * never throws (`_probeTipAdvertise` returns `null` on any failure
+   * mode); a timeout also resolves to `null` so the caller can treat the
+   * peer as a non-vote rather than a disagreement. The pending probe
+   * keeps running on the background event loop after timeout, but its
+   * resolution is discarded by Promise.race.
+   *
+   * @internal
+   */
+  private async _raceTipAdvertiseProbe(
+    peer: import('@multiformats/multiaddr').Multiaddr,
+    serializedRequest: Uint8Array,
+    timeoutMs: number,
+  ): Promise<Uint8Array | null> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<null>((resolve) => {
+      timer = setTimeout(() => resolve(null), timeoutMs);
+    });
+    try {
+      return await Promise.race([
+        this._probeTipAdvertise(peer, serializedRequest),
+        timeout,
+      ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Extract the remote peer-id portion of a Multiaddr in a form suitable
+   * for keying the quorum decision map. For relay-circuit multiaddrs (e.g.
+   * `.../p2p/<relay>/p2p-circuit/p2p/<remote>`), the remote peer-id is the
+   * LAST `/p2p/<id>` segment. Falls back to the full multiaddr string when
+   * no `/p2p/<id>` segment is present so two responses from the same peer
+   * always collide on the same map key.
+   *
+   * @internal
+   */
+  private _peerIdOf(peer: import('@multiformats/multiaddr').Multiaddr): string {
+    const str = peer.toString();
+    const matches = [...str.matchAll(/\/p2p\/([^/]+)/g)];
+    return matches.length > 0 ? matches[matches.length - 1][1] : str;
+  }
+
   // API Methods --------------------------------------------------------------
 
   // https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#duplex-it
@@ -2037,12 +2328,37 @@ export class CollabswarmDocument<
    *   substring from each peer's `Multiaddr.toString()` (the canonical string
    *   form), since `@multiformats/multiaddr` v13 dropped the `getPeerId()`
    *   helper and `getComponents()` may surface the `/p2p` value as bytes.
+   * **Initial-load quorum gate.** When
+   * `CollabswarmConfig.loadQuorumEnabled` is `true` (the default), `load()`
+   * first queries up to `loadQuorumK` peers in parallel via the
+   * `tipAdvertiseV1` protocol for a lightweight tip-set hash. The full
+   * document-load only proceeds against a peer that participated in a
+   * majority (`loadQuorumQ`-of-K) agreement on the tip set, defending
+   * against a single malicious or partitioned peer unilaterally serving a
+   * stale or maliciously-crafted initial state. If quorum is not met,
+   * `load()` rejects with a `LoadQuorumFailedError` (see
+   * `load-quorum.ts`). The gate can be disabled wholesale via
+   * `loadQuorumEnabled: false` for single-peer dev/test scenarios; the
+   * single-peer edge case is covered by `loadQuorumAllowSinglePeer`. Tip-
+   * advertise responses with an unknown encryption key, missing/invalid
+   * writer signature, document-id mismatch, or short/missing tip hash are
+   * recorded as non-votes (NOT disagreements) so a stale peer cache does
+   * not flip a partition into a Byzantine-failure verdict. Closes the gap
+   * tracked under issue #189 §5.4 item 2 (and bulleted in #186).
+   *
    * @returns `true` if the document was successfully loaded from a peer.
    *   `false` if no peer could provide the document -- this is ambiguous: it
    *   may mean the document is brand new (no peers have it) OR that all peers
    *   failed to respond, failed to decrypt, or failed signature verification.
    *   Note: `open()` treats `false` as "new document" and initializes a fresh
    *   document with the current user as writer and a new encryption key.
+   * @throws {LoadQuorumFailedError} When the initial-load quorum gate is
+   *   enabled and fewer than `loadQuorumQ` peers agreed on the same tip
+   *   hash within the configured timeout. Callers can `instanceof`-check
+   *   this error to distinguish quorum failure from other I/O errors
+   *   raised inside `load()`. The original single-peer
+   *   "return false on no peers" behaviour is preserved when the quorum
+   *   gate is disabled (`loadQuorumEnabled: false`).
    */
   // Key exchange happens during:
   // - Load messages.
@@ -2103,6 +2419,132 @@ export class CollabswarmDocument<
       signature,
     };
     const serializedRequest = this._loadMessageSerializer.serializeLoadRequest(loadRequest);
+
+    // Initial-load quorum gate (#189 §5.4.2 / #186).
+    //
+    // Run BEFORE the existing single-peer snapshot/doc-load loop so that a
+    // failed quorum aborts the load entirely (the caller cannot accidentally
+    // accept a single peer's response). When the gate is disabled, or the
+    // edge cases below apply (founding-member empty `_hashes`, single peer
+    // with `loadQuorumAllowSinglePeer: true`), we fall through to the
+    // legacy loop unchanged so existing callers see the same behaviour.
+    const quorumEnabled = this.swarm.config?.loadQuorumEnabled ?? true;
+    if (quorumEnabled) {
+      const configuredK = this.swarm.config?.loadQuorumK ?? 3;
+      const configuredQDefault = Math.ceil(configuredK / 2) + 1;
+      const configuredQ = this.swarm.config?.loadQuorumQ ?? configuredQDefault;
+      const timeoutMs = this.swarm.config?.loadQuorumTimeoutMs ?? 5000;
+      const allowSinglePeer =
+        this.swarm.config?.loadQuorumAllowSinglePeer ?? false;
+
+      const k = effectiveK(configuredK, orderedPeers.length);
+      const q = effectiveQ(configuredQ, k);
+
+      // Edge case: founding-member / brand-new document. If our local
+      // `_hashes` is empty, we have nothing to compare against -- there is
+      // no risk of a peer poisoning state we don't yet hold. Skip the
+      // gate in this case (it would otherwise wedge fresh
+      // `open()` calls on solo dev peers). Note `_hashes` is only ever
+      // non-empty after we have applied changes locally (e.g. previously
+      // loaded successfully), so this safely catches the bootstrap case.
+      const isFoundingCase = this._hashes.size === 0;
+
+      if (k === 0) {
+        // No peers known. Existing behaviour: treat as "new document"
+        // and return false. The open() path will run validateDocumentPath
+        // and create the document from scratch. This is also the founding-
+        // member case, so the quorum gate has nothing to defend.
+        return false;
+      } else if (k === 1 && !allowSinglePeer && !isFoundingCase) {
+        throw new LoadQuorumFailedError({
+          documentPath: this.documentPath,
+          reason: 'insufficient-responses',
+          respondingCount: 0,
+          requiredQ: q,
+          agreement: new Map(),
+        });
+      } else if (k === 1 && allowSinglePeer && !isFoundingCase) {
+        // Single-peer pass-through. Probe the one known peer; if it
+        // responds at all we proceed with the legacy load. Warn loudly
+        // so operators can spot the regression. Q is forced to 1 here.
+        console.warn(
+          `[${this.documentPath}] Initial-load quorum: only one peer known; ` +
+            `proceeding under loadQuorumAllowSinglePeer (trust assumptions ` +
+            `degraded back to single-peer load). Configure additional peers ` +
+            `to restore Byzantine-fault-tolerant quorum semantics.`,
+        );
+        const probe = await this._raceTipAdvertiseProbe(
+          orderedPeers[0],
+          serializedRequest,
+          timeoutMs,
+        );
+        if (probe === null) {
+          throw new LoadQuorumFailedError({
+            documentPath: this.documentPath,
+            reason: 'insufficient-responses',
+            respondingCount: 0,
+            requiredQ: 1,
+            agreement: new Map(),
+          });
+        }
+        // Proceed with `orderedPeers` unchanged (preferred-peer order
+        // preserved). Fall through to the legacy snapshot/doc-load loop.
+      } else if (!isFoundingCase) {
+        // Standard K-of-Q quorum path. Take the first K peers from the
+        // already-ordered list (preferredPeer is at index 0, so it is
+        // always queried), probe in parallel, and decide.
+        const probedPeers = orderedPeers.slice(0, k);
+        const advertisements: PeerTipAdvertisement[] = await Promise.all(
+          probedPeers.map(async (peer) => {
+            const hash = await this._raceTipAdvertiseProbe(
+              peer,
+              serializedRequest,
+              timeoutMs,
+            );
+            return { peerId: this._peerIdOf(peer), hash };
+          }),
+        );
+        const decision = decideLoadQuorum(advertisements, q);
+        if (!decision.ok) {
+          console.warn(
+            `[${this.documentPath}] Initial-load quorum FAILED: ` +
+              `${decision.reason} (${decision.respondingCount} responses, ` +
+              `required ${decision.effectiveQ}). Aborting load.`,
+          );
+          throw new LoadQuorumFailedError({
+            documentPath: this.documentPath,
+            reason: decision.reason,
+            respondingCount: decision.respondingCount,
+            requiredQ: decision.effectiveQ,
+            agreement: decision.agreement,
+          });
+        }
+        console.log(
+          `[${this.documentPath}] Initial-load quorum passed: ` +
+            `${decision.agreeingPeerIds.length}/${decision.respondingCount} ` +
+            `peers agreed on tipsHash=${decision.winningHashHex.slice(0, 12)}...`,
+        );
+        // Narrow `orderedPeers` to only the agreeing cohort. The legacy
+        // snapshot/doc-load loop below then asks one of these peers for
+        // the full state; with quorum agreement, any single agreeing
+        // peer's load is defended by Q-1 other peers attesting to the
+        // same tip set. Order is preserved (preferredPeer first if it
+        // was among the agreeing cohort).
+        const agreeingSet = new Set(decision.agreeingPeerIds);
+        const narrowed = orderedPeers.filter((p) =>
+          agreeingSet.has(this._peerIdOf(p)),
+        );
+        // Defensive: at least one agreeing peer must remain. If
+        // peer-id extraction loses a peer (should never happen given
+        // we built the same set above), fall back to the full list so
+        // we don't accidentally degrade to "no peers to load from".
+        if (narrowed.length > 0) {
+          orderedPeers.length = 0;
+          orderedPeers.push(...narrowed);
+        }
+      }
+      // else: founding case -- fall through with `orderedPeers` unchanged.
+    }
 
     // Try snapshot-load first for faster initial sync.
     // If the peer returns an empty response (no snapshot available),

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -66,9 +66,12 @@ import {
   deriveDocumentKeyFromRootSecret,
   deriveEpochIdFromRootSecret,
 } from './derive-doc-key';
-import { tipsHash, TIPS_HASH_LENGTH } from './tips-hash';
+import { tipsHash, tipsHashToHex, TIPS_HASH_LENGTH } from './tips-hash';
 import {
+  constantTimeHexEquals,
   decideLoadQuorum,
+  dedupePeersByPeerId,
+  defaultQuorumQ,
   effectiveK,
   effectiveQ,
   LoadQuorumFailedError,
@@ -2314,6 +2317,58 @@ export class CollabswarmDocument<
     return matches.length > 0 ? matches[matches.length - 1][1] : str;
   }
 
+  /**
+   * Verify that the just-applied load response matches the tip-set hash the
+   * quorum agreed on. Called after `_sendLoadRequestAndSync` returns `true`
+   * and `_hashes` has been populated with the served state's CIDs. The
+   * recomputed `tipsHash(this._hashes)` MUST equal `expectedHex` (the
+   * quorum's `winningHashHex`), otherwise a peer in the agreeing cohort
+   * voted for one tip set and served a different one (Byzantine
+   * equivocation: cheap to do because the tip-advertise probe and the
+   * full-state load happen on separate streams). On mismatch we throw
+   * `LoadQuorumFailedError`; the in-memory document is already partially
+   * mutated at that point, so the caller MUST treat the document instance
+   * as poisoned and construct a fresh one (this is acceptable because the
+   * gate runs during `open()`, before the document is exposed to
+   * application code or subscribed to pubsub).
+   *
+   * Constant-time comparison: the two hex strings are always 64 chars
+   * (SHA-256 lowercase hex). An early-exit `===` would leak which prefix
+   * matched; a brute-force timing attacker can amplify that into "I know
+   * which agreeing peer you'd accept", which while not catastrophic is
+   * also free to avoid.
+   *
+   * When `expectedHex` is `null` (quorum disabled), this is a no-op.
+   *
+   * @internal
+   */
+  private async _enforceQuorumHashBinding(
+    expectedHex: string | null,
+  ): Promise<void> {
+    if (expectedHex === null) return;
+    const actualBytes = await tipsHash(this._hashes);
+    const actualHex = tipsHashToHex(actualBytes);
+    if (!constantTimeHexEquals(expectedHex, actualHex)) {
+      console.warn(
+        `[${this.documentPath}] Initial-load quorum hash binding FAILED: ` +
+          `expected tipsHash=${expectedHex.slice(0, 12)}... but loaded ` +
+          `state hashed to ${actualHex.slice(0, 12)}.... An agreeing peer ` +
+          `served a state that does not match its tip-advertise vote; ` +
+          `treating as Byzantine equivocation.`,
+      );
+      throw new LoadQuorumFailedError({
+        documentPath: this.documentPath,
+        reason: 'no-majority',
+        respondingCount: 0,
+        requiredQ: 0,
+        agreement: new Map([
+          [expectedHex, 0],
+          [actualHex, 0],
+        ]),
+      });
+    }
+  }
+
   // API Methods --------------------------------------------------------------
 
   // https://gist.github.com/alanshaw/591dc7dd54e4f99338a347ef568d6ee9#duplex-it
@@ -2335,7 +2390,10 @@ export class CollabswarmDocument<
    * document-load only proceeds against a peer that participated in a
    * majority (`loadQuorumQ`-of-K) agreement on the tip set, defending
    * against a single malicious or partitioned peer unilaterally serving a
-   * stale or maliciously-crafted initial state. If quorum is not met,
+   * stale or maliciously-crafted initial state. The gate runs uniformly
+   * regardless of local `_hashes` state (an empty local `_hashes` is the
+   * exact state the gate must defend on first `open()` of an existing
+   * document — bypassing it then would be unsafe). If quorum is not met,
    * `load()` rejects with a `LoadQuorumFailedError` (see
    * `load-quorum.ts`). The gate can be disabled wholesale via
    * `loadQuorumEnabled: false` for single-peer dev/test scenarios; the
@@ -2343,8 +2401,14 @@ export class CollabswarmDocument<
    * advertise responses with an unknown encryption key, missing/invalid
    * writer signature, document-id mismatch, or short/missing tip hash are
    * recorded as non-votes (NOT disagreements) so a stale peer cache does
-   * not flip a partition into a Byzantine-failure verdict. Closes the gap
-   * tracked under issue #189 §5.4 item 2 (and bulleted in #186).
+   * not flip a partition into a Byzantine-failure verdict. Peers are
+   * deduped by libp2p PeerId before the probe so a single peer with
+   * multiple open connections cannot cast multiple votes. After quorum
+   * passes, the served full state is bound to the agreed hash: the
+   * recomputed `tipsHash(this._hashes)` post-sync must equal the quorum
+   * `winningHashHex`, otherwise an agreeing peer equivocated between its
+   * advertise vote and its served state and the load is rejected. Closes
+   * the gap tracked under issue #189 §5.4 item 2 (and bulleted in #186).
    *
    * @returns `true` if the document was successfully loaded from a peer.
    *   `false` if no peer could provide the document -- this is ambiguous: it
@@ -2420,19 +2484,47 @@ export class CollabswarmDocument<
     };
     const serializedRequest = this._loadMessageSerializer.serializeLoadRequest(loadRequest);
 
+    // Dedupe `orderedPeers` by peer id BEFORE the quorum probe. `getConnections()`
+    // returns one entry per OPEN connection, and libp2p maintains separate
+    // connections per multiaddr / per transport — so a single remote peer with
+    // two open connections (e.g. direct + relay-circuit) shows up twice. Without
+    // this dedup, that peer would cast two votes in the quorum tally, allowing a
+    // single malicious peer with multiple connections to dominate the agreement
+    // count. Dedup by `_peerIdOf` (which extracts the LAST `/p2p/<id>` segment,
+    // i.e. the remote peer's libp2p PeerId for both direct and circuit-relay
+    // multiaddrs). Preserves first-seen order so the preferredPeer (placed at
+    // index 0 above) remains first.
+    {
+      const deduped = dedupePeersByPeerId(orderedPeers, (p) => this._peerIdOf(p));
+      orderedPeers.length = 0;
+      orderedPeers.push(...deduped);
+    }
+
     // Initial-load quorum gate (#189 §5.4.2 / #186).
     //
     // Run BEFORE the existing single-peer snapshot/doc-load loop so that a
     // failed quorum aborts the load entirely (the caller cannot accidentally
-    // accept a single peer's response). When the gate is disabled, or the
-    // edge cases below apply (founding-member empty `_hashes`, single peer
-    // with `loadQuorumAllowSinglePeer: true`), we fall through to the
-    // legacy loop unchanged so existing callers see the same behaviour.
+    // accept a single peer's response). When the gate is disabled we fall
+    // through to the legacy loop unchanged so existing callers see the same
+    // behaviour.
+    //
+    // `winningHashHex` (set when quorum passes) is also used below as the
+    // post-load binding check: after `_sendLoadRequestAndSync` applies the
+    // served state, the recomputed `tipsHash(this._hashes)` MUST equal
+    // `winningHashHex`, otherwise an agreeing peer voted for one tip set and
+    // served a different one (Byzantine equivocation).
     const quorumEnabled = this.swarm.config?.loadQuorumEnabled ?? true;
+    let winningHashHex: string | null = null;
     if (quorumEnabled) {
       const configuredK = this.swarm.config?.loadQuorumK ?? 3;
-      const configuredQDefault = Math.ceil(configuredK / 2) + 1;
-      const configuredQ = this.swarm.config?.loadQuorumQ ?? configuredQDefault;
+      // Strict-majority threshold: `Math.floor(K/2) + 1`. For K=3 this gives
+      // Q=2 (tolerating one fault), matching the BFT design note in #189
+      // §5.4.2. `Math.ceil(K/2) + 1` would yield Q=3 at K=3 (everyone must
+      // agree), defeating the fault-tolerance intent of the gate. The
+      // formula lives in `defaultQuorumQ` so the loader, the config
+      // docstring, and the test matrix all reference one source of truth.
+      const configuredQ =
+        this.swarm.config?.loadQuorumQ ?? defaultQuorumQ(configuredK);
       const timeoutMs = this.swarm.config?.loadQuorumTimeoutMs ?? 5000;
       const allowSinglePeer =
         this.swarm.config?.loadQuorumAllowSinglePeer ?? false;
@@ -2440,22 +2532,29 @@ export class CollabswarmDocument<
       const k = effectiveK(configuredK, orderedPeers.length);
       const q = effectiveQ(configuredQ, k);
 
-      // Edge case: founding-member / brand-new document. If our local
-      // `_hashes` is empty, we have nothing to compare against -- there is
-      // no risk of a peer poisoning state we don't yet hold. Skip the
-      // gate in this case (it would otherwise wedge fresh
-      // `open()` calls on solo dev peers). Note `_hashes` is only ever
-      // non-empty after we have applied changes locally (e.g. previously
-      // loaded successfully), so this safely catches the bootstrap case.
-      const isFoundingCase = this._hashes.size === 0;
+      // NOTE: previously this block bypassed the gate when `_hashes.size === 0`
+      // on the assumption it identified a "founding-member" brand-new document.
+      // That bypass was unsafe: `_hashes` is ALSO empty on the first `open()`
+      // of an EXISTING document (before load populates it), which is exactly
+      // the case the gate is meant to protect. We no longer special-case empty
+      // local state; the gate runs uniformly. True founders (no peers in the
+      // mesh) are handled by the `peers.length === 0` short-circuit at the top
+      // of `load()` plus the `k === 0` branch below (which falls through to
+      // return false → caller treats as new document).
 
       if (k === 0) {
-        // No peers known. Existing behaviour: treat as "new document"
-        // and return false. The open() path will run validateDocumentPath
-        // and create the document from scratch. This is also the founding-
-        // member case, so the quorum gate has nothing to defend.
+        // No peers known. Treat as "new document" — `open()` will run
+        // validateDocumentPath and create the document from scratch. This is
+        // the legitimate founder path: no remote peer exists to serve a
+        // mismatched view, so there is nothing for the quorum gate to defend.
         return false;
-      } else if (k === 1 && !allowSinglePeer && !isFoundingCase) {
+      } else if (k === 1 && !allowSinglePeer) {
+        // Only one peer reachable but quorum requires Q>=2 by default.
+        // Without a second opinion we cannot distinguish "honest solo peer"
+        // from "malicious peer serving a forged state". Refuse. Callers in
+        // genuine single-peer scenarios (tests, small private swarms,
+        // founding member with one known seed) must opt in explicitly via
+        // `loadQuorumAllowSinglePeer: true` or `loadQuorumEnabled: false`.
         throw new LoadQuorumFailedError({
           documentPath: this.documentPath,
           reason: 'insufficient-responses',
@@ -2463,7 +2562,7 @@ export class CollabswarmDocument<
           requiredQ: q,
           agreement: new Map(),
         });
-      } else if (k === 1 && allowSinglePeer && !isFoundingCase) {
+      } else if (k === 1 && allowSinglePeer) {
         // Single-peer pass-through. Probe the one known peer; if it
         // responds at all we proceed with the legacy load. Warn loudly
         // so operators can spot the regression. Q is forced to 1 here.
@@ -2487,9 +2586,14 @@ export class CollabswarmDocument<
             agreement: new Map(),
           });
         }
+        // Bind the single peer's advertised hash so the post-load check
+        // below still verifies that the served state matches what was
+        // advertised (defends against a malicious peer that decides what
+        // to serve only after seeing the advertise round-trip).
+        winningHashHex = tipsHashToHex(probe);
         // Proceed with `orderedPeers` unchanged (preferred-peer order
         // preserved). Fall through to the legacy snapshot/doc-load loop.
-      } else if (!isFoundingCase) {
+      } else {
         // Standard K-of-Q quorum path. Take the first K peers from the
         // already-ordered list (preferredPeer is at index 0, so it is
         // always queried), probe in parallel, and decide.
@@ -2524,6 +2628,7 @@ export class CollabswarmDocument<
             `${decision.agreeingPeerIds.length}/${decision.respondingCount} ` +
             `peers agreed on tipsHash=${decision.winningHashHex.slice(0, 12)}...`,
         );
+        winningHashHex = decision.winningHashHex;
         // Narrow `orderedPeers` to only the agreeing cohort. The legacy
         // snapshot/doc-load loop below then asks one of these peers for
         // the full state; with quorum agreement, any single agreeing
@@ -2543,12 +2648,21 @@ export class CollabswarmDocument<
           orderedPeers.push(...narrowed);
         }
       }
-      // else: founding case -- fall through with `orderedPeers` unchanged.
     }
 
     // Try snapshot-load first for faster initial sync.
     // If the peer returns an empty response (no snapshot available),
     // fall back to the regular doc-load protocol.
+    //
+    // After a successful load we verify `tipsHash(this._hashes)` equals the
+    // quorum-agreed `winningHashHex` (when quorum is enabled). This binds the
+    // served full state to what the peer advertised during the probe round.
+    // Without this binding, a peer in the agreeing cohort could vote for
+    // hash X and then serve a different state, defeating the gate's whole
+    // purpose. On mismatch the load is rejected and `LoadQuorumFailedError`
+    // is thrown; the in-memory document state is poisoned at that point so
+    // we cannot transparently retry the next peer — the caller must
+    // construct a fresh document instance.
     for (const peer of orderedPeers) {
       try {
         console.log('Trying snapshot-load from peer:', peer.toString());
@@ -2560,9 +2674,13 @@ export class CollabswarmDocument<
           snapshotLoadV2,
         ]));
         const loaded = await this._sendLoadRequestAndSync(snapshotStream, serializedRequest);
-        if (loaded) return true;
+        if (loaded) {
+          await this._enforceQuorumHashBinding(winningHashHex);
+          return true;
+        }
         // Empty response -- peer has no snapshot, try doc-load below.
-      } catch {
+      } catch (err) {
+        if (err instanceof LoadQuorumFailedError) throw err;
         // Peer doesn't support snapshot-load protocol.
       }
 
@@ -2573,8 +2691,12 @@ export class CollabswarmDocument<
           documentLoadV2,
         ]));
         const loaded = await this._sendLoadRequestAndSync(docStream, serializedRequest);
-        if (loaded) return true;
+        if (loaded) {
+          await this._enforceQuorumHashBinding(winningHashHex);
+          return true;
+        }
       } catch (err) {
+        if (err instanceof LoadQuorumFailedError) throw err;
         console.warn(
           `Failed to load document via ${documentLoadV2}:`,
           peer.toString(),

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -2870,11 +2870,15 @@ export class CollabswarmDocument<
                 try {
                   const cid = CID.parse(cidStr);
                   // Force the blockstore to retrieve the block. Helia
-                  // validates content vs CID on `get`; reading the
+                  // validates content vs CID on `get`; draining the
                   // returned async-iterable triggers the actual fetch.
-                  await readUint8Iterable(
-                    this.swarm.heliaNode.blockstore.get(cid),
-                  );
+                  // Discard the chunks (no concat) — we only need
+                  // content-validation here, not the bytes.
+                  for await (const _chunk of this.swarm.heliaNode.blockstore.get(
+                    cid,
+                  )) {
+                    void _chunk;
+                  }
                 } catch {
                   missingCids.push(cidStr);
                 }

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -27,6 +27,7 @@ import {
 } from './crdt-change-node';
 import {
   collectReferencedAncestors,
+  computeServedFrontier,
   MAX_CROSS_LINKS,
   MAX_RECENT_TIPS,
   mergeRemoteSyncTree,
@@ -1851,18 +1852,30 @@ export class CollabswarmDocument<
         loadMessage.snapshot = this._latestSnapshot;
       }
 
-      // Attach an explicit tip-set advertisement so the loader can bind the
-      // served state to this responder's current frontier (issue #186 /
-      // #189 §5.4.2). The loader recomputes `tipsHash(tips)` and compares
-      // against the quorum-agreed `winningHashHex`; `_currentFrontier()`
-      // is the canonical helper used by ALL three protocols (tip-advertise,
-      // doc-load, snapshot-load) so a peer that voted for hash X but
-      // serves a load whose `tips` hash to Y is caught. The frontier is
-      // `_hashes \ _referencedAncestors` -- the heads of the local DAG --
-      // which converges across honest peers even when their full `_hashes`
-      // cardinality differs (e.g. one loaded from a snapshot, the other
-      // has the full ancestor history). This is part of the SIGNED v3
-      // payload; see `wire-protocols.ts` for the version-bump rationale.
+      // Attach an explicit tip-set advertisement so the loader can apply
+      // a defense-in-depth consistency check against this responder's
+      // self-attested current frontier (issue #186 / #189 §5.4.2).
+      //
+      // NOTE: as of PR #284 r7, the loader's PRIMARY binding is derived
+      // STRUCTURALLY from the served `changes`/`snapshot` payload via
+      // `computeServedFrontier`; the responder's `tips` array is NOT
+      // trusted as the source of truth (a Byzantine peer can populate
+      // it with the agreed CIDs while serving a divergent payload).
+      // `tips` is still emitted by honest responders because the loader
+      // ALSO verifies that the responder's own attestation hashes to
+      // the same value as the structurally-derived served frontier --
+      // a peer whose `tips` contradicts their own served payload is
+      // caught at the secondary check. `_currentFrontier()` remains
+      // the canonical helper used by ALL three protocols
+      // (tip-advertise, doc-load, snapshot-load) so an honest
+      // responder advertises the same frontier across the probe and
+      // the load round. The frontier is `_hashes \
+      // _referencedAncestors` -- the heads of the local DAG -- which
+      // converges across honest peers even when their full `_hashes`
+      // cardinality differs (e.g. one loaded from a snapshot, the
+      // other has the full ancestor history). This field is part of
+      // the SIGNED v3 payload; see `wire-protocols.ts` for the
+      // version-bump rationale.
       loadMessage.tips = this._currentFrontier();
 
       // Sign new message.
@@ -2361,21 +2374,41 @@ export class CollabswarmDocument<
         }
 
         // Quorum frontier binding (#186 / #189 §5.4.2). When the loader
-        // ran a quorum probe round, the responder must have included its
-        // current frontier in `message.tips`; we hash that and require it
-        // to match the quorum-agreed `winningHashHex`. Done BEFORE
-        // `this.sync(...)` so a Byzantine peer that voted hash X but
-        // serves a load with a different frontier never gets to mutate
-        // the in-memory document. Recomputing the hash from
-        // `tipsHash(this._hashes)` post-sync (the prior behaviour) is
-        // unreliable because snapshot-loads don't restore ancestor CIDs
-        // and the loader's pre-existing local CIDs (if any) inflate the
-        // recomputed set.
+        // ran a quorum probe round, the served full-load payload must
+        // structurally describe the same tip set the responder voted
+        // for. Done BEFORE `this.sync(...)` so a Byzantine peer that
+        // voted hash X but serves a load with a different frontier
+        // never gets to mutate the in-memory document.
+        //
+        // CRITICAL: the bind decision is derived from the ACTUAL served
+        // payload, NOT from the responder-supplied `message.tips`.
+        // Trusting `message.tips` -- as previous rounds did -- was a
+        // hole: a Byzantine peer could vote hash X, put the matching
+        // tip CIDs in `message.tips`, and then serve a `changes` /
+        // `snapshot` payload describing a completely different state.
+        // The advertised-vs-claimed check would pass even though the
+        // application would receive divergent content. PR #284 r7
+        // Copilot review caught this; the fix delegates frontier
+        // computation to the pure helper `computeServedFrontier`, which
+        // walks the served `changes` tree (plus the snapshot boundary
+        // CID) and returns the set of payload CIDs that no other node
+        // in the same payload references as a parent -- i.e. the heads
+        // of what was actually served. We then hash that frontier and
+        // compare to `winningHashHex`.
+        //
+        // We additionally verify `message.tips`, when present,
+        // matches the structurally-derived served frontier as a
+        // defense-in-depth check: a peer whose `tips` attestation
+        // contradicts their own served payload is misbehaving even if
+        // the served-frontier hash happens to match the quorum vote
+        // (e.g. if they tried to claim extra heads in `tips`). This
+        // catches the responder-equivocation mode where `tips` and
+        // `changes` were assembled inconsistently.
         //
         // Throws the module-private `_QuorumBindCheckFailedError` on
-        // mismatch / missing-tips so the surrounding `load()` loop can
-        // record this peer as a bind-failure and proceed to the NEXT
-        // peer in the agreeing cohort. Previously this site threw
+        // mismatch so the surrounding `load()` loop can record this
+        // peer as a bind-failure and proceed to the NEXT peer in the
+        // agreeing cohort. Previously this site threw
         // `LoadQuorumFailedError` directly, which `load()` re-raised --
         // letting a single malicious peer in the agreeing cohort vote
         // for the majority hash, serve a mismatched full load, and
@@ -2385,32 +2418,52 @@ export class CollabswarmDocument<
         // `LoadQuorumFailedError(bind-check-failed-all-agreeing-peers)`
         // when EVERY narrowed peer fails the bind step.
         if (expectedTipsHashHex !== null) {
-          if (!Array.isArray(message.tips)) {
-            console.warn(
-              `[${this.documentPath}] Quorum frontier binding: responder ` +
-                `omitted 'tips' on load response; refusing to apply state ` +
-                `from an un-attesting peer.`,
-            );
-            throw new _QuorumBindCheckFailedError(
-              '(missing tips)',
-              `Quorum frontier binding: responder omitted 'tips' on load response.`,
-            );
-          }
-          const advertisedBytes = await tipsHash(message.tips);
-          const advertisedHex = tipsHashToHex(advertisedBytes);
-          if (!constantTimeHexEquals(expectedTipsHashHex, advertisedHex)) {
+          // Derive the served frontier STRUCTURALLY from the payload
+          // the responder is asking us to apply -- not from the
+          // responder's own `tips` attestation.
+          const servedFrontier = computeServedFrontier(
+            message.changeId,
+            message.changes,
+            message.snapshot?.lastChangeNodeCID,
+          );
+          const servedBytes = await tipsHash(servedFrontier);
+          const servedHex = tipsHashToHex(servedBytes);
+          if (!constantTimeHexEquals(expectedTipsHashHex, servedHex)) {
             console.warn(
               `[${this.documentPath}] Quorum frontier binding FAILED: ` +
                 `expected tipsHash=${expectedTipsHashHex.slice(0, 12)}... but ` +
-                `responder advertised tips that hash to ${advertisedHex.slice(0, 12)}.... ` +
+                `served payload's frontier hashes to ${servedHex.slice(0, 12)}.... ` +
                 `An agreeing peer voted for one tip set and served a ` +
                 `different one; treating as Byzantine equivocation.`,
             );
             throw new _QuorumBindCheckFailedError(
-              advertisedHex,
-              `Quorum frontier binding mismatch: expected ${expectedTipsHashHex.slice(0, 12)}... ` +
-                `got ${advertisedHex.slice(0, 12)}...`,
+              servedHex,
+              `Quorum frontier binding mismatch (served payload): expected ` +
+                `${expectedTipsHashHex.slice(0, 12)}... got ${servedHex.slice(0, 12)}...`,
             );
+          }
+          // Defense-in-depth: if the responder included `tips`, it
+          // must hash to the same value as the structurally-derived
+          // served frontier. A peer whose attested `tips` contradicts
+          // their own served payload (e.g. claims extra heads that
+          // are not present in the served tree) is misbehaving.
+          if (Array.isArray(message.tips)) {
+            const advertisedBytes = await tipsHash(message.tips);
+            const advertisedHex = tipsHashToHex(advertisedBytes);
+            if (!constantTimeHexEquals(servedHex, advertisedHex)) {
+              console.warn(
+                `[${this.documentPath}] Quorum frontier binding FAILED: ` +
+                  `served payload frontier hashes to ${servedHex.slice(0, 12)}... ` +
+                  `but responder advertised tips hashing to ${advertisedHex.slice(0, 12)}.... ` +
+                  `Responder's own attestation contradicts the served payload.`,
+              );
+              throw new _QuorumBindCheckFailedError(
+                advertisedHex,
+                `Quorum frontier binding mismatch (advertised vs served): ` +
+                  `advertised ${advertisedHex.slice(0, 12)}... served ` +
+                  `${servedHex.slice(0, 12)}...`,
+              );
+            }
           }
         }
 
@@ -2696,29 +2749,35 @@ export class CollabswarmDocument<
    * (when `loadQuorumEnabled: false`) keeps the ORIGINAL un-deduped
    * peer list so it can retry across multiple multiaddrs for the same
    * peer id (e.g. a direct connection + a relay-circuit fallback). See
-   * PR #284 r7 Copilot review for the dedup-scope rationale. After
-   * quorum passes, the served full state is bound to the agreed hash via the
-   * responder-supplied `tips` array on the load response: the loader
-   * computes `tipsHash(message.tips)` and verifies it equals the quorum
-   * `winningHashHex` BEFORE applying the response. Hashing the
-   * responder's own attestation (rather than recomputing
-   * `tipsHash(this._hashes)` post-sync) keeps the binding correct under
-   * snapshot-load (which doesn't restore ancestor CIDs to `_hashes`),
-   * history compaction, and pre-existing local CIDs — the prior
-   * recompute-locally approach would fail-open or fail-closed in those
-   * cases. An agreeing peer that voted hash X but serves a load whose
-   * `tips` hash to Y is treated as a PER-PEER bind failure: the loader
-   * records the offending peer in `agreeingPeerBindFailures`, skips it,
-   * and tries the next peer in the agreeing cohort. This prevents a
-   * single malicious peer in the agreeing cohort from DoS'ing the
-   * entire load by voting for the majority hash (passing quorum) and
-   * then serving a mismatched full load. Only after EVERY peer in the
-   * agreeing cohort has bind-failed does the loader throw
-   * `LoadQuorumFailedError(reason: 'bind-check-failed-all-agreeing-
-   * peers')`, with `agreeingPeerBindFailures` recording per-peer what
-   * each Byzantine peer served instead. Closes the gap tracked under
-   * issue #189 §5.4 item 2 (and bulleted in #186). See PR #284 r6
-   * Copilot review for the DoS rationale on the per-peer retry.
+   * PR #284 r7 Copilot review for the dedup-scope rationale.
+   *
+   * After quorum passes, the served full state is bound to the agreed
+   * hash STRUCTURALLY -- the loader derives the responder's served
+   * frontier from the actual `changes`/`snapshot` payload via
+   * `computeServedFrontier`, hashes that, and verifies it equals
+   * `winningHashHex` BEFORE applying the response. The
+   * responder-supplied `message.tips` array is NO LONGER trusted as the
+   * source of truth (previous rounds did, which let a Byzantine peer
+   * vote hash X, put X's tips in `message.tips`, and serve a divergent
+   * payload). When present, `message.tips` is additionally checked to
+   * hash to the same value as the structurally-derived served
+   * frontier; this catches the responder-internal-equivocation case
+   * where the served `changes` and the advertised `tips` were
+   * assembled inconsistently. See PR #284 r7 Copilot review. An
+   * agreeing peer whose served payload's structural frontier hashes to
+   * something other than `winningHashHex` is treated as a PER-PEER bind
+   * failure: the loader records the offending peer in
+   * `agreeingPeerBindFailures`, skips it, and tries the next peer in
+   * the agreeing cohort. This prevents a single malicious peer in the
+   * agreeing cohort from DoS'ing the entire load by voting for the
+   * majority hash (passing quorum) and then serving a mismatched full
+   * load. Only after EVERY peer in the agreeing cohort has bind-failed
+   * does the loader throw `LoadQuorumFailedError(reason: 'bind-check-
+   * failed-all-agreeing-peers')`, with `agreeingPeerBindFailures`
+   * recording per-peer what each Byzantine peer served instead.
+   * Closes the gap tracked under issue #189 §5.4 item 2 (and bulleted
+   * in #186). See PR #284 r6 Copilot review for the DoS rationale on
+   * the per-peer retry.
    *
    * @returns `true` if the document was successfully loaded from a peer.
    *   `false` if no peer could provide the document -- this is ambiguous: it
@@ -2907,11 +2966,17 @@ export class CollabswarmDocument<
     // fall back to the regular doc-load protocol.
     //
     // Quorum frontier binding: when `winningHashHex` is non-null,
-    // `_sendLoadRequestAndSync` requires the responder to include its
-    // current frontier in `message.tips` and verifies
-    // `tipsHash(message.tips) === winningHashHex` BEFORE applying the
-    // sync, so a Byzantine peer that voted for one tip set and serves a
-    // different one never gets to mutate in-memory document state.
+    // `_sendLoadRequestAndSync` derives the responder's served frontier
+    // STRUCTURALLY from the actual `changes`/`snapshot` payload via
+    // `computeServedFrontier`, hashes that, and verifies it equals
+    // `winningHashHex` BEFORE applying the sync, so a Byzantine peer
+    // that voted for one tip set and serves a different one never gets
+    // to mutate in-memory document state. The responder-supplied
+    // `message.tips` is checked as a defense-in-depth consistency
+    // requirement but is NOT the source of truth -- previous rounds
+    // trusted it as such, which let a Byzantine peer game the binding
+    // by populating `tips` with the agreed CIDs while serving a
+    // divergent `changes` payload. See PR #284 r7 Copilot review.
     //
     // Per-peer bind failures (`_QuorumBindCheckFailedError`) are NOT
     // fatal to the whole load -- they only disqualify the offending
@@ -2924,9 +2989,10 @@ export class CollabswarmDocument<
     // See PR #284 r6 Copilot review.
     //
     // The `agreeingPeerBindFailures` map records, per peer, the hex
-    // hash the responder's served `tips` actually hashed to (or the
-    // sentinel `'(missing tips)'` for an omitted-tips response). This
-    // is threaded into the final error so callers / operators can see
+    // hash the served payload's structural frontier actually hashed to
+    // (or the hex of the responder's contradicting `tips` attestation
+    // when the defense-in-depth secondary check fails). This is
+    // threaded into the final error so callers / operators can see
     // which peers in the agreeing cohort equivocated between the
     // probe round and the load round and what they served instead.
     const agreeingPeerBindFailures = new Map<string, string>();
@@ -2952,14 +3018,15 @@ export class CollabswarmDocument<
         // Empty response -- peer has no snapshot, try doc-load below.
       } catch (err) {
         if (err instanceof _QuorumBindCheckFailedError) {
-          // This peer voted hash X in the probe round but served a
-          // load whose tips hash to something else (or omitted tips
-          // entirely). Record the failure and skip the doc-load
-          // fallback for this peer -- a peer that equivocated once
-          // is not given a second chance on the same load round.
+          // This peer voted hash X in the probe round but the structural
+          // frontier of their served payload hashes to something else
+          // (or their advertised `tips` contradicts the served payload).
+          // Record the failure and skip the doc-load fallback for this
+          // peer -- a peer that equivocated once is not given a second
+          // chance on the same load round.
           console.warn(
             `[${this.documentPath}] Agreeing peer ${peer.toString()} failed ` +
-              `quorum frontier bind on snapshot-load (served ${err.advertisedHex}); ` +
+              `quorum frontier bind on snapshot-load (offending hash ${err.advertisedHex}); ` +
               `marking peer as Byzantine for this load and trying next peer in agreeing cohort.`,
           );
           agreeingPeerBindFailures.set(this._peerIdOf(peer), err.advertisedHex);
@@ -2993,7 +3060,7 @@ export class CollabswarmDocument<
         if (err instanceof _QuorumBindCheckFailedError) {
           console.warn(
             `[${this.documentPath}] Agreeing peer ${peer.toString()} failed ` +
-              `quorum frontier bind on doc-load (served ${err.advertisedHex}); ` +
+              `quorum frontier bind on doc-load (offending hash ${err.advertisedHex}); ` +
               `marking peer as Byzantine for this load and trying next peer in agreeing cohort.`,
           );
           agreeingPeerBindFailures.set(this._peerIdOf(peer), err.advertisedHex);

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -3198,25 +3198,45 @@ export class CollabswarmDocument<
       }
     }
 
-    // If the loop exhausted the agreeing cohort AND at least one peer
-    // bind-failed AND quorum was actually run (`winningHashHex !==
-    // null`), every peer in the cohort either failed the bind check or
-    // failed to serve at all -- which, given they all voted for the
-    // same hash, indicates a coordinated Byzantine cohort. Escalate
-    // with the dedicated reason so callers can distinguish this from
-    // the "no peer responded" outcome. Only raise when at least one
-    // peer was actually flagged as bind-failed; if every peer instead
-    // failed for some OTHER reason (network, protocol, etc.) we fall
-    // through to the legacy `return false` so a brand-new document is
-    // still indistinguishable from a transient outage. See PR #284 r6.
-    if (winningHashHex !== null && agreeingPeerBindFailures.size > 0) {
+    // If quorum was actually run (`winningHashHex !== null`) but the
+    // load loop is exhausted, the cohort agreed the document exists
+    // yet none of them could serve it. Two sub-cases:
+    //
+    //   a) `agreeingPeerBindFailures.size > 0` -- at least one peer
+    //      voted for the agreed hash and then served a divergent
+    //      payload. Coordinated Byzantine behaviour is the simplest
+    //      explanation; we escalate with the dedicated reason.
+    //
+    //   b) `agreeingPeerBindFailures.size === 0` -- every agreeing
+    //      peer failed for an OTHER reason (transport/protocol/etc.).
+    //      We cannot distinguish "all agreeing peers transiently
+    //      offline" from "all agreeing peers refusing to serve", but
+    //      we MUST NOT fall through to `return false` -- that would
+    //      let `open()` initialize a brand-new document despite
+    //      quorum just attesting that the document exists. Surface
+    //      the failure with `'agreeing-peers-unreachable'` so the
+    //      caller decides whether to retry or surface to the user.
+    //
+    // Only after a TRUE no-quorum-was-run outcome (winningHashHex
+    // is null -- legacy non-quorum load or quorum disabled / no
+    // peers / etc.) is `return false` the right answer.
+    if (winningHashHex !== null) {
+      if (agreeingPeerBindFailures.size > 0) {
+        throw new LoadQuorumFailedError({
+          documentPath: this.documentPath,
+          reason: 'bind-check-failed-all-agreeing-peers',
+          respondingCount: 0,
+          requiredQ: 0,
+          agreement: new Map([[winningHashHex, 0]]),
+          agreeingPeerBindFailures,
+        });
+      }
       throw new LoadQuorumFailedError({
         documentPath: this.documentPath,
-        reason: 'bind-check-failed-all-agreeing-peers',
+        reason: 'agreeing-peers-unreachable',
         respondingCount: 0,
         requiredQ: 0,
         agreement: new Map([[winningHashHex, 0]]),
-        agreeingPeerBindFailures,
       });
     }
 

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -26,6 +26,7 @@ import {
   crdtWriterChangeNode,
 } from './crdt-change-node';
 import {
+  collectReferencedAncestors,
   MAX_CROSS_LINKS,
   MAX_RECENT_TIPS,
   mergeRemoteSyncTree,
@@ -48,8 +49,8 @@ import {
   beekemPathUpdateV1,
   beekemWelcomeV1,
   documentKeyUpdateV2,
-  documentLoadV2,
-  snapshotLoadV2,
+  documentLoadV3,
+  snapshotLoadV3,
   tipAdvertiseV1,
 } from './wire-protocols';
 import { BeeKEM } from './beekem/beekem';
@@ -472,6 +473,39 @@ export class CollabswarmDocument<
   // Set of already-merged change blocks.
   private _hashes = new Set<string>();
 
+  // Set of CIDs that have been seen as a `children` key in any sync tree we
+  // have processed (locally created or remotely received) -- i.e. every CID
+  // some node references as a parent / cross-link target. These are
+  // *referenced ancestors*: by definition they are NOT heads of the local
+  // DAG, because at least one node points to them as a predecessor.
+  //
+  // `_currentFrontier()` returns `_hashes \ _referencedAncestors` -- the set
+  // of CIDs that no node we've ever seen has referenced. That is the actual
+  // "frontier" / "heads" of the merged-changes DAG, which is what the
+  // initial-load quorum tip-set advertisement is supposed to attest to.
+  //
+  // Critically, this set converges across honest peers: two peers with the
+  // same logical state but different sync histories (e.g. one loaded from a
+  // snapshot, the other has been merging changes since founding) will have
+  // *different* `_hashes` cardinality but the same head set, hence the same
+  // `_hashes \ _referencedAncestors`. Drawing the quorum probe from
+  // `_hashes` alone (the prior buggy implementation) would have made the
+  // probe pessimistically diverge on irrelevant sync history.
+  //
+  // Populated in:
+  //   - `_makeChange()`: every newly-attached `changeNode.children` key
+  //     is recorded -- the new change references those parents.
+  //   - `_syncDocumentChanges()`: every received sync tree is walked once
+  //     and its `children` keys are recorded -- the receiver now knows the
+  //     same parent relationships the sender did.
+  //
+  // Snapshot boundaries: when a snapshot is applied, `lastChangeNodeCID` is
+  // added to `_hashes` as a sentinel for dedup, but its ancestor chain is
+  // pruned -- those ancestors are not added to `_referencedAncestors`,
+  // which is correct: the snapshot boundary IS the local "oldest" head
+  // from the loader's view of the DAG.
+  private _referencedAncestors = new Set<string>();
+
   // Bounded list of recently-known change CIDs paired with their node kind.
   // Used by `_makeChange()` to attach Merkle-CRDT cross-links (paper §VI.B.e)
   // in addition to the primary parent link. Cross-links improve consistency
@@ -771,21 +805,57 @@ export class CollabswarmDocument<
   /**
    * Returns this peer's current frontier as a plain string[] of CIDs —
    * "what tips would I advertise to a fresh `tipAdvertiseV1` probe right
-   * now". Drawn from `this._hashes`, which is the same source the
-   * tip-advertise hash is computed from, so the advertised hash and the
-   * load-response `tips` field stay in lockstep across the two streams
-   * the loader uses (probe + full load).
+   * now".
    *
-   * Wrapped in a helper so the load-response handlers, the tip-advertise
-   * handler, and (if reused later) any internal callers all hit the same
-   * canonical primitive. Returns a fresh array so callers can't mutate
-   * `_hashes` through the returned reference; the array is later sorted
-   * by `tipsHash` independently, so we don't sort here.
+   * The frontier is the set of heads of the local merged-changes DAG:
+   * CIDs that this peer has seen but that no other change references as
+   * a parent or cross-link target. Computed as `_hashes \
+   * _referencedAncestors`. See the `_referencedAncestors` field docstring
+   * for why this matters: it is the part of the local DAG that converges
+   * across honest peers regardless of differing sync histories or pruning
+   * levels, so two peers in the same logical state produce identical
+   * `tipsHash` digests.
+   *
+   * Returning the full `_hashes` set (the prior buggy implementation)
+   * silently breaks the initial-load quorum gate -- it includes every
+   * referenced ancestor, so two honest peers with the same heads but
+   * differing ancestor visibility (e.g. one loaded from a snapshot, the
+   * other has the full history) produce different tip-set hashes and
+   * fail quorum even though they agree on state.
+   *
+   * Edge cases:
+   *   - Empty DAG (founding member, brand-new document): `_hashes` is
+   *     empty, the returned frontier is `[]`. `tipsHash([])` is the
+   *     SHA-256 of the empty string, a deterministic value all honest
+   *     peers compute identically -- quorum cleanly bootstraps.
+   *   - Just-loaded from snapshot: `_hashes` holds the snapshot boundary
+   *     CID (and any post-snapshot changes). The boundary CID is NOT in
+   *     `_referencedAncestors` (no in-tree node points back through it),
+   *     so it correctly appears as a head along with any post-snapshot
+   *     leaves -- which is exactly what the responder would serve.
+   *   - Pruned ancestors: irrelevant. Pruning removes CIDs from the
+   *     in-memory change tree but leaves them in `_hashes` for dedup;
+   *     they were already in `_referencedAncestors` (recorded when the
+   *     tree contained them), so they remain marked as non-heads.
+   *
+   * Wrapped in a helper so the load-response handlers
+   * (`handleLoadRequestData`, `handleSnapshotLoadRequestData`) and the
+   * tip-advertise handler (`handleTipAdvertiseRequestData`) all hit the
+   * same canonical primitive -- the probe-then-load round-trip binds
+   * against a byte-identical tip set. Returns a fresh array so callers
+   * can't mutate internal state; `tipsHash` sorts independently, so we
+   * don't sort here.
    *
    * @internal
    */
   private _currentFrontier(): string[] {
-    return Array.from(this._hashes);
+    const out: string[] = [];
+    for (const cid of this._hashes) {
+      if (!this._referencedAncestors.has(cid)) {
+        out.push(cid);
+      }
+    }
+    return out;
   }
 
   /**
@@ -809,6 +879,19 @@ export class CollabswarmDocument<
     changeId: string | undefined,
     changes: CRDTChangeNode<ChangesType>,
   ) {
+    // Walk the incoming sync tree once and record every CID that appears
+    // as a `children` key. Those CIDs are referenced ancestors -- by
+    // definition no longer heads of the local DAG. Doing this BEFORE the
+    // merge keeps `_currentFrontier()` correct regardless of whether the
+    // referenced parent ends up applied inline or fetched lazily from the
+    // blockstore: either way, the receiver now knows the parent relationship
+    // the sender had.
+    //
+    // Idempotent and inexpensive: the helper walks at most the size of the
+    // delivered tree (bounded by the sender's compaction config); duplicates
+    // are no-ops in a Set.
+    collectReferencedAncestors(changeId, changes, this._referencedAncestors);
+
     // Only process hashes that we haven't seen yet.
     const newChangeEntries = await this._mergeSyncTree(
       changeId,
@@ -1313,6 +1396,18 @@ export class CollabswarmDocument<
     updateMessage.changeId = hash;
     updateMessage.changes = changeNode;
 
+    // Record every CID this new change references as a parent / cross-link
+    // target. The primary parent and all cross-link tips become *referenced
+    // ancestors* and drop out of `_currentFrontier()`. Walks just the new
+    // `changeNode` (not the full inherited subtree below it) because the
+    // inherited subtree's ancestor relationships were already recorded
+    // when each of those nodes was created or applied.
+    if (changeNode.children) {
+      for (const childCid of Object.keys(changeNode.children)) {
+        this._referencedAncestors.add(childCid);
+      }
+    }
+
     // Track this new tip for future cross-linking. The primary parent is
     // also retained -- it's the immediate predecessor of *this* tip and may
     // still be useful as a cross-link target for the *next* change if a
@@ -1699,15 +1794,15 @@ export class CollabswarmDocument<
       // Attach an explicit tip-set advertisement so the loader can bind the
       // served state to this responder's current frontier (issue #186 /
       // #189 §5.4.2). The loader recomputes `tipsHash(tips)` and compares
-      // against the quorum-agreed `winningHashHex`; using the responder's
-      // own `_hashes` here keeps the binding source identical to the one
-      // used by the `tipAdvertiseV1` probe response so a peer that voted
-      // for hash X but serves a load whose `tips` hash to Y is caught.
-      // Drawn from the same `_hashes` set so a peer that loaded from a
-      // snapshot (and therefore has a pruned `_hashes`) still produces a
-      // self-consistent advertisement; the responder is attesting to
-      // "what tip-advertise would I respond with right now", not "what
-      // full history did I once have".
+      // against the quorum-agreed `winningHashHex`; `_currentFrontier()`
+      // is the canonical helper used by ALL three protocols (tip-advertise,
+      // doc-load, snapshot-load) so a peer that voted for hash X but
+      // serves a load whose `tips` hash to Y is caught. The frontier is
+      // `_hashes \ _referencedAncestors` -- the heads of the local DAG --
+      // which converges across honest peers even when their full `_hashes`
+      // cardinality differs (e.g. one loaded from a snapshot, the other
+      // has the full ancestor history). This is part of the SIGNED v3
+      // payload; see `wire-protocols.ts` for the version-bump rationale.
       loadMessage.tips = this._currentFrontier();
 
       // Sign new message.
@@ -1829,12 +1924,13 @@ export class CollabswarmDocument<
       snapshotMessage.keychainChanges = await this._keychainChangesForVisibility();
       // Tip-set advertisement for the post-load binding check (see the
       // doc-load handler above and the in-line check in
-      // `_sendLoadRequestAndSync` for the rationale). On a snapshot-load
-      // the loader's post-sync `_hashes`
-      // does NOT include ancestor CIDs that were compacted into the
-      // snapshot, so a `tipsHash(loader._hashes)` recomputation would
-      // never match a responder whose `_hashes` retains full history.
-      // The responder's `tips` is the canonical source of truth here.
+      // `_sendLoadRequestAndSync` for the rationale). `_currentFrontier()`
+      // returns the heads of the local DAG (`_hashes \
+      // _referencedAncestors`), which is the convergent quantity across
+      // honest peers regardless of whether either side loaded from a
+      // snapshot or replayed the full history. Part of the signed v3
+      // payload -- the version bump (snapshotLoadV2 -> snapshotLoadV3)
+      // is required because `tips` is now covered by the writer signature.
       snapshotMessage.tips = this._currentFrontier();
       snapshotMessage.signature = await this._signAsWriter(snapshotMessage);
 
@@ -2799,7 +2895,7 @@ export class CollabswarmDocument<
         // duplex shape that `_sendLoadRequestAndSync` (and the legacy
         // `it-pipe` calls inside it) still expects.
         const snapshotStream = wrapStream(await this.libp2p.dialProtocol(peer, [
-          snapshotLoadV2,
+          snapshotLoadV3,
         ]));
         const loaded = await this._sendLoadRequestAndSync(
           snapshotStream,
@@ -2819,7 +2915,7 @@ export class CollabswarmDocument<
         console.log('Trying doc-load from peer:', peer.toString());
         // See snapshot-load above for why we wrap the v3 Stream here.
         const docStream = wrapStream(await this.libp2p.dialProtocol(peer, [
-          documentLoadV2,
+          documentLoadV3,
         ]));
         const loaded = await this._sendLoadRequestAndSync(
           docStream,
@@ -2832,7 +2928,7 @@ export class CollabswarmDocument<
       } catch (err) {
         if (err instanceof LoadQuorumFailedError) throw err;
         console.warn(
-          `Failed to load document via ${documentLoadV2}:`,
+          `Failed to load document via ${documentLoadV3}:`,
           peer.toString(),
           err,
         );
@@ -3375,8 +3471,9 @@ export class CollabswarmDocument<
    * `_documentChangeCount`, `_changesSinceSnapshot`, and `_recentTips`
    * are restored from snapshots captured before `_makeChange()`.
    * (`_recentTips` is bounded to `MAX_RECENT_TIPS` entries so the snapshot
-   * is a cheap shallow array copy.) For `_hashes`, all entries added to
-   * the Set after `hashSizeBefore` are removed. Because the node remains
+   * is a cheap shallow array copy.) For `_hashes` and
+   * `_referencedAncestors`, all entries added to each Set after its
+   * pre-attempt size are removed. Because the node remains
    * subscribed to pubsub during the async transaction, this may include
    * CIDs appended by concurrent remote syncs, not just local ones.
    * This is acceptable because CRDT convergence guarantees those remote
@@ -3411,6 +3508,7 @@ export class CollabswarmDocument<
     // _makeChange adds at most one CID, and JS Sets iterate in insertion order,
     // so on rollback we remove only entries appended after this point.
     const hashSizeBefore = this._hashes.size;
+    const referencedAncestorsSizeBefore = this._referencedAncestors.size;
     const lastSyncSnapshot = this._lastSyncMessage;
     const changeCountSnapshot = this._documentChangeCount;
     const compactionCountSnapshot = this._changesSinceSnapshot;
@@ -3468,6 +3566,24 @@ export class CollabswarmDocument<
         }
         for (const hash of toRemove) {
           this._hashes.delete(hash);
+        }
+      }
+      // Mirror the `_hashes` rollback for `_referencedAncestors`: remove
+      // only entries appended past the pre-attempt size. Same rationale --
+      // insertion-ordered Set iteration plus O(delta) memory -- and same
+      // best-effort caveat for concurrent sync that may have inserted into
+      // either set in parallel.
+      if (this._referencedAncestors.size > referencedAncestorsSizeBefore) {
+        const toRemoveRefs: string[] = [];
+        let j = 0;
+        for (const cid of this._referencedAncestors) {
+          if (j >= referencedAncestorsSizeBefore) {
+            toRemoveRefs.push(cid);
+          }
+          j++;
+        }
+        for (const cid of toRemoveRefs) {
+          this._referencedAncestors.delete(cid);
         }
       }
       this._lastSyncMessage = lastSyncSnapshot;

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -70,14 +70,10 @@ import {
 import { tipsHash, tipsHashToHex, TIPS_HASH_LENGTH } from './tips-hash';
 import {
   constantTimeHexEquals,
-  decideLoadQuorum,
   dedupePeersByPeerId,
-  defaultQuorumQ,
-  effectiveK,
-  effectiveQ,
   LoadQuorumFailedError,
-  PeerTipAdvertisement,
 } from './load-quorum';
+import { runLoadQuorum } from './load-quorum-orchestrator';
 import { CRDTSnapshotNode } from './snapshot-node';
 import { CompactionConfig, defaultCompactionConfig } from './compaction-config';
 import {
@@ -188,6 +184,20 @@ export type CollabswarmDocumentChangeHandler<DocType, PublicKey> = (
  * @typeParam PublicKey The type of key used to identify a user publicly
  * @typeParam DocumentKey The type of key used to encrypt/decrypt document changes
  */
+
+/**
+ * Maximum size (in bytes) of a `tipAdvertiseV1` probe response read. A
+ * legitimate response is a single encrypted `CRDTSyncMessage` carrying
+ * only `documentId`, a 32-byte `tipsHash`, and an optional writer
+ * signature — a few hundred bytes at most after JSON framing plus the
+ * AES-GCM header/tag. 2 KiB is generous for honest peers (well above the
+ * realistic upper bound, even with longer document paths or larger
+ * signatures) while bounding what a malicious peer can force the loader
+ * to buffer before being rejected as a non-vote. See PR #284 r4 Copilot
+ * review.
+ */
+const MAX_TIP_ADVERTISE_RESPONSE_SIZE = 2 * 1024;
+
 export class CollabswarmDocument<
   DocType,
   ChangesType,
@@ -2427,7 +2437,21 @@ export class CollabswarmDocument<
     }
     try {
       await pipe([serializedRequest], stream.sink);
-      const assembled = await readUint8Iterable(stream.source);
+      // Size-bound the tip-advertise response read. A `tipAdvertiseV1` body
+      // is an encrypted `CRDTSyncMessage` carrying only `documentId`, a
+      // 32-byte `tipsHash`, and (optionally) a writer signature — a few
+      // hundred bytes at most after JSON framing + AES-GCM header/tag. A
+      // 2 KiB cap is generous for legitimate peers but prevents a
+      // malicious peer from streaming an unbounded payload to force
+      // `load()` to buffer it all before returning a non-vote. If the
+      // read overruns the cap, `readUint8Iterable` throws a `RangeError`
+      // that is caught by the surrounding `try { ... } catch { return
+      // null; }` — surfacing as a non-vote (same outcome as a timeout),
+      // NOT a quorum disagreement. See PR #284 r4 Copilot review.
+      const assembled = await readUint8Iterable(
+        stream.source,
+        MAX_TIP_ADVERTISE_RESPONSE_SIZE,
+      );
       if (assembled.length === 0) {
         // Peer declined (unknown doc, unauthorized, etc.).
         return null;
@@ -2725,152 +2749,70 @@ export class CollabswarmDocument<
     // served state, the recomputed `tipsHash(this._hashes)` MUST equal
     // `winningHashHex`, otherwise an agreeing peer voted for one tip set and
     // served a different one (Byzantine equivocation).
-    const quorumEnabled = this.swarm.config?.loadQuorumEnabled ?? true;
+    // NOTE: previously this block bypassed the gate when `_hashes.size === 0`
+    // on the assumption it identified a "founding-member" brand-new document.
+    // That bypass was unsafe: `_hashes` is ALSO empty on the first `open()`
+    // of an EXISTING document (before load populates it), which is exactly
+    // the case the gate is meant to protect. We no longer special-case empty
+    // local state; the gate runs uniformly. True founders (no peers in the
+    // mesh) are handled by the `peers.length === 0` short-circuit at the top
+    // of `load()` plus the `k === 0` branch inside `runLoadQuorum` (which
+    // returns `{ skipped: true }` → we fall through to the legacy "no peer
+    // could provide the document" path and return false).
+    //
+    // The K-of-Q decision logic itself lives in `runLoadQuorum`
+    // (`load-quorum-orchestrator.ts`) so the orchestration can be unit-tested
+    // without standing up a libp2p/Helia stack. The orchestrator is given a
+    // probe-fn closure that captures this document's `_raceTipAdvertiseProbe`
+    // (the only network-touching call); narrowing, agreement counting, and
+    // single-peer fallback all happen in pure code with the same control
+    // flow as before the extraction. See PR #284 r4 Copilot review for the
+    // test-coverage rationale.
+    const timeoutMs = this.swarm.config?.loadQuorumTimeoutMs ?? 5000;
+    const quorumResult = await runLoadQuorum({
+      peers: orderedPeers,
+      peerIdOf: (p) => this._peerIdOf(p),
+      probeFn: (peer) =>
+        this._raceTipAdvertiseProbe(peer, serializedRequest, timeoutMs),
+      documentPath: this.documentPath,
+      config: {
+        enabled: this.swarm.config?.loadQuorumEnabled ?? true,
+        k: this.swarm.config?.loadQuorumK ?? 3,
+        q: this.swarm.config?.loadQuorumQ,
+        timeoutMs,
+        allowSinglePeer:
+          this.swarm.config?.loadQuorumAllowSinglePeer ?? false,
+      },
+    });
+
     let winningHashHex: string | null = null;
-    if (quorumEnabled) {
+    if ('skipped' in quorumResult) {
+      // `runLoadQuorum` returns `{ skipped: true }` in two cases: (a) the
+      // gate is disabled wholesale (`loadQuorumEnabled: false`), or (b) the
+      // effective K resolved to 0 (no peers OR misconfigured `loadQuorumK
+      // <= 0`). For (a) we want to fall through to the legacy single-peer
+      // load loop unchanged (no narrowing, no winningHashHex). For (b)
+      // there is nothing to load against — treat as new document. The
+      // peer-list empty short-circuit at the top of `load()` already
+      // covers the trivial "no peers" path; this branch handles the
+      // configuredK<=0 edge case so a misconfiguration cannot silently
+      // skip the gate against a populated peer list.
+      const quorumWasEnabled = this.swarm.config?.loadQuorumEnabled ?? true;
       const configuredK = this.swarm.config?.loadQuorumK ?? 3;
-      // Strict-majority threshold: `Math.floor(K/2) + 1`. For K=3 this gives
-      // Q=2 (tolerating one fault), matching the BFT design note in #189
-      // §5.4.2. `Math.ceil(K/2) + 1` would yield Q=3 at K=3 (everyone must
-      // agree), defeating the fault-tolerance intent of the gate. The
-      // formula lives in `defaultQuorumQ` so the loader, the config
-      // docstring, and the test matrix all reference one source of truth.
-      const configuredQ =
-        this.swarm.config?.loadQuorumQ ?? defaultQuorumQ(configuredK);
-      const timeoutMs = this.swarm.config?.loadQuorumTimeoutMs ?? 5000;
-      const allowSinglePeer =
-        this.swarm.config?.loadQuorumAllowSinglePeer ?? false;
-
-      const k = effectiveK(configuredK, orderedPeers.length);
-      const q = effectiveQ(configuredQ, k);
-
-      // NOTE: previously this block bypassed the gate when `_hashes.size === 0`
-      // on the assumption it identified a "founding-member" brand-new document.
-      // That bypass was unsafe: `_hashes` is ALSO empty on the first `open()`
-      // of an EXISTING document (before load populates it), which is exactly
-      // the case the gate is meant to protect. We no longer special-case empty
-      // local state; the gate runs uniformly. True founders (no peers in the
-      // mesh) are handled by the `peers.length === 0` short-circuit at the top
-      // of `load()` plus the `k === 0` branch below (which falls through to
-      // return false → caller treats as new document).
-
-      if (k === 0) {
-        // No peers known. Treat as "new document" — `open()` will run
-        // validateDocumentPath and create the document from scratch. This is
-        // the legitimate founder path: no remote peer exists to serve a
-        // mismatched view, so there is nothing for the quorum gate to defend.
+      if (quorumWasEnabled && configuredK > 0 && orderedPeers.length === 0) {
         return false;
-      } else if (k === 1 && !allowSinglePeer) {
-        // Only one peer reachable but quorum requires Q>=2 by default.
-        // Without a second opinion we cannot distinguish "honest solo peer"
-        // from "malicious peer serving a forged state". Refuse. Callers in
-        // genuine single-peer scenarios (tests, small private swarms,
-        // founding member with one known seed) must opt in explicitly via
-        // `loadQuorumAllowSinglePeer: true` or `loadQuorumEnabled: false`.
-        throw new LoadQuorumFailedError({
-          documentPath: this.documentPath,
-          reason: 'insufficient-responses',
-          respondingCount: 0,
-          requiredQ: q,
-          agreement: new Map(),
-        });
-      } else if (k === 1 && allowSinglePeer) {
-        // Single-peer pass-through. Probe the one known peer; if it
-        // responds at all we proceed with the legacy load. Warn loudly
-        // so operators can spot the regression. Q is forced to 1 here.
-        console.warn(
-          `[${this.documentPath}] Initial-load quorum: only one peer known; ` +
-            `proceeding under loadQuorumAllowSinglePeer (trust assumptions ` +
-            `degraded back to single-peer load). Configure additional peers ` +
-            `to restore Byzantine-fault-tolerant quorum semantics.`,
-        );
-        const probedPeer = orderedPeers[0];
-        const probe = await this._raceTipAdvertiseProbe(
-          probedPeer,
-          serializedRequest,
-          timeoutMs,
-        );
-        if (probe === null) {
-          throw new LoadQuorumFailedError({
-            documentPath: this.documentPath,
-            reason: 'insufficient-responses',
-            respondingCount: 0,
-            requiredQ: 1,
-            agreement: new Map(),
-          });
-        }
-        // Bind the single peer's advertised hash so the post-load check
-        // below still verifies that the served state matches what was
-        // advertised (defends against a malicious peer that decides what
-        // to serve only after seeing the advertise round-trip).
-        winningHashHex = tipsHashToHex(probe);
-        // Narrow `orderedPeers` to ONLY the probed peer. Without this,
-        // the subsequent snapshot/doc-load loop would also try the other
-        // peers in `orderedPeers` (which were never probed) and bind
-        // their served state against THIS peer's hash — a non-sequitur
-        // that could either: (a) pass the binding by coincidence and
-        // accept state from a peer that never voted for it, or (b) fail
-        // the binding and abort the load even though the single-peer
-        // path explicitly opted into single-peer trust. Restrict the
-        // load loop to the one peer whose hash we accepted. See PR #284
-        // r2 CodeRabbit comment on this block.
-        orderedPeers.length = 0;
-        orderedPeers.push(probedPeer);
-      } else {
-        // Standard K-of-Q quorum path. Take the first K peers from the
-        // already-ordered list (preferredPeer is at index 0, so it is
-        // always queried), probe in parallel, and decide.
-        const probedPeers = orderedPeers.slice(0, k);
-        const advertisements: PeerTipAdvertisement[] = await Promise.all(
-          probedPeers.map(async (peer) => {
-            const hash = await this._raceTipAdvertiseProbe(
-              peer,
-              serializedRequest,
-              timeoutMs,
-            );
-            return { peerId: this._peerIdOf(peer), hash };
-          }),
-        );
-        const decision = decideLoadQuorum(advertisements, q);
-        if (!decision.ok) {
-          console.warn(
-            `[${this.documentPath}] Initial-load quorum FAILED: ` +
-              `${decision.reason} (${decision.respondingCount} responses, ` +
-              `required ${decision.effectiveQ}). Aborting load.`,
-          );
-          throw new LoadQuorumFailedError({
-            documentPath: this.documentPath,
-            reason: decision.reason,
-            respondingCount: decision.respondingCount,
-            requiredQ: decision.effectiveQ,
-            agreement: decision.agreement,
-          });
-        }
-        console.log(
-          `[${this.documentPath}] Initial-load quorum passed: ` +
-            `${decision.agreeingPeerIds.length}/${decision.respondingCount} ` +
-            `peers agreed on tipsHash=${decision.winningHashHex.slice(0, 12)}...`,
-        );
-        winningHashHex = decision.winningHashHex;
-        // Narrow `orderedPeers` to only the agreeing cohort. The legacy
-        // snapshot/doc-load loop below then asks one of these peers for
-        // the full state; with quorum agreement, any single agreeing
-        // peer's load is defended by Q-1 other peers attesting to the
-        // same tip set. Order is preserved (preferredPeer first if it
-        // was among the agreeing cohort).
-        const agreeingSet = new Set(decision.agreeingPeerIds);
-        const narrowed = orderedPeers.filter((p) =>
-          agreeingSet.has(this._peerIdOf(p)),
-        );
-        // Defensive: at least one agreeing peer must remain. If
-        // peer-id extraction loses a peer (should never happen given
-        // we built the same set above), fall back to the full list so
-        // we don't accidentally degrade to "no peers to load from".
-        if (narrowed.length > 0) {
-          orderedPeers.length = 0;
-          orderedPeers.push(...narrowed);
-        }
       }
+      if (quorumWasEnabled && configuredK <= 0) {
+        // Defensive: misconfigured K. Honour the original behaviour
+        // (return false → caller treats as new document) rather than
+        // silently bypassing the gate against a populated peer list.
+        return false;
+      }
+      // Else: gate disabled OR peers list empty. Either way fall through.
+    } else {
+      winningHashHex = quorumResult.winningHashHex;
+      orderedPeers.length = 0;
+      orderedPeers.push(...quorumResult.narrowedPeers);
     }
 
     // Try snapshot-load first for faster initial sync.

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -28,6 +28,7 @@ import {
 import {
   collectReferencedAncestors,
   computeServedFrontier,
+  stripInlineChanges,
   MAX_CROSS_LINKS,
   MAX_RECENT_TIPS,
   mergeRemoteSyncTree,
@@ -1301,6 +1302,7 @@ export class CollabswarmDocument<
       }
     }
   }
+
 
   /**
    * Sanctioned wrapper around `_readers.merge` that also drains any
@@ -2702,6 +2704,59 @@ export class CollabswarmDocument<
                 `${servedHex.slice(0, 12)}...`,
             );
           }
+
+          // Content-address verification (PR #284 r17 Copilot review).
+          //
+          // The structural bind above proves Q peers agree on the
+          // FRONTIER CIDs and that those CIDs appear as keys in the
+          // served tree. It does NOT prove the inline `change` content
+          // for each CID actually hashes back to that CID -- a Byzantine
+          // peer could vote for the agreed frontier and then serve a
+          // tree whose `children` map uses the agreed CIDs as keys but
+          // whose inline `change` values are forged.
+          //
+          // On a FIRST load (`_writers` empty), per-change signature
+          // verification inside the CRDT merge cannot fire -- there are
+          // no writer keys to verify against -- so forged inline content
+          // would otherwise reach `_crdtProvider.remoteChange`/
+          // `_mergeWriters`/`_mergeReaders` unchecked.
+          //
+          // Defense: strip inline `change` content from every node in
+          // the served tree before applying. `sync()` then routes each
+          // CID through `missingDocumentHashes -> _getBlock(cid) ->
+          // helia.blockstore.get(cid)`, which content-validates the
+          // fetched bytes against the CID intrinsically (a Byzantine
+          // peer cannot serve bytes that hash to a CID they did not
+          // produce, and bitswap will retrieve from an honest peer in
+          // the agreeing cohort that does hold the legitimate block).
+          //
+          // Cost: N bitswap roundtrips instead of one inline load. Paid
+          // only on quorum-bound loads; the legacy `winningHashHex ===
+          // null` path is untouched.
+          //
+          // Snapshots: `CRDTSnapshotNode.state` is NOT CID-addressed --
+          // the snapshot's `lastChangeNodeCID` only identifies the
+          // boundary, not the snapshot bytes. Defense is the writer
+          // signature (`_verifySnapshotSignature`), which fails on
+          // first load (writers empty) and rejects the snapshot
+          // automatically. On subsequent loads writers are known and
+          // the signature is the source of truth. We drop the snapshot
+          // entirely on first load below so a malicious snapshot
+          // signature forged with an attacker-controlled key (which
+          // would be admitted if the inline ACL pre-pass were trusted)
+          // never reaches `applySnapshot`.
+          stripInlineChanges(message.changes);
+          const preLoadWriterCount = (await this._writers.users()).length;
+          if (preLoadWriterCount === 0 && message.snapshot) {
+            console.warn(
+              `[${this.documentPath}] Dropping snapshot from quorum-bound ` +
+                `first load: writers ACL is not yet populated so the ` +
+                `snapshot signature cannot be verified. The receiver will ` +
+                `rebuild state from individual change blocks via Helia ` +
+                `(each block content-validated against its CID).`,
+            );
+            message.snapshot = undefined;
+          }
         }
 
         const syncResult = await this.sync(message, false);
@@ -3247,6 +3302,21 @@ export class CollabswarmDocument<
       orderedPeers.push(...quorumResult.narrowedPeers);
     }
 
+    // Capture the post-narrow cohort size so the failure-reason decision
+    // below can distinguish "every agreeing peer bind-failed" (coordinated
+    // Byzantine equivocation on the load step -- the dedicated
+    // `bind-check-failed-all-agreeing-peers` reason) from "some agreeing
+    // peers bind-failed, others failed for transport/protocol reasons"
+    // (mixed failure -- caller should treat as transient and retry, the
+    // `agreeing-peers-unreachable` reason). The previous logic used
+    // `bind-check-failed-all-agreeing-peers` whenever ANY bind failure was
+    // recorded, which contradicted the reason's public name and could
+    // make callers treat a mixed transient retrieval failure as
+    // coordinated Byzantine behaviour. See PR #284 r17 Copilot review.
+    // For the legacy non-quorum path (`winningHashHex === null`), this
+    // value is unused -- the failure block guards on `winningHashHex`.
+    const narrowedCohortSize = orderedPeers.length;
+
     // Try snapshot-load first for faster initial sync.
     // If the peer returns an empty response (no snapshot available),
     // fall back to the regular doc-load protocol.
@@ -3362,28 +3432,45 @@ export class CollabswarmDocument<
 
     // If quorum was actually run (`winningHashHex !== null`) but the
     // load loop is exhausted, the cohort agreed the document exists
-    // yet none of them could serve it. Two sub-cases:
+    // yet none of them could serve it. Three sub-cases:
     //
-    //   a) `agreeingPeerBindFailures.size > 0` -- at least one peer
-    //      voted for the agreed hash and then served a divergent
-    //      payload. Coordinated Byzantine behaviour is the simplest
-    //      explanation; we escalate with the dedicated reason.
+    //   a) `agreeingPeerBindFailures.size === narrowedCohortSize` --
+    //      EVERY peer in the agreeing cohort voted for the agreed
+    //      hash and then served a divergent payload. Coordinated
+    //      Byzantine behaviour is the only explanation; we escalate
+    //      with the dedicated `bind-check-failed-all-agreeing-peers`
+    //      reason whose public docs say exactly this.
     //
-    //   b) `agreeingPeerBindFailures.size === 0` -- every agreeing
-    //      peer failed for an OTHER reason (transport/protocol/etc.).
-    //      We cannot distinguish "all agreeing peers transiently
-    //      offline" from "all agreeing peers refusing to serve", but
-    //      we MUST NOT fall through to `return false` -- that would
-    //      let `open()` initialize a brand-new document despite
-    //      quorum just attesting that the document exists. Surface
+    //   b) `agreeingPeerBindFailures.size > 0` but less than the
+    //      cohort size -- MIXED failure: some peers bind-failed
+    //      (suspicious) and others failed for transport/protocol
+    //      reasons (likely transient). We can't conclude coordinated
+    //      Byzantine equivocation across the whole cohort, so we
+    //      report `'agreeing-peers-unreachable'` and let the caller
+    //      retry. Using `bind-check-failed-all-agreeing-peers` here
+    //      would contradict the reason's public name/docs and could
+    //      make callers wrongly treat a mixed transient failure as
+    //      coordinated Byzantine behaviour. The `agreeingPeerBindFailures`
+    //      map is still threaded through for diagnostics so operators
+    //      can see which peers in the cohort did bind-fail.
+    //      See PR #284 r17 Copilot review.
+    //
+    //   c) `agreeingPeerBindFailures.size === 0` -- every agreeing
+    //      peer failed for a transport/protocol reason; we surface
     //      the failure with `'agreeing-peers-unreachable'` so the
     //      caller decides whether to retry or surface to the user.
+    //      We MUST NOT fall through to `return false` -- that would
+    //      let `open()` initialize a brand-new document despite
+    //      quorum just attesting that the document exists.
     //
     // Only after a TRUE no-quorum-was-run outcome (winningHashHex
     // is null -- legacy non-quorum load or quorum disabled / no
     // peers / etc.) is `return false` the right answer.
     if (winningHashHex !== null) {
-      if (agreeingPeerBindFailures.size > 0) {
+      if (
+        narrowedCohortSize > 0 &&
+        agreeingPeerBindFailures.size === narrowedCohortSize
+      ) {
         throw new LoadQuorumFailedError({
           documentPath: this.documentPath,
           reason: 'bind-check-failed-all-agreeing-peers',
@@ -3399,6 +3486,7 @@ export class CollabswarmDocument<
         respondingCount: 0,
         requiredQ: 0,
         agreement: new Map([[winningHashHex, 0]]),
+        agreeingPeerBindFailures,
       });
     }
 

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -27,6 +27,7 @@ import {
 } from './crdt-change-node';
 import {
   collectReferencedAncestors,
+  collectAllCidsInTree,
   computeServedFrontier,
   stripInlineChanges,
   MAX_CROSS_LINKS,
@@ -2745,6 +2746,21 @@ export class CollabswarmDocument<
           // signature forged with an attacker-controlled key (which
           // would be admitted if the inline ACL pre-pass were trusted)
           // never reaches `applySnapshot`.
+          // Capture every CID that appears in the served tree BEFORE
+          // stripping. `_syncDocumentChanges` swallows per-block fetch
+          // failures (logs + returns); without a post-sync verification
+          // step a transient bitswap/blockstore miss would let this
+          // method return `true` with only a partially-applied document
+          // and `load()` report success. After `sync()` we re-check that
+          // every captured CID is now in `_hashes`; any missing CID is
+          // surfaced as a per-peer bind failure so the loader can retry
+          // the next peer in the agreeing cohort. See PR #284 r18
+          // Copilot review.
+          const expectedCids = collectAllCidsInTree(
+            message.changeId,
+            message.changes,
+          );
+
           stripInlineChanges(message.changes);
           const preLoadWriterCount = (await this._writers.users()).length;
           if (preLoadWriterCount === 0 && message.snapshot) {
@@ -2757,6 +2773,77 @@ export class CollabswarmDocument<
             );
             message.snapshot = undefined;
           }
+
+          // Snapshot-only first-load detection: after the snapshot drop
+          // above, if the response now carries NO changes tree AND NO
+          // snapshot, the responder served us nothing usable. Without
+          // this guard the path falls through to `sync(message, false)`
+          // (which returns `true` for a vacuously-empty message because
+          // there is nothing to merge / reject) and this method reports
+          // success — `load()` then returns `true` with neither state
+          // applied nor an opportunity to retry. Treat as a per-peer
+          // bind failure so the agreeing-cohort load loop tries the
+          // next peer (which may serve a real changes tree). See
+          // PR #284 r18 Copilot review.
+          if (
+            message.changes === undefined &&
+            message.snapshot === undefined
+          ) {
+            console.warn(
+              `[${this.documentPath}] Quorum-bound first-load response ` +
+                `carries neither a changes tree nor a snapshot after the ` +
+                `defensive snapshot drop. Treating as bind failure so the ` +
+                `loader tries the next agreeing peer.`,
+            );
+            throw new _QuorumBindCheckFailedError(
+              '(snapshot-only first-load)',
+              `Quorum-bound first-load response had only a snapshot (now ` +
+                `dropped because writers are not yet populated) and no ` +
+                `changes tree; no state can be applied.`,
+            );
+          }
+
+          const syncResult = await this.sync(message, false);
+          if (!syncResult) {
+            console.warn(
+              `sync rejected message during load for ${this.documentPath}`,
+            );
+            // Return false so the caller tries the next peer.
+            return false;
+          }
+
+          // Post-sync verification (PR #284 r18 Copilot review): every
+          // CID we expected from the (stripped) served tree must have
+          // landed in `_hashes` via either inline application (for the
+          // non-stripped path this branch never reaches) or via the
+          // `_getBlock(cid)` Helia fetch path inside
+          // `_syncDocumentChanges`. A missing CID means bitswap could
+          // not retrieve that block; without surfacing this the load
+          // would silently report success with a partial document.
+          const missingCids: string[] = [];
+          for (const cid of expectedCids) {
+            if (!this._hashes.has(cid)) missingCids.push(cid);
+          }
+          if (missingCids.length > 0) {
+            console.warn(
+              `[${this.documentPath}] Quorum-bound load did not complete: ` +
+                `${missingCids.length} of ${expectedCids.length} expected ` +
+                `CIDs were not fetched from Helia (e.g. ${missingCids
+                  .slice(0, 3)
+                  .map((c) => c.slice(0, 12) + '...')
+                  .join(', ')}). Recording peer as bind-failed so the ` +
+                `loader tries the next agreeing peer.`,
+            );
+            throw new _QuorumBindCheckFailedError(
+              '(missing-blocks)',
+              `Quorum-bound load completed sync() but ${missingCids.length} ` +
+                `of ${expectedCids.length} expected CIDs were not retrievable; ` +
+                `served tree had stripped inline content and bitswap could ` +
+                `not retrieve the missing blocks.`,
+            );
+          }
+
+          return true;
         }
 
         const syncResult = await this.sync(message, false);

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -218,6 +218,25 @@ export type CollabswarmDocumentChangeHandler<DocType, PublicKey> = (
 const MAX_TIP_ADVERTISE_RESPONSE_SIZE = 6 * 1024;
 
 /**
+ * Bound on the number of parallel Helia `blockstore.get(cid)` fetches
+ * issued by the quorum-bound load pre-fetch (`_sendLoadRequestAndSync`).
+ *
+ * A bound is needed because the served `changes` tree can be large
+ * under an adversary-shaped response (the agreeing peer voted for the
+ * expected frontier but stuffed the tree with many additional CIDs that
+ * must still be retrieved to satisfy the post-sync coverage check).
+ * Without a cap, the prefetch would issue every fetch in parallel and
+ * each fetch holds a libp2p bitswap stream + buffers the retrieved
+ * payload via `readUint8Iterable`; for very large responses this can
+ * exhaust per-connection stream quotas and pressure memory. The cap is
+ * chosen large enough to overlap WAN-latency-bound bitswap fetches and
+ * keep the load fast (8 inflight is comfortably more than typical mesh
+ * peer counts) but small enough to bound peak resource use on the
+ * loader. See PR #284 r24 Copilot review.
+ */
+const LOAD_PREFETCH_MAX_CONCURRENCY = 8;
+
+/**
  * Module-private sentinel thrown by `_sendLoadRequestAndSync` when the
  * quorum frontier binding check fails on a single peer's load response
  * (either the responder omitted `tips` or the served `tips` hashed to a
@@ -2822,28 +2841,48 @@ export class CollabswarmDocument<
           // `bind-check-failed-all-agreeing-peers` if every peer
           // exhausts.
           //
-          // Run in parallel via `Promise.allSettled` so a single slow
-          // peer cannot pessimize the load. Block bytes are cached
-          // locally on success; the subsequent `sync()` call only does
-          // local lookups for those CIDs and applies them.
+          // Run via a bounded worker pool so a single slow peer cannot
+          // pessimize the load AND a large load response (many CIDs)
+          // cannot trigger a burst of parallel `blockstore.get()` fetches
+          // that exhaust libp2p/Helia per-connection stream quotas or
+          // pressure memory by buffering N inline payloads at once. The
+          // previous implementation used `Promise.allSettled` over the
+          // full `expectedCids` list with no concurrency cap, which
+          // worked fine for typical loads but scaled linearly with the
+          // worst-case adversary-shaped response. `LOAD_PREFETCH_MAX_CONCURRENCY`
+          // (8) is a balance: large enough to overlap WAN-latency-bound
+          // bitswap fetches, small enough to bound peak resource use on
+          // the loader. Block bytes are cached locally on success; the
+          // subsequent `sync()` call only does local lookups for those
+          // CIDs and applies them. See PR #284 r24 Copilot review.
           if (expectedCids.length > 0) {
-            const prefetchResults = await Promise.allSettled(
-              expectedCids.map(async (cidStr) => {
-                const cid = CID.parse(cidStr);
-                // Force the blockstore to retrieve the block. Helia
-                // validates content vs CID on `get`; the read of the
-                // returned async-iterable triggers the actual fetch.
-                await readUint8Iterable(
-                  this.swarm.heliaNode.blockstore.get(cid),
-                );
-              }),
-            );
             const missingCids: string[] = [];
-            for (let i = 0; i < prefetchResults.length; i++) {
-              if (prefetchResults[i]!.status === 'rejected') {
-                missingCids.push(expectedCids[i]!);
+            let nextIndex = 0;
+            const workerCount = Math.min(
+              LOAD_PREFETCH_MAX_CONCURRENCY,
+              expectedCids.length,
+            );
+            const worker = async (): Promise<void> => {
+              while (true) {
+                const i = nextIndex++;
+                if (i >= expectedCids.length) return;
+                const cidStr = expectedCids[i]!;
+                try {
+                  const cid = CID.parse(cidStr);
+                  // Force the blockstore to retrieve the block. Helia
+                  // validates content vs CID on `get`; reading the
+                  // returned async-iterable triggers the actual fetch.
+                  await readUint8Iterable(
+                    this.swarm.heliaNode.blockstore.get(cid),
+                  );
+                } catch {
+                  missingCids.push(cidStr);
+                }
               }
-            }
+            };
+            await Promise.all(
+              Array.from({ length: workerCount }, () => worker()),
+            );
             if (missingCids.length > 0) {
               console.warn(
                 `[${this.documentPath}] Quorum-bound load pre-fetch ` +

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -2281,10 +2281,12 @@ export class CollabswarmDocument<
     stream: { sink: (data: Iterable<Uint8Array>) => Promise<void> },
   ): Promise<void> {
     try {
-      console.log(
-        `received tip-advertise request for ${this.documentPath}:`,
-        message,
-      );
+      // Tip-advertise runs on every `open()` from every peer that opens
+      // this document, so a per-request log line scales with mesh size.
+      // Drop the unconditional log entirely; the only field the handler
+      // would have logged is attacker-controlled (`message`), and the
+      // mismatch/unauthorized branches below already emit targeted
+      // warnings when they fail. See PR #284 r27 Copilot review.
 
       if (message.documentId !== this.documentPath) {
         console.warn(

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -2180,8 +2180,8 @@ export class CollabswarmDocument<
       const snapshotMessage = this._createSyncMessage();
       snapshotMessage.snapshot = this._latestSnapshot;
       snapshotMessage.keychainChanges = await this._keychainChangesForVisibility();
-      // Tip-set advertisement for the post-load binding check (see the
-      // doc-load handler above and the in-line check in
+      // Tip-set advertisement for the pre-apply structural binding check
+      // (see the doc-load handler above and the in-line check in
       // `_sendLoadRequestAndSync` for the rationale).
       //
       // PR #284 r8: this is the *served* frontier (`_servedFrontier()`)
@@ -2719,17 +2719,31 @@ export class CollabswarmDocument<
 
   /**
    * Send a single `tipAdvertiseV1` probe to one peer and decrypt the
-   * response to extract the peer's `tipsHash`. Returns `null` for any
-   * non-vote outcome: empty/declined response, decryption failure with an
-   * unknown key (peer has a different keychain), missing/invalid signature,
-   * deserialization failure, document-id mismatch, missing/short tip hash,
-   * or thrown errors. Timeouts are handled at the caller level via
-   * Promise.race.
+   * response to extract the peer's `tipsHash`. Returns one of:
    *
-   * Returns `null` rather than throwing so the caller can record this
-   * peer as a non-vote (NOT a disagreement) and `decideLoadQuorum` can
-   * apply the correct quorum semantics. See `load-quorum.ts` for the
-   * timeout-vs-disagreement distinction.
+   *   - `Uint8Array` -- the peer's advertised `tipsHash` (32 bytes).
+   *   - `'unknown-doc'` -- the peer explicitly disclaimed the document
+   *     (returned the 1-byte `0xFF` UNKNOWN_DOC sentinel). This is the
+   *     signal `Collabswarm.tipAdvertiseHandler` emits when no document
+   *     is registered for the requested path. Distinguishing this from
+   *     `null` lets the orchestrator tally `'unknown-doc'` exactly like
+   *     a tip-hash vote so that when a Q-of-K majority of peers all
+   *     disclaim the document, `load()` returns `false` to let a fresh
+   *     `open()` create the document on top of an existing swarm. The
+   *     previous design returned `null` for the unknown-doc case, which
+   *     was indistinguishable from a partition / timeout and made
+   *     new-document creation in an existing mesh fail with
+   *     `LoadQuorumFailedError`. See PR #284 r16 Copilot review.
+   *   - `null` -- any other non-vote outcome: empty response, decryption
+   *     failure with an unknown key (peer has a different keychain),
+   *     missing/invalid signature, deserialization failure, document-id
+   *     mismatch, missing/short tip hash, or thrown errors. Timeouts are
+   *     handled at the caller level via Promise.race.
+   *
+   * Returns rather than throws so the caller can record this peer as a
+   * non-vote (NOT a disagreement) and `decideLoadQuorum` can apply the
+   * correct quorum semantics. See `load-quorum.ts` for the
+   * timeout-vs-disagreement-vs-unknown-doc distinction.
    *
    * @internal
    */
@@ -2737,7 +2751,7 @@ export class CollabswarmDocument<
     peer: import('@multiformats/multiaddr').Multiaddr,
     serializedRequest: Uint8Array,
     signal?: AbortSignal,
-  ): Promise<Uint8Array | null> {
+  ): Promise<Uint8Array | 'unknown-doc' | null> {
     // Capture the underlying v3 Stream so the abort path below can call
     // `abort()` on it directly (the wrapped DuplexStream only exposes the
     // write-side half-close via `close()`, not a full bidirectional tear-
@@ -2804,8 +2818,22 @@ export class CollabswarmDocument<
         MAX_TIP_ADVERTISE_RESPONSE_SIZE,
       );
       if (assembled.length === 0) {
-        // Peer declined (unknown doc, unauthorized, etc.).
+        // Peer declined (unauthorized, decryption failure, document-id
+        // mismatch, etc.). Distinct from the 1-byte UNKNOWN_DOC sentinel
+        // handled below, which signals "I don't have this document at all"
+        // (a distinguishable case used to let new-doc creation succeed
+        // in an existing swarm; see method docstring).
         return null;
+      }
+      // 1-byte UNKNOWN_DOC sentinel response: `Collabswarm.tipAdvertiseHandler`
+      // emits this when no document is registered for the requested path.
+      // The orchestrator counts these toward a separate "unknown-doc"
+      // tally so a Q-of-K majority of disclaims becomes a clean
+      // new-doc-creation signal rather than a `LoadQuorumFailedError`.
+      // See `_probeTipAdvertise`'s docstring and PR #284 r16 Copilot
+      // review for the rationale.
+      if (assembled.length === 1 && assembled[0] === 0xff) {
+        return 'unknown-doc';
       }
       const headerLength = this._keychainProvider.keyIDLength + this._authProvider.nonceBits;
       if (assembled.length <= headerLength) {
@@ -2910,7 +2938,7 @@ export class CollabswarmDocument<
     peer: import('@multiformats/multiaddr').Multiaddr,
     serializedRequest: Uint8Array,
     timeoutMs: number,
-  ): Promise<Uint8Array | null> {
+  ): Promise<Uint8Array | 'unknown-doc' | null> {
     const controller = new AbortController();
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<null>((resolve) => {
@@ -3123,28 +3151,32 @@ export class CollabswarmDocument<
     // behaviour.
     //
     // `winningHashHex` (set when quorum passes) is also used below as the
-    // per-peer binding check inside `_sendLoadRequestAndSync`: BEFORE
-    // applying the served state, the loader derives the served frontier
-    // structurally from the responder's payload via
-    // `computeServedFrontier(message.changeId, message.changes,
-    // message.snapshot?.lastChangeNodeCID)`, hashes it, and compares to
-    // `winningHashHex`. If they disagree, an agreeing peer voted for one
-    // tip set and served a different one (Byzantine equivocation): the
-    // peer is recorded as a bind failure and the loader retries the next
-    // agreeing peer without ever mutating in-memory state. The check is
-    // intentionally derived from the served payload (not post-sync
-    // `_hashes`) so a Byzantine peer cannot poison the in-memory document
-    // before the binding decision is made. See PR #284 r7 Copilot review.
+    // per-peer binding check inside `_sendLoadRequestAndSync`. The check
+    // is purely structural and runs BEFORE the served state is applied:
+    // the loader hashes `computeServedFrontier(message.changeId,
+    // message.changes, message.snapshot?.lastChangeNodeCID)` and compares
+    // to `winningHashHex`. If they disagree, an agreeing peer voted for
+    // one tip set and served a different one (Byzantine equivocation):
+    // the peer is recorded as a bind failure and the loader retries the
+    // next agreeing peer without ever mutating in-memory state. The
+    // pre-apply ordering is the load-bearing property -- a Byzantine peer
+    // cannot poison the in-memory document because the bind decision
+    // happens before `sync()` runs. See PR #284 r7 Copilot review.
     // NOTE: previously this block bypassed the gate when `_hashes.size === 0`
     // on the assumption it identified a "founding-member" brand-new document.
     // That bypass was unsafe: `_hashes` is ALSO empty on the first `open()`
     // of an EXISTING document (before load populates it), which is exactly
     // the case the gate is meant to protect. We no longer special-case empty
-    // local state; the gate runs uniformly. True founders (no peers in the
-    // mesh) are handled by the `peers.length === 0` short-circuit at the top
-    // of `load()` plus the `k === 0` branch inside `runLoadQuorum` (which
-    // returns `{ skipped: true }` → we fall through to the legacy "no peer
-    // could provide the document" path and return false).
+    // local state; the gate runs uniformly. New-document creation in an
+    // EXISTING swarm is handled by the `'unknown-doc'` probe sentinel: each
+    // peer that does not have the document responds with the 1-byte UNKNOWN_DOC
+    // marker (see `Collabswarm.tipAdvertiseHandler`), the orchestrator tallies
+    // these alongside tip-hash votes, and a Q-of-K majority of disclaims
+    // surfaces as `{ newDoc: true }` here -- the loader returns `false` and
+    // `open()` proceeds to create the doc fresh. True founders (no peers in
+    // the mesh) are still handled by the `peers.length === 0` short-circuit
+    // at the top of `load()` plus the `k === 0` branch inside `runLoadQuorum`
+    // (which returns `{ skipped: true }`). See PR #284 r16 Copilot review.
     //
     // The K-of-Q decision logic itself lives in `runLoadQuorum`
     // (`load-quorum-orchestrator.ts`) so the orchestration can be unit-tested
@@ -3197,6 +3229,15 @@ export class CollabswarmDocument<
       }
       // Else: gate disabled. Fall through with the original (un-deduped)
       // `orderedPeers` so the legacy loop can retry per-multiaddr.
+    } else if ('newDoc' in quorumResult) {
+      // A Q-of-K majority of probed peers explicitly disclaimed the
+      // document via the `'unknown-doc'` sentinel. Return `false` so
+      // `open()` can create the document fresh on top of the existing
+      // swarm. Without this branch, the previous design conflated
+      // unknown-doc with partition / timeout and surfaced
+      // `LoadQuorumFailedError` -- preventing new-document creation in
+      // any swarm with online peers. See PR #284 r16 Copilot review.
+      return false;
     } else {
       winningHashHex = quorumResult.winningHashHex;
       // Quorum succeeded: narrow the load loop to the agreeing cohort.

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -2490,14 +2490,19 @@ export class CollabswarmDocument<
         // of what was actually served. We then hash that frontier and
         // compare to `winningHashHex`.
         //
-        // We additionally verify `message.tips`, when present,
-        // matches the structurally-derived served frontier as a
-        // defense-in-depth check: a peer whose `tips` attestation
-        // contradicts their own served payload is misbehaving even if
-        // the served-frontier hash happens to match the quorum vote
-        // (e.g. if they tried to claim extra heads in `tips`). This
-        // catches the responder-equivocation mode where `tips` and
-        // `changes` were assembled inconsistently.
+        // We additionally REQUIRE `message.tips` on every v3 quorum-
+        // enabled load response (PR #284 r9 Copilot review, issue #1).
+        // The v3 load-response contract mandates the responder commit
+        // to an explicit frontier attestation; a responder that omits
+        // `tips` is recorded as a per-peer bind failure so the loader
+        // retries the next agreeing peer. The structural check above
+        // is the primary defense; the explicit `tips` requirement
+        // ensures protocol compliance AND that the defense-in-depth
+        // check below (verifying `tips` matches the structurally-
+        // derived served frontier) actually runs. Catches the
+        // responder-equivocation mode where `tips` and `changes` were
+        // assembled inconsistently — e.g. a peer that claims extra
+        // heads in `tips` that are not present in the served tree.
         //
         // Throws the module-private `_QuorumBindCheckFailedError` on
         // mismatch so the surrounding `load()` loop can record this
@@ -2536,28 +2541,53 @@ export class CollabswarmDocument<
                 `${expectedTipsHashHex.slice(0, 12)}... got ${servedHex.slice(0, 12)}...`,
             );
           }
-          // Defense-in-depth: if the responder included `tips`, it
-          // must hash to the same value as the structurally-derived
-          // served frontier. A peer whose attested `tips` contradicts
-          // their own served payload (e.g. claims extra heads that
-          // are not present in the served tree) is misbehaving.
-          if (Array.isArray(message.tips)) {
-            const advertisedBytes = await tipsHash(message.tips);
-            const advertisedHex = tipsHashToHex(advertisedBytes);
-            if (!constantTimeHexEquals(servedHex, advertisedHex)) {
-              console.warn(
-                `[${this.documentPath}] Quorum frontier binding FAILED: ` +
-                  `served payload frontier hashes to ${servedHex.slice(0, 12)}... ` +
-                  `but responder advertised tips hashing to ${advertisedHex.slice(0, 12)}.... ` +
-                  `Responder's own attestation contradicts the served payload.`,
-              );
-              throw new _QuorumBindCheckFailedError(
-                advertisedHex,
-                `Quorum frontier binding mismatch (advertised vs served): ` +
-                  `advertised ${advertisedHex.slice(0, 12)}... served ` +
-                  `${servedHex.slice(0, 12)}...`,
-              );
-            }
+          // Protocol compliance: under the v3 load-response contract,
+          // a quorum-enabled load REQUIRES `message.tips` to be present
+          // on the response so the responder commits to an explicit
+          // frontier attestation alongside the served payload. The
+          // structural-frontier check above is the primary defense; this
+          // explicit `Array.isArray(message.tips)` guard ensures a v3
+          // responder that omits `tips` is recorded as a per-peer bind
+          // failure (so the loader retries the NEXT agreeing peer)
+          // rather than silently passing on the structural-hash check
+          // alone. Without this guard, a responder could violate the
+          // protocol contract — and a defense-in-depth check that
+          // catches contradictions between `tips` and the served payload
+          // would never run because the `Array.isArray` branch would
+          // simply skip. See PR #284 r9 Copilot review (issue #1).
+          if (!Array.isArray(message.tips)) {
+            console.warn(
+              `[${this.documentPath}] Quorum frontier binding FAILED: ` +
+                `quorum-enabled load response omitted required \`tips\` ` +
+                `attestation (v3 protocol violation). Recording peer as ` +
+                `bind-failed; loader will try the next agreeing peer.`,
+            );
+            throw new _QuorumBindCheckFailedError(
+              '(missing tips)',
+              `Quorum frontier binding: responder omitted required \`tips\` ` +
+                `attestation on v3 quorum-enabled load response.`,
+            );
+          }
+          // Defense-in-depth: the responder-supplied `tips` must hash
+          // to the same value as the structurally-derived served
+          // frontier. A peer whose attested `tips` contradicts their
+          // own served payload (e.g. claims extra heads that are not
+          // present in the served tree) is misbehaving.
+          const advertisedBytes = await tipsHash(message.tips);
+          const advertisedHex = tipsHashToHex(advertisedBytes);
+          if (!constantTimeHexEquals(servedHex, advertisedHex)) {
+            console.warn(
+              `[${this.documentPath}] Quorum frontier binding FAILED: ` +
+                `served payload frontier hashes to ${servedHex.slice(0, 12)}... ` +
+                `but responder advertised tips hashing to ${advertisedHex.slice(0, 12)}.... ` +
+                `Responder's own attestation contradicts the served payload.`,
+            );
+            throw new _QuorumBindCheckFailedError(
+              advertisedHex,
+              `Quorum frontier binding mismatch (advertised vs served): ` +
+                `advertised ${advertisedHex.slice(0, 12)}... served ` +
+                `${servedHex.slice(0, 12)}...`,
+            );
           }
         }
 

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -865,48 +865,49 @@ export class CollabswarmDocument<
   }
 
   /**
-   * Returns this peer's current frontier as a plain string[] of CIDs —
-   * "what tips would I advertise to a fresh `tipAdvertiseV1` probe right
-   * now".
+   * Returns this peer's structural local-DAG frontier as a plain
+   * string[] of CIDs -- the heads of EVERYTHING this peer has seen.
+   *
+   * NOTE: this is NOT the value advertised in a `tipAdvertiseV1` probe
+   * and NOT the value the responder commits to on a v3 load response.
+   * Both of those use `_servedFrontier()` instead -- the heads of the
+   * change tree this peer can actually ship in a single load round.
+   * See `_servedFrontier()`'s docstring for why the two differ (short
+   * version: a load response only carries the tree rooted at
+   * `_lastSyncMessage.changeId`, so concurrent local heads that aren't
+   * cross-linked into that tree don't appear in what's served).
+   *
+   * `_currentFrontier()` is retained for callers that need the
+   * structural truth of "what heads do I have locally?" rather than
+   * "what would I advertise / serve?":
+   *
+   *   - `_makeChange()` cross-link selection (so a new local change
+   *     can reference concurrent remote heads that landed since the
+   *     last cached sync message).
+   *   - Diagnostics / introspection paths.
    *
    * The frontier is the set of heads of the local merged-changes DAG:
-   * CIDs that this peer has seen but that no other change references as
-   * a parent or cross-link target. Computed as `_hashes \
-   * _referencedAncestors`. See the `_referencedAncestors` field docstring
-   * for why this matters: it is the part of the local DAG that converges
-   * across honest peers regardless of differing sync histories or pruning
-   * levels, so two peers in the same logical state produce identical
-   * `tipsHash` digests.
-   *
-   * Returning the full `_hashes` set (the prior buggy implementation)
-   * silently breaks the initial-load quorum gate -- it includes every
-   * referenced ancestor, so two honest peers with the same heads but
-   * differing ancestor visibility (e.g. one loaded from a snapshot, the
-   * other has the full history) produce different tip-set hashes and
-   * fail quorum even though they agree on state.
+   * CIDs that this peer has seen but that no other change references
+   * as a parent or cross-link target. Computed as `_hashes \
+   * _referencedAncestors`. See the `_referencedAncestors` field
+   * docstring for why this matters: it is the part of the local DAG
+   * that converges across honest peers regardless of differing sync
+   * histories or pruning levels.
    *
    * Edge cases:
    *   - Empty DAG (founding member, brand-new document): `_hashes` is
-   *     empty, the returned frontier is `[]`. `tipsHash([])` is the
-   *     SHA-256 of the empty string, a deterministic value all honest
-   *     peers compute identically -- quorum cleanly bootstraps.
-   *   - Just-loaded from snapshot: `_hashes` holds the snapshot boundary
-   *     CID (and any post-snapshot changes). The boundary CID is NOT in
-   *     `_referencedAncestors` (no in-tree node points back through it),
-   *     so it correctly appears as a head along with any post-snapshot
-   *     leaves -- which is exactly what the responder would serve.
+   *     empty, the returned frontier is `[]`.
+   *   - Just-loaded from snapshot: `_hashes` holds the snapshot
+   *     boundary CID (and any post-snapshot changes). The boundary CID
+   *     is NOT in `_referencedAncestors`, so it correctly appears as a
+   *     head.
    *   - Pruned ancestors: irrelevant. Pruning removes CIDs from the
    *     in-memory change tree but leaves them in `_hashes` for dedup;
-   *     they were already in `_referencedAncestors` (recorded when the
-   *     tree contained them), so they remain marked as non-heads.
+   *     they were already in `_referencedAncestors`, so they remain
+   *     marked as non-heads.
    *
-   * Wrapped in a helper so the load-response handlers
-   * (`handleLoadRequestData`, `handleSnapshotLoadRequestData`) and the
-   * tip-advertise handler (`handleTipAdvertiseRequestData`) all hit the
-   * same canonical primitive -- the probe-then-load round-trip binds
-   * against a byte-identical tip set. Returns a fresh array so callers
-   * can't mutate internal state; `tipsHash` sorts independently, so we
-   * don't sort here.
+   * Returns a fresh array so callers can't mutate internal state;
+   * `tipsHash` sorts independently, so we don't sort here.
    *
    * @internal
    */
@@ -3122,10 +3123,18 @@ export class CollabswarmDocument<
     // behaviour.
     //
     // `winningHashHex` (set when quorum passes) is also used below as the
-    // post-load binding check: after `_sendLoadRequestAndSync` applies the
-    // served state, the recomputed `tipsHash(this._hashes)` MUST equal
-    // `winningHashHex`, otherwise an agreeing peer voted for one tip set and
-    // served a different one (Byzantine equivocation).
+    // per-peer binding check inside `_sendLoadRequestAndSync`: BEFORE
+    // applying the served state, the loader derives the served frontier
+    // structurally from the responder's payload via
+    // `computeServedFrontier(message.changeId, message.changes,
+    // message.snapshot?.lastChangeNodeCID)`, hashes it, and compares to
+    // `winningHashHex`. If they disagree, an agreeing peer voted for one
+    // tip set and served a different one (Byzantine equivocation): the
+    // peer is recorded as a bind failure and the loader retries the next
+    // agreeing peer without ever mutating in-memory state. The check is
+    // intentionally derived from the served payload (not post-sync
+    // `_hashes`) so a Byzantine peer cannot poison the in-memory document
+    // before the binding decision is made. See PR #284 r7 Copilot review.
     // NOTE: previously this block bypassed the gate when `_hashes.size === 0`
     // on the assumption it identified a "founding-member" brand-new document.
     // That bypass was unsafe: `_hashes` is ALSO empty on the first `open()`

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -920,6 +920,75 @@ export class CollabswarmDocument<
   }
 
   /**
+   * Returns the frontier this peer would *advertise as part of a load
+   * response* -- the heads of the change tree this peer can actually ship
+   * in a single `documentLoadV3` / `snapshotLoadV3` round.
+   *
+   * # Why this is NOT the same as `_currentFrontier()`
+   *
+   * `_currentFrontier()` returns the heads of the local DAG (`_hashes \
+   * _referencedAncestors`) -- the structural truth of EVERYTHING this peer
+   * has seen. That set is the right answer for "what is the logical state
+   * of my local document?", but it is the WRONG answer for "what hash
+   * should I advertise in a `tipAdvertiseV1` probe?".
+   *
+   * A load response only carries ONE change tree (rooted at
+   * `_lastSyncMessage.changeId`), plus optionally `_latestSnapshot` --
+   * `_lastSyncMessage` is only refreshed by `_makeChange()`, so its tree
+   * is rooted at *this peer's* last locally-produced change. Remote
+   * changes broadcast over GossipSub are applied to local CRDT state and
+   * recorded in `_hashes`, but they do NOT become roots of
+   * `_lastSyncMessage.changes` until this peer makes its next local
+   * change (which cross-links them via `selectCrossLinks`).
+   *
+   * So when a peer has multiple concurrent heads (e.g. its own last local
+   * change H1 plus remotely-applied changes H2, H3 that aren't yet
+   * cross-linked from any local change), `_currentFrontier()` returns
+   * `{H1, H2, H3}` but the load response only contains H1's subtree.
+   * Round 8 of the PR #284 Copilot review caught the resulting
+   * inconsistency: the tip-advertise probe would hash `{H1, H2, H3}` and
+   * win the quorum vote, but the served payload's structural frontier
+   * (`computeServedFrontier(...)` on the loader side) hashes only `{H1}`,
+   * causing the loader's bind check to reject the honest peer.
+   *
+   * # What this returns
+   *
+   * The heads of the served payload, computed via `computeServedFrontier`
+   * over EXACTLY the same inputs the load response will carry:
+   *   - `_lastSyncMessage?.changeId` -- root CID of the served tree (if any);
+   *   - `_lastSyncMessage?.changes` -- the served tree itself (if any);
+   *   - `_latestSnapshot?.lastChangeNodeCID` -- snapshot boundary CID (if any).
+   *
+   * This mirrors the loader's `_sendLoadRequestAndSync` binding check:
+   * both sides hash the structurally-derived served frontier, so an
+   * honest responder advertises a hash the loader can reproduce from the
+   * payload it received. Two honest peers in the same logical state with
+   * the same `_lastSyncMessage` / `_latestSnapshot` advertise the same
+   * hash regardless of any unrelated concurrent heads they happen to be
+   * holding in `_currentFrontier()`.
+   *
+   * # Trade-off (acknowledged)
+   *
+   * The quorum no longer verifies that a responder has all of its
+   * logical heads -- only the ones it would actually serve. A peer with
+   * un-served concurrent heads can pass quorum on the subset it ships
+   * via load. This matches the existing load semantics (the load only
+   * ever ships what `_lastSyncMessage` covers anyway) and is reconciled
+   * by post-load GossipSub sync; the alternative (Option B in the design
+   * notes) would require the load response itself to carry every head's
+   * subtree, a larger protocol change. See PR #284 r8 review.
+   *
+   * @internal
+   */
+  private _servedFrontier(): string[] {
+    return computeServedFrontier(
+      this._lastSyncMessage?.changeId,
+      this._lastSyncMessage?.changes,
+      this._latestSnapshot?.lastChangeNodeCID,
+    );
+  }
+
+  /**
    * Record a CID as a recently-known tip for Merkle-CRDT cross-linking
    * (paper §VI.B.e). Called for both locally-generated and remote-applied
    * change nodes -- a peer A that just received B's change can cross-link
@@ -1854,7 +1923,7 @@ export class CollabswarmDocument<
 
       // Attach an explicit tip-set advertisement so the loader can apply
       // a defense-in-depth consistency check against this responder's
-      // self-attested current frontier (issue #186 / #189 §5.4.2).
+      // self-attested served frontier (issue #186 / #189 §5.4.2).
       //
       // NOTE: as of PR #284 r7, the loader's PRIMARY binding is derived
       // STRUCTURALLY from the served `changes`/`snapshot` payload via
@@ -1865,18 +1934,21 @@ export class CollabswarmDocument<
       // ALSO verifies that the responder's own attestation hashes to
       // the same value as the structurally-derived served frontier --
       // a peer whose `tips` contradicts their own served payload is
-      // caught at the secondary check. `_currentFrontier()` remains
-      // the canonical helper used by ALL three protocols
-      // (tip-advertise, doc-load, snapshot-load) so an honest
-      // responder advertises the same frontier across the probe and
-      // the load round. The frontier is `_hashes \
-      // _referencedAncestors` -- the heads of the local DAG -- which
-      // converges across honest peers even when their full `_hashes`
-      // cardinality differs (e.g. one loaded from a snapshot, the
-      // other has the full ancestor history). This field is part of
-      // the SIGNED v3 payload; see `wire-protocols.ts` for the
-      // version-bump rationale.
-      loadMessage.tips = this._currentFrontier();
+      // caught at the secondary check.
+      //
+      // PR #284 r8: `tips` is now the *served* frontier
+      // (`_servedFrontier()`) -- i.e. the heads of the change tree this
+      // load response actually carries -- NOT the full local DAG
+      // frontier (`_currentFrontier()`). The two differ when this peer
+      // has multiple concurrent heads but `_lastSyncMessage` only roots
+      // at one of them (the load wire shape only ships a single tree).
+      // The tip-advertise handler hashes the same served frontier, so
+      // the probe and the load round bind against a byte-identical tip
+      // set even when the responder is holding remotely-applied heads
+      // that aren't yet cross-linked into `_lastSyncMessage.changes`.
+      // This field is part of the SIGNED v3 payload; see
+      // `wire-protocols.ts` for the version-bump rationale.
+      loadMessage.tips = this._servedFrontier();
 
       // Sign new message.
       loadMessage.signature = await this._signAsWriter(loadMessage);
@@ -1997,14 +2069,19 @@ export class CollabswarmDocument<
       snapshotMessage.keychainChanges = await this._keychainChangesForVisibility();
       // Tip-set advertisement for the post-load binding check (see the
       // doc-load handler above and the in-line check in
-      // `_sendLoadRequestAndSync` for the rationale). `_currentFrontier()`
-      // returns the heads of the local DAG (`_hashes \
-      // _referencedAncestors`), which is the convergent quantity across
-      // honest peers regardless of whether either side loaded from a
-      // snapshot or replayed the full history. Part of the signed v3
-      // payload -- the version bump (snapshotLoadV2 -> snapshotLoadV3)
-      // is required because `tips` is now covered by the writer signature.
-      snapshotMessage.tips = this._currentFrontier();
+      // `_sendLoadRequestAndSync` for the rationale).
+      //
+      // PR #284 r8: this is the *served* frontier (`_servedFrontier()`)
+      // -- the heads of the served payload (`_lastSyncMessage.changes`
+      // tree plus the snapshot boundary) -- NOT the full local DAG
+      // frontier (`_currentFrontier()`). When this peer holds concurrent
+      // heads that `_lastSyncMessage` does not yet root over, the
+      // load response only carries one head's subtree, so the
+      // advertised `tips` must match that subset to satisfy the
+      // loader's structural bind check. Part of the signed v3 payload
+      // -- the version bump (snapshotLoadV2 -> snapshotLoadV3) is
+      // required because `tips` is now covered by the writer signature.
+      snapshotMessage.tips = this._servedFrontier();
       snapshotMessage.signature = await this._signAsWriter(snapshotMessage);
 
       const serialized =
@@ -2122,14 +2199,31 @@ export class CollabswarmDocument<
         return;
       }
 
-      // Compute the canonical tip-set hash from the document's current
-      // frontier — the same source load responses use for the `tips` field
-      // (see `handleLoadRequestData` / `handleSnapshotLoadRequestData`),
-      // so a probe-then-load round-trip from this responder always binds
-      // against a consistent advertisement. Two peers with the same view
+      // Compute the canonical tip-set hash from the document's *served*
+      // frontier — the heads of the payload this peer would actually ship
+      // in a `documentLoadV3` / `snapshotLoadV3` round (computed via
+      // `computeServedFrontier` over `_lastSyncMessage.changes` plus
+      // `_latestSnapshot?.lastChangeNodeCID`, the exact same sources
+      // `handleLoadRequestData` / `handleSnapshotLoadRequestData` populate
+      // into the load response).
+      //
+      // PR #284 r8: this used to hash `_currentFrontier()` -- the full
+      // local DAG frontier (`_hashes \ _referencedAncestors`). That
+      // produces a hash an honest peer cannot bind against if it holds
+      // multiple concurrent heads: `_currentFrontier()` returns every
+      // head (including remotely-applied tips not yet cross-linked into
+      // `_lastSyncMessage.changes`), but the load response only carries
+      // one head's tree, so the loader's structural derivation of the
+      // served frontier produces a different (smaller) set. Hashing the
+      // served frontier here closes that gap -- a probe-then-load
+      // round-trip from this responder always binds against a
+      // byte-identical tip set. See `_servedFrontier()` for the
+      // full rationale.
+      //
+      // Two peers with the same `_lastSyncMessage` / `_latestSnapshot`
       // produce byte-identical hashes; see `tips-hash.ts` for the
       // canonicalization (sort + `\n` separator + SHA-256).
-      const hash = await tipsHash(this._currentFrontier());
+      const hash = await tipsHash(this._servedFrontier());
 
       const advertisement: CRDTSyncMessage<ChangesType, PublicKey> = {
         documentId: this.documentPath,

--- a/packages/collabswarm/src/collabswarm-document.ts
+++ b/packages/collabswarm/src/collabswarm-document.ts
@@ -213,6 +213,41 @@ export type CollabswarmDocumentChangeHandler<DocType, PublicKey> = (
  */
 const MAX_TIP_ADVERTISE_RESPONSE_SIZE = 6 * 1024;
 
+/**
+ * Module-private sentinel thrown by `_sendLoadRequestAndSync` when the
+ * quorum frontier binding check fails on a single peer's load response
+ * (either the responder omitted `tips` or the served `tips` hashed to a
+ * value other than the agreed `winningHashHex`). Caught by the `load()`
+ * loop, which records the failure against the responsible peer and
+ * proceeds to the NEXT peer in the agreeing cohort.
+ *
+ * Critical to the DoS fix from PR #284 r6: previously
+ * `_sendLoadRequestAndSync` threw `LoadQuorumFailedError` on bind
+ * mismatch and `load()` re-raised it, aborting the entire load. A
+ * single malicious peer in the agreeing cohort could vote for the
+ * majority hash (passing quorum) and then serve a mismatched full load
+ * (failing the bind check), unilaterally preventing the loader from
+ * trying any other honest agreeing peer.
+ *
+ * Public callers never see this type; `load()` catches it internally
+ * and only escalates to `LoadQuorumFailedError(reason:
+ * 'bind-check-failed-all-agreeing-peers')` once EVERY peer in the
+ * narrowed cohort has bind-failed.
+ *
+ * The `advertisedHex` field carries the hash the responder's served
+ * `tips` actually hashed to (or the sentinel `'(missing tips)'` when the
+ * response omitted the `tips` field entirely) so the outer loop can
+ * thread it into the final error's `agreeingPeerBindFailures` map.
+ */
+class _QuorumBindCheckFailedError extends Error {
+  public readonly advertisedHex: string;
+  constructor(advertisedHex: string, message: string) {
+    super(message);
+    this.name = '_QuorumBindCheckFailedError';
+    this.advertisedHex = advertisedHex;
+  }
+}
+
 export class CollabswarmDocument<
   DocType,
   ChangesType,
@@ -2336,6 +2371,19 @@ export class CollabswarmDocument<
         // unreliable because snapshot-loads don't restore ancestor CIDs
         // and the loader's pre-existing local CIDs (if any) inflate the
         // recomputed set.
+        //
+        // Throws the module-private `_QuorumBindCheckFailedError` on
+        // mismatch / missing-tips so the surrounding `load()` loop can
+        // record this peer as a bind-failure and proceed to the NEXT
+        // peer in the agreeing cohort. Previously this site threw
+        // `LoadQuorumFailedError` directly, which `load()` re-raised --
+        // letting a single malicious peer in the agreeing cohort vote
+        // for the majority hash, serve a mismatched full load, and
+        // unilaterally DoS the entire load by aborting before the
+        // honest agreeing peers could be tried. See PR #284 r6 Copilot
+        // review. `load()` only escalates to a structured
+        // `LoadQuorumFailedError(bind-check-failed-all-agreeing-peers)`
+        // when EVERY narrowed peer fails the bind step.
         if (expectedTipsHashHex !== null) {
           if (!Array.isArray(message.tips)) {
             console.warn(
@@ -2343,13 +2391,10 @@ export class CollabswarmDocument<
                 `omitted 'tips' on load response; refusing to apply state ` +
                 `from an un-attesting peer.`,
             );
-            throw new LoadQuorumFailedError({
-              documentPath: this.documentPath,
-              reason: 'no-majority',
-              respondingCount: 0,
-              requiredQ: 0,
-              agreement: new Map([[expectedTipsHashHex, 0]]),
-            });
+            throw new _QuorumBindCheckFailedError(
+              '(missing tips)',
+              `Quorum frontier binding: responder omitted 'tips' on load response.`,
+            );
           }
           const advertisedBytes = await tipsHash(message.tips);
           const advertisedHex = tipsHashToHex(advertisedBytes);
@@ -2361,16 +2406,11 @@ export class CollabswarmDocument<
                 `An agreeing peer voted for one tip set and served a ` +
                 `different one; treating as Byzantine equivocation.`,
             );
-            throw new LoadQuorumFailedError({
-              documentPath: this.documentPath,
-              reason: 'no-majority',
-              respondingCount: 0,
-              requiredQ: 0,
-              agreement: new Map([
-                [expectedTipsHashHex, 0],
-                [advertisedHex, 0],
-              ]),
-            });
+            throw new _QuorumBindCheckFailedError(
+              advertisedHex,
+              `Quorum frontier binding mismatch: expected ${expectedTipsHashHex.slice(0, 12)}... ` +
+                `got ${advertisedHex.slice(0, 12)}...`,
+            );
           }
         }
 
@@ -2663,9 +2703,18 @@ export class CollabswarmDocument<
    * history compaction, and pre-existing local CIDs — the prior
    * recompute-locally approach would fail-open or fail-closed in those
    * cases. An agreeing peer that voted hash X but serves a load whose
-   * `tips` hash to Y is caught and the load is rejected before any
-   * in-memory document state is mutated. Closes the gap tracked under
-   * issue #189 §5.4 item 2 (and bulleted in #186).
+   * `tips` hash to Y is treated as a PER-PEER bind failure: the loader
+   * records the offending peer in `agreeingPeerBindFailures`, skips it,
+   * and tries the next peer in the agreeing cohort. This prevents a
+   * single malicious peer in the agreeing cohort from DoS'ing the
+   * entire load by voting for the majority hash (passing quorum) and
+   * then serving a mismatched full load. Only after EVERY peer in the
+   * agreeing cohort has bind-failed does the loader throw
+   * `LoadQuorumFailedError(reason: 'bind-check-failed-all-agreeing-
+   * peers')`, with `agreeingPeerBindFailures` recording per-peer what
+   * each Byzantine peer served instead. Closes the gap tracked under
+   * issue #189 §5.4 item 2 (and bulleted in #186). See PR #284 r6
+   * Copilot review for the DoS rationale on the per-peer retry.
    *
    * @returns `true` if the document was successfully loaded from a peer.
    *   `false` if no peer could provide the document -- this is ambiguous: it
@@ -2843,12 +2892,27 @@ export class CollabswarmDocument<
     // current frontier in `message.tips` and verifies
     // `tipsHash(message.tips) === winningHashHex` BEFORE applying the
     // sync, so a Byzantine peer that voted for one tip set and serves a
-    // different one never gets to mutate in-memory document state. On
-    // mismatch the load is rejected via `LoadQuorumFailedError` and the
-    // caller must construct a fresh document instance (the gate runs
-    // during `open()`, so no application code has observed the document
-    // yet).
+    // different one never gets to mutate in-memory document state.
+    //
+    // Per-peer bind failures (`_QuorumBindCheckFailedError`) are NOT
+    // fatal to the whole load -- they only disqualify the offending
+    // peer. The loop records the failure and continues to the NEXT
+    // peer in the agreeing cohort, so a single malicious peer that
+    // voted for the majority hash and then served a mismatched full
+    // load cannot DoS the entire load. Only after every peer in the
+    // narrowed cohort has bind-failed does `load()` escalate to
+    // `LoadQuorumFailedError(bind-check-failed-all-agreeing-peers)`.
+    // See PR #284 r6 Copilot review.
+    //
+    // The `agreeingPeerBindFailures` map records, per peer, the hex
+    // hash the responder's served `tips` actually hashed to (or the
+    // sentinel `'(missing tips)'` for an omitted-tips response). This
+    // is threaded into the final error so callers / operators can see
+    // which peers in the agreeing cohort equivocated between the
+    // probe round and the load round and what they served instead.
+    const agreeingPeerBindFailures = new Map<string, string>();
     for (const peer of orderedPeers) {
+      let peerBindFailed = false;
       try {
         console.log('Trying snapshot-load from peer:', peer.toString());
         // dialProtocol returns a libp2p v3 `Stream` (event-driven, with a
@@ -2868,8 +2932,28 @@ export class CollabswarmDocument<
         }
         // Empty response -- peer has no snapshot, try doc-load below.
       } catch (err) {
-        if (err instanceof LoadQuorumFailedError) throw err;
-        // Peer doesn't support snapshot-load protocol.
+        if (err instanceof _QuorumBindCheckFailedError) {
+          // This peer voted hash X in the probe round but served a
+          // load whose tips hash to something else (or omitted tips
+          // entirely). Record the failure and skip the doc-load
+          // fallback for this peer -- a peer that equivocated once
+          // is not given a second chance on the same load round.
+          console.warn(
+            `[${this.documentPath}] Agreeing peer ${peer.toString()} failed ` +
+              `quorum frontier bind on snapshot-load (served ${err.advertisedHex}); ` +
+              `marking peer as Byzantine for this load and trying next peer in agreeing cohort.`,
+          );
+          agreeingPeerBindFailures.set(this._peerIdOf(peer), err.advertisedHex);
+          peerBindFailed = true;
+        }
+        // Else: peer doesn't support snapshot-load protocol, or some
+        // other transient error -- fall through to doc-load below.
+      }
+
+      if (peerBindFailed) {
+        // Don't retry doc-load against a peer that already equivocated
+        // on snapshot-load -- continue to the next peer in the cohort.
+        continue;
       }
 
       try {
@@ -2887,13 +2971,43 @@ export class CollabswarmDocument<
           return true;
         }
       } catch (err) {
-        if (err instanceof LoadQuorumFailedError) throw err;
+        if (err instanceof _QuorumBindCheckFailedError) {
+          console.warn(
+            `[${this.documentPath}] Agreeing peer ${peer.toString()} failed ` +
+              `quorum frontier bind on doc-load (served ${err.advertisedHex}); ` +
+              `marking peer as Byzantine for this load and trying next peer in agreeing cohort.`,
+          );
+          agreeingPeerBindFailures.set(this._peerIdOf(peer), err.advertisedHex);
+          continue;
+        }
         console.warn(
           `Failed to load document via ${documentLoadV3}:`,
           peer.toString(),
           err,
         );
       }
+    }
+
+    // If the loop exhausted the agreeing cohort AND at least one peer
+    // bind-failed AND quorum was actually run (`winningHashHex !==
+    // null`), every peer in the cohort either failed the bind check or
+    // failed to serve at all -- which, given they all voted for the
+    // same hash, indicates a coordinated Byzantine cohort. Escalate
+    // with the dedicated reason so callers can distinguish this from
+    // the "no peer responded" outcome. Only raise when at least one
+    // peer was actually flagged as bind-failed; if every peer instead
+    // failed for some OTHER reason (network, protocol, etc.) we fall
+    // through to the legacy `return false` so a brand-new document is
+    // still indistinguishable from a transient outage. See PR #284 r6.
+    if (winningHashHex !== null && agreeingPeerBindFailures.size > 0) {
+      throw new LoadQuorumFailedError({
+        documentPath: this.documentPath,
+        reason: 'bind-check-failed-all-agreeing-peers',
+        respondingCount: 0,
+        requiredQ: 0,
+        agreement: new Map([[winningHashHex, 0]]),
+        agreeingPeerBindFailures,
+      });
     }
 
     // No peer could provide the document -- assume new document.

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -627,12 +627,35 @@ export class Collabswarm<
           }
           const doc = this._documentRegistry.get(request.documentId);
           if (!doc) {
-            // Unknown document -- decline with empty response so the loader
-            // counts this peer as a non-vote, not a disagreement.
+            // Unknown document -- respond with the 1-byte UNKNOWN_DOC
+            // sentinel (`0xFF`) so the loader can DISTINGUISH "I don't
+            // have this document" from generic probe failures (timeout,
+            // auth failure, decryption failure, malformed response). The
+            // loader uses this signal so that when EVERY queried peer in
+            // the swarm explicitly disclaims the document, `load()`
+            // returns `false` to let a fresh `open()` create the document
+            // on top of an existing swarm -- the previous empty-response
+            // decline was indistinguishable from a partition / timeout
+            // and made new-document creation in an existing mesh fail
+            // with `LoadQuorumFailedError`.
+            //
+            // Unauthenticated: this signal carries no signature. A
+            // Byzantine peer can lie and claim "unknown" even when other
+            // honest peers have the document. Defense: quorum tallies
+            // `'unknown-doc'` exactly like a tip-hash vote -- if Q of K
+            // peers all agree on `'unknown-doc'` the loader trusts the
+            // disclaimer, but a single lying peer in a 3-of-3 mesh whose
+            // other 2 peers have the doc cannot force new-doc creation
+            // (the honest hash X wins the tally). Worst case is the same
+            // Q-Byzantine threshold the rest of the quorum gate already
+            // tolerates. See `decideLoadQuorum` for the tally semantics
+            // and PR #284 r16 Copilot review for the original bug report.
             console.warn(
               `Shared tip-advertise handler: no document registered for "${request.documentId}"`,
             );
-            await stream.sink([] as Iterable<Uint8Array>);
+            await stream.sink([
+              new Uint8Array([0xff]),
+            ] as Iterable<Uint8Array>);
             return [];
           }
           await doc.handleTipAdvertiseRequestData(request, stream);

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -25,6 +25,7 @@ import { ChangesSerializer } from './changes-serializer';
 import { ACLProvider } from './acl-provider';
 import { KeychainProvider } from './keychain-provider';
 import { LoadMessageSerializer } from './load-request-serializer';
+import { validateLoadQuorumConfig } from './load-quorum';
 import {
   beekemPathUpdateV1,
   beekemWelcomeV1,
@@ -240,6 +241,17 @@ export class Collabswarm<
     if (!config) {
       config = defaultConfig(defaultBootstrapConfig([]));
     }
+
+    // Validate the load-quorum tuning knobs at startup so an operator
+    // misconfiguration (e.g. `loadQuorumK: 1.5`, `loadQuorumQ: NaN`)
+    // surfaces immediately as a structured `LoadQuorumFailedError(
+    // invalid-config)` rather than silently degrading every subsequent
+    // `load()` to a single-peer probe. See PR #284 r9 Copilot review for
+    // the input-validation hardening rationale (issues #2/#3): fractional
+    // K let `peers.slice(0, 1.5)` slip through to a 1-peer probe, and
+    // NaN Q propagated through `effectiveQ` so `bestPeers.length < NaN`
+    // evaluated as false and the gate passed with a single responder.
+    validateLoadQuorumConfig(config);
 
     this._config = config;
 

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -28,9 +28,9 @@ import { LoadMessageSerializer } from './load-request-serializer';
 import {
   beekemPathUpdateV1,
   beekemWelcomeV1,
-  documentLoadV2,
+  documentLoadV3,
   documentKeyUpdateV2,
-  snapshotLoadV2,
+  snapshotLoadV3,
   tipAdvertiseV1,
 } from './wire-protocols';
 import { readPathPrefixedProtocolHeader, readUint8Iterable } from './utils';
@@ -574,7 +574,7 @@ export class Collabswarm<
 
     // Handler implementation for tip-advertise requests (initial-load
     // quorum probe; see `wire-protocols.ts::tipAdvertiseV1`). Wire format
-    // mirrors documentLoadV2: a single serialized CRDTLoadRequest in,
+    // mirrors documentLoadV3: a single serialized CRDTLoadRequest in,
     // a single (small) encrypted/serialized CRDTSyncMessage out (whose
     // only populated payload field is `tipsHash`), or an empty response
     // on decline.
@@ -625,8 +625,8 @@ export class Collabswarm<
     // Register shared protocol handlers. Each protocol ID uses a single
     // handler for all documents; the document path is extracted from the
     // stream payload for routing.
-    this.libp2p.handle(documentLoadV2, docLoadHandler);
-    this.libp2p.handle(snapshotLoadV2, snapshotLoadHandler);
+    this.libp2p.handle(documentLoadV3, docLoadHandler);
+    this.libp2p.handle(snapshotLoadV3, snapshotLoadHandler);
     this.libp2p.handle(documentKeyUpdateV2, keyUpdateHandler);
     this.libp2p.handle(beekemWelcomeV1, beekemWelcomeHandler);
     this.libp2p.handle(beekemPathUpdateV1, beekemPathUpdateHandler);

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -31,6 +31,7 @@ import {
   documentLoadV2,
   documentKeyUpdateV2,
   snapshotLoadV2,
+  tipAdvertiseV1,
 } from './wire-protocols';
 import { readPathPrefixedProtocolHeader, readUint8Iterable } from './utils';
 import { wrapStream } from './stream-adapter';
@@ -571,6 +572,56 @@ export class Collabswarm<
       });
     };
 
+    // Handler implementation for tip-advertise requests (initial-load
+    // quorum probe; see `wire-protocols.ts::tipAdvertiseV1`). Wire format
+    // mirrors documentLoadV2: a single serialized CRDTLoadRequest in,
+    // a single (small) encrypted/serialized CRDTSyncMessage out (whose
+    // only populated payload field is `tipsHash`), or an empty response
+    // on decline.
+    // See note on `docLoadHandler` above re: the v3 StreamHandler signature.
+    const tipAdvertiseHandler = (rawStream: Stream) => {
+      const stream: ProtocolStream = wrapStream(rawStream);
+      pipe(
+        stream.source,
+        async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
+          let assembled: Uint8Array;
+          try {
+            assembled = await readUint8Iterable(source, MAX_REQUEST_SIZE);
+          } catch (err) {
+            const reason = err instanceof RangeError ? 'request too large' : 'failed to read request';
+            console.warn(`Shared tip-advertise handler: ${reason}, dropping`);
+            await stream.sink([] as Iterable<Uint8Array>);
+            return [];
+          }
+          let request;
+          try {
+            request = this._loadMessageSerializer.deserializeLoadRequest(assembled);
+          } catch (err) {
+            console.warn(
+              'Shared tip-advertise handler: failed to deserialize load request, dropping:',
+              err,
+            );
+            await stream.sink([] as Iterable<Uint8Array>);
+            return [];
+          }
+          const doc = this._documentRegistry.get(request.documentId);
+          if (!doc) {
+            // Unknown document -- decline with empty response so the loader
+            // counts this peer as a non-vote, not a disagreement.
+            console.warn(
+              `Shared tip-advertise handler: no document registered for "${request.documentId}"`,
+            );
+            await stream.sink([] as Iterable<Uint8Array>);
+            return [];
+          }
+          await doc.handleTipAdvertiseRequestData(request, stream);
+          return [];
+        },
+      ).catch((err: unknown) => {
+        console.error('Error in shared tip-advertise handler:', err);
+      });
+    };
+
     // Register shared protocol handlers. Each protocol ID uses a single
     // handler for all documents; the document path is extracted from the
     // stream payload for routing.
@@ -579,6 +630,7 @@ export class Collabswarm<
     this.libp2p.handle(documentKeyUpdateV2, keyUpdateHandler);
     this.libp2p.handle(beekemWelcomeV1, beekemWelcomeHandler);
     this.libp2p.handle(beekemPathUpdateV1, beekemPathUpdateHandler);
+    this.libp2p.handle(tipAdvertiseV1, tipAdvertiseHandler);
   }
 
   /**

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -251,7 +251,16 @@ export class Collabswarm<
     // K let `peers.slice(0, 1.5)` slip through to a 1-peer probe, and
     // NaN Q propagated through `effectiveQ` so `bestPeers.length < NaN`
     // evaluated as false and the gate passed with a single responder.
-    validateLoadQuorumConfig(config);
+    //
+    // Skip validation when the feature is explicitly disabled -- a
+    // shared config object that carries leftover quorum knobs alongside
+    // `loadQuorumEnabled: false` should still initialize cleanly via
+    // the legacy load path. `runLoadQuorum` mirrors this early-exit
+    // ordering: `enabled === false` is checked before validation, so
+    // the two boundaries stay consistent.
+    if (config.loadQuorumEnabled !== false) {
+      validateLoadQuorumConfig(config);
+    }
 
     this._config = config;
 

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -605,71 +605,84 @@ export class Collabswarm<
       pipe(
         stream.source,
         async (source: AsyncIterable<Uint8ArrayList | Uint8Array>) => {
-          let assembled: Uint8Array;
           try {
-            assembled = await readUint8Iterable(source, MAX_REQUEST_SIZE);
-          } catch (err) {
-            const reason = err instanceof RangeError ? 'request too large' : 'failed to read request';
-            console.warn(`Shared tip-advertise handler: ${reason}, dropping`);
-            await stream.sink([] as Iterable<Uint8Array>);
+            let assembled: Uint8Array;
+            try {
+              assembled = await readUint8Iterable(source, MAX_REQUEST_SIZE);
+            } catch (err) {
+              const reason = err instanceof RangeError ? 'request too large' : 'failed to read request';
+              console.warn(`Shared tip-advertise handler: ${reason}, dropping`);
+              await stream.sink([] as Iterable<Uint8Array>);
+              return [];
+            }
+            let request;
+            try {
+              request = this._loadMessageSerializer.deserializeLoadRequest(assembled);
+            } catch (err) {
+              console.warn(
+                'Shared tip-advertise handler: failed to deserialize load request, dropping:',
+                err,
+              );
+              await stream.sink([] as Iterable<Uint8Array>);
+              return [];
+            }
+            const doc = this._documentRegistry.get(request.documentId);
+            if (!doc) {
+              // Unknown document -- respond with the 1-byte UNKNOWN_DOC
+              // sentinel (`0xFF`) so the loader can DISTINGUISH "I don't
+              // have this document" from generic probe failures (timeout,
+              // auth failure, decryption failure, malformed response). The
+              // loader uses this signal so that when EVERY queried peer in
+              // the swarm explicitly disclaims the document, `load()`
+              // returns `false` to let a fresh `open()` create the document
+              // on top of an existing swarm -- the previous empty-response
+              // decline was indistinguishable from a partition / timeout
+              // and made new-document creation in an existing mesh fail
+              // with `LoadQuorumFailedError`.
+              //
+              // Unauthenticated: this signal carries no signature. A
+              // Byzantine peer can lie and claim "unknown" even when other
+              // honest peers have the document. Defense: quorum tallies
+              // `'unknown-doc'` exactly like a tip-hash vote -- if Q of K
+              // peers all agree on `'unknown-doc'` the loader trusts the
+              // disclaimer, but a single lying peer in a 3-of-3 mesh whose
+              // other 2 peers have the doc cannot force new-doc creation
+              // (the honest hash X wins the tally). Worst case is the same
+              // Q-Byzantine threshold the rest of the quorum gate already
+              // tolerates. See `decideLoadQuorum` for the tally semantics
+              // and PR #284 r16 Copilot review for the original bug report.
+              //
+              // Information-disclosure tradeoff (PR #284 r27): replying with
+              // `0xff` lets any peer that can dial this node learn whether
+              // `documentId` is registered here. We accept this because the
+              // quorum protocol REQUIRES a distinguishable "unknown-doc"
+              // signal to allow new-document creation on an existing swarm;
+              // suppressing the signal would block legitimate `open()` calls
+              // for fresh paths. Two mitigations are wired in: (1) no
+              // unauthenticated-probe log line so attacker-controlled
+              // `documentId` values don't reach the host log, and (2) the
+              // sentinel is a single byte with no per-document content, so
+              // it leaks only the existence bit -- nothing about contents,
+              // membership, or history.
+              await stream.sink([
+                new Uint8Array([0xff]),
+              ] as Iterable<Uint8Array>);
+              return [];
+            }
+            await doc.handleTipAdvertiseRequestData(request, stream);
             return [];
+          } finally {
+            // Tip-advertise runs on every `open()` quorum probe, so every
+            // connected peer hits this handler. Always close the inbound
+            // stream (even on the sink-already-completed happy path) so
+            // per-connection stream quota doesn't leak under load or when
+            // a downstream call throws after sink. Safe to call after
+            // `stream.sink`: libp2p stream.close() is idempotent on a
+            // already-half-closed stream.
+            await stream.close().catch(() => {
+              // swallow: close-after-error is best-effort cleanup
+            });
           }
-          let request;
-          try {
-            request = this._loadMessageSerializer.deserializeLoadRequest(assembled);
-          } catch (err) {
-            console.warn(
-              'Shared tip-advertise handler: failed to deserialize load request, dropping:',
-              err,
-            );
-            await stream.sink([] as Iterable<Uint8Array>);
-            return [];
-          }
-          const doc = this._documentRegistry.get(request.documentId);
-          if (!doc) {
-            // Unknown document -- respond with the 1-byte UNKNOWN_DOC
-            // sentinel (`0xFF`) so the loader can DISTINGUISH "I don't
-            // have this document" from generic probe failures (timeout,
-            // auth failure, decryption failure, malformed response). The
-            // loader uses this signal so that when EVERY queried peer in
-            // the swarm explicitly disclaims the document, `load()`
-            // returns `false` to let a fresh `open()` create the document
-            // on top of an existing swarm -- the previous empty-response
-            // decline was indistinguishable from a partition / timeout
-            // and made new-document creation in an existing mesh fail
-            // with `LoadQuorumFailedError`.
-            //
-            // Unauthenticated: this signal carries no signature. A
-            // Byzantine peer can lie and claim "unknown" even when other
-            // honest peers have the document. Defense: quorum tallies
-            // `'unknown-doc'` exactly like a tip-hash vote -- if Q of K
-            // peers all agree on `'unknown-doc'` the loader trusts the
-            // disclaimer, but a single lying peer in a 3-of-3 mesh whose
-            // other 2 peers have the doc cannot force new-doc creation
-            // (the honest hash X wins the tally). Worst case is the same
-            // Q-Byzantine threshold the rest of the quorum gate already
-            // tolerates. See `decideLoadQuorum` for the tally semantics
-            // and PR #284 r16 Copilot review for the original bug report.
-            //
-            // Information-disclosure tradeoff (PR #284 r27): replying with
-            // `0xff` lets any peer that can dial this node learn whether
-            // `documentId` is registered here. We accept this because the
-            // quorum protocol REQUIRES a distinguishable "unknown-doc"
-            // signal to allow new-document creation on an existing swarm;
-            // suppressing the signal would block legitimate `open()` calls
-            // for fresh paths. Two mitigations are wired in: (1) no
-            // unauthenticated-probe log line so attacker-controlled
-            // `documentId` values don't reach the host log, and (2) the
-            // sentinel is a single byte with no per-document content, so
-            // it leaks only the existence bit -- nothing about contents,
-            // membership, or history.
-            await stream.sink([
-              new Uint8Array([0xff]),
-            ] as Iterable<Uint8Array>);
-            return [];
-          }
-          await doc.handleTipAdvertiseRequestData(request, stream);
-          return [];
         },
       ).catch((err: unknown) => {
         console.error('Error in shared tip-advertise handler:', err);

--- a/packages/collabswarm/src/collabswarm.ts
+++ b/packages/collabswarm/src/collabswarm.ts
@@ -650,9 +650,19 @@ export class Collabswarm<
             // Q-Byzantine threshold the rest of the quorum gate already
             // tolerates. See `decideLoadQuorum` for the tally semantics
             // and PR #284 r16 Copilot review for the original bug report.
-            console.warn(
-              `Shared tip-advertise handler: no document registered for "${request.documentId}"`,
-            );
+            //
+            // Information-disclosure tradeoff (PR #284 r27): replying with
+            // `0xff` lets any peer that can dial this node learn whether
+            // `documentId` is registered here. We accept this because the
+            // quorum protocol REQUIRES a distinguishable "unknown-doc"
+            // signal to allow new-document creation on an existing swarm;
+            // suppressing the signal would block legitimate `open()` calls
+            // for fresh paths. Two mitigations are wired in: (1) no
+            // unauthenticated-probe log line so attacker-controlled
+            // `documentId` values don't reach the host log, and (2) the
+            // sentinel is a single byte with no per-document content, so
+            // it leaks only the existence bit -- nothing about contents,
+            // membership, or history.
             await stream.sink([
               new Uint8Array([0xff]),
             ] as Iterable<Uint8Array>);

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -179,37 +179,50 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
   tipsHash?: Uint8Array;
 
   /**
-   * Optional explicit tip-set advertisement, populated by load responses
-   * (doc-load and snapshot-load) to bind the served full state to the
-   * responder's current frontier.
+   * Explicit tip-set advertisement, populated by load responses
+   * (documentLoadV3 and snapshotLoadV3) to bind the served full state to
+   * the responder's current frontier. **Part of the signed payload** on v3
+   * load responses -- changing the wire shape from v2 is why the protocol
+   * id was bumped (see `wire-protocols.ts`).
+   *
+   * "Frontier" here means the *heads* of the local merged-changes DAG:
+   * CIDs the responder has seen but that no other change references as a
+   * parent or cross-link target (computed by
+   * `CollabswarmDocument._currentFrontier()` as `_hashes \
+   * _referencedAncestors`). This is the set the responder would attest to
+   * if asked "what would I serve as my current heads", and it is the
+   * quantity that converges across honest peers regardless of differing
+   * sync histories or pruning levels.
    *
    * The initial-load quorum gate binds the loader's accepted state to the
    * tip-advertise hash a Q-of-K cohort voted for. Recomputing
    * `tipsHash(loader._hashes)` after sync is unreliable because:
    *   - on a snapshot-load, only the snapshot boundary CID is added to
-   *     `_hashes` — the ancestor CIDs the snapshot compacts away are NOT
+   *     `_hashes` -- the ancestor CIDs the snapshot compacts away are NOT
    *     restored, so `_hashes` does not represent the responder's full
    *     history;
    *   - on a regular doc-load, the loader's pre-existing local CIDs (if
    *     any) inflate `_hashes` beyond what the responder advertised;
-   *   - on a compacted/pruned peer, the responder's own `_hashes` is the
-   *     responder's *current* frontier, NOT the full historical CID bag,
-   *     so two honest pruned peers could advertise different hashes if
-   *     the loader hashed reconstructed history.
+   *   - on a compacted/pruned peer, the responder's `_hashes` includes
+   *     referenced ancestors which two honest peers can have differently
+   *     based on sync history -- which is exactly the bug round 3 of the
+   *     Copilot review flagged.
    *
-   * To avoid both, the responder explicitly includes its current tip set
-   * here (drawn from the same `_hashes` source it would use to respond to
-   * a fresh `tipAdvertiseV1` probe). The loader hashes `tips` directly
-   * and compares against the quorum-agreed `winningHashHex`, decoupling
-   * the binding from either peer's local history retention. Because the
-   * load response is signed by the responder, this is a responder-signed
-   * attestation of "my current frontier"; a peer that voted hash X but
-   * then serves a load with a different `tips` array (and thus a
-   * different `tipsHash(tips)`) is caught by the binding.
+   * To avoid all of these, the responder explicitly includes its current
+   * frontier here (drawn from `_currentFrontier()`). The loader hashes
+   * `tips` directly and compares against the quorum-agreed
+   * `winningHashHex`, decoupling the binding from either peer's local
+   * history retention. Because the load response is signed by the
+   * responder, this is a responder-signed attestation of "my current
+   * frontier"; a peer that voted hash X but then serves a load with a
+   * different `tips` array (and thus a different `tipsHash(tips)`) is
+   * caught by the binding.
    *
-   * Optional on the wire so legacy peers without quorum support don't
-   * break; the loader treats absence as a binding failure only when the
-   * quorum gate is enabled (i.e. when `winningHashHex` is non-null).
+   * `tips` is REQUIRED on v3 load responses (responder always populates,
+   * loader rejects absence when the quorum gate is enabled). The field
+   * remains optional in the TypeScript type because the same
+   * `CRDTSyncMessage` shape is also used for pubsub-broadcast change
+   * messages, which do not carry a frontier advertisement.
    */
   tips?: string[];
 

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -163,11 +163,39 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
    *
    * When a new node opens a document it queries up to K peers in parallel
    * via `tipAdvertiseV1`; each peer responds with a `CRDTSyncMessage` whose
-   * only populated payload field is `tipsHash` (computed deterministically
-   * from the peer's `_hashes` set so peers with the same view produce
-   * byte-identical hashes). The loader counts how many peers returned the
-   * same hash and proceeds with a full documentLoadV3/snapshotLoadV3
-   * against one of the agreeing peers only when at least Q peers agree.
+   * only populated payload field is `tipsHash`. The loader counts how many
+   * peers returned the same hash and proceeds with a full
+   * documentLoadV3/snapshotLoadV3 against one of the agreeing peers only
+   * when at least Q peers agree.
+   *
+   * # Protocol contract: WHAT to hash
+   *
+   * `tipsHash` is computed over the canonical **frontier** of the peer's
+   * local change DAG -- i.e. the set of change-block CIDs that have NO
+   * descendants in the local DAG (the "heads" or "tips"). The reference
+   * implementation is `CollabswarmDocument._currentFrontier()` in
+   * `collabswarm-document.ts`, which returns `_hashes \
+   * _referencedAncestors` (the merged-CID set minus every CID that some
+   * other change references as a parent or cross-link target).
+   *
+   * # Implementer warning: do NOT hash `_hashes` directly
+   *
+   * Implementers **MUST NOT** hash the full set of observed/merged CIDs
+   * (e.g. the peer's entire `_hashes` set). Two honest peers with the same
+   * logical document state can have DIFFERENT observed-CID sets when their
+   * history depths differ (history compaction, snapshot-loads that don't
+   * restore ancestors, different join times). Hashing the full set would
+   * cause those honest peers to advertise different hashes, the quorum
+   * gate would never agree, and the load would fail for a state both peers
+   * actually share. Round 3 of the PR #284 Copilot review caught and fixed
+   * exactly this bug -- the docstring previously said "`_hashes` set",
+   * which was wrong; the implementation correctly uses the frontier.
+   *
+   * Hashing the frontier (rather than `_hashes`) makes the hash
+   * deterministic across honest peers with the same logical state
+   * regardless of differing pruning / sync histories: two peers that have
+   * converged on the same CRDT state always have the same frontier even
+   * if their internal merged-CID sets differ.
    *
    * The field is also tolerated (but optional) on regular load responses,
    * so a future optimization can fold quorum into the full load. It is

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -157,7 +157,7 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
   pathUpdateEpochId?: Uint8Array;
 
   /**
-   * Optional canonical hash of the responder's current tip set, used by the
+   * Optional canonical hash of the responder's served tip set, used by the
    * initial-load quorum protocol (`tipAdvertiseV1`, see `wire-protocols.ts`
    * and `tips-hash.ts`).
    *
@@ -170,32 +170,41 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
    *
    * # Protocol contract: WHAT to hash
    *
-   * `tipsHash` is computed over the canonical **frontier** of the peer's
-   * local change DAG -- i.e. the set of change-block CIDs that have NO
-   * descendants in the local DAG (the "heads" or "tips"). The reference
-   * implementation is `CollabswarmDocument._currentFrontier()` in
-   * `collabswarm-document.ts`, which returns `_hashes \
-   * _referencedAncestors` (the merged-CID set minus every CID that some
-   * other change references as a parent or cross-link target).
+   * `tipsHash` is computed over the **served frontier** -- the heads of
+   * the change tree the responder would actually ship in a load response
+   * (NOT the full local DAG frontier). The reference implementation is
+   * `CollabswarmDocument._servedFrontier()` in `collabswarm-document.ts`,
+   * which computes this via `computeServedFrontier` over
+   * `_lastSyncMessage.changes` plus `_latestSnapshot?.lastChangeNodeCID`
+   * -- exactly the inputs `handleLoadRequestData` /
+   * `handleSnapshotLoadRequestData` populate into the load response.
    *
-   * # Implementer warning: do NOT hash `_hashes` directly
+   * Hashing this set produces a value the loader can reproduce
+   * structurally from the served payload via `computeServedFrontier`,
+   * which is exactly the binding `_sendLoadRequestAndSync` uses.
    *
-   * Implementers **MUST NOT** hash the full set of observed/merged CIDs
-   * (e.g. the peer's entire `_hashes` set). Two honest peers with the same
-   * logical document state can have DIFFERENT observed-CID sets when their
-   * history depths differ (history compaction, snapshot-loads that don't
-   * restore ancestors, different join times). Hashing the full set would
-   * cause those honest peers to advertise different hashes, the quorum
-   * gate would never agree, and the load would fail for a state both peers
-   * actually share. Round 3 of the PR #284 Copilot review caught and fixed
-   * exactly this bug -- the docstring previously said "`_hashes` set",
-   * which was wrong; the implementation correctly uses the frontier.
+   * # Implementer warning: do NOT hash `_currentFrontier()` or `_hashes`
    *
-   * Hashing the frontier (rather than `_hashes`) makes the hash
-   * deterministic across honest peers with the same logical state
-   * regardless of differing pruning / sync histories: two peers that have
-   * converged on the same CRDT state always have the same frontier even
-   * if their internal merged-CID sets differ.
+   * Implementers **MUST NOT** hash `_currentFrontier()` (the full local
+   * DAG frontier). A peer that has remotely-applied heads not yet
+   * cross-linked into `_lastSyncMessage.changes` produces a
+   * `_currentFrontier()` larger than the served frontier, so the
+   * advertised hash would not match what the load response actually
+   * contains. The loader's structural bind check derives the served
+   * frontier from the received `changes` tree and rejects honest peers
+   * whose advertise hash disagrees. Round 8 of the PR #284 Copilot
+   * review caught this exact bug.
+   *
+   * Implementers **MUST NOT** hash the full `_hashes` set either. Two
+   * honest peers with the same logical document state can have DIFFERENT
+   * observed-CID sets when their history depths differ (history
+   * compaction, snapshot-loads that don't restore ancestors, different
+   * join times). Round 3 of the PR #284 Copilot review caught and fixed
+   * that earlier variant of the bug.
+   *
+   * Hashing the served frontier makes the hash deterministic across
+   * honest peers whose `_lastSyncMessage` / `_latestSnapshot` describe
+   * the same logical state.
    *
    * The field is also tolerated (but optional) on regular load responses,
    * so a future optimization can fold quorum into the full load. It is
@@ -209,22 +218,44 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
   /**
    * Explicit tip-set advertisement, populated by load responses
    * (documentLoadV3 and snapshotLoadV3) to bind the served full state to
-   * the responder's current frontier. **Part of the signed payload** on v3
+   * the responder's served frontier. **Part of the signed payload** on v3
    * load responses -- changing the wire shape from v2 is why the protocol
    * id was bumped (see `wire-protocols.ts`).
    *
-   * "Frontier" here means the *heads* of the local merged-changes DAG:
-   * CIDs the responder has seen but that no other change references as a
-   * parent or cross-link target (computed by
-   * `CollabswarmDocument._currentFrontier()` as `_hashes \
-   * _referencedAncestors`). This is the set the responder would attest to
-   * if asked "what would I serve as my current heads", and it is the
-   * quantity that converges across honest peers regardless of differing
-   * sync histories or pruning levels.
+   * "Frontier" here means the **served frontier** -- the heads of the
+   * change tree this load response actually carries (computed by
+   * `CollabswarmDocument._servedFrontier()` via `computeServedFrontier`
+   * over `_lastSyncMessage.changes` plus `_latestSnapshot?.lastChangeNodeCID`).
+   * This is the set the responder attests it is shipping in THIS payload,
+   * not the full set of heads the responder has in its local DAG.
    *
-   * The initial-load quorum gate binds the loader's accepted state to the
-   * tip-advertise hash a Q-of-K cohort voted for. Recomputing
-   * `tipsHash(loader._hashes)` after sync is unreliable because:
+   * # Why served frontier (not local DAG frontier)
+   *
+   * A load response only carries one change tree (rooted at
+   * `changeId`), plus an optional snapshot. A peer that has multiple
+   * concurrent heads -- e.g. one local head plus a remotely-applied head
+   * not yet cross-linked into `_lastSyncMessage.changes` -- can only
+   * serve one of them in a single load response. Advertising the full
+   * local DAG frontier in `tips` would not match the structurally-derived
+   * frontier of the served payload, so the loader's bind check would
+   * reject honest peers. Round 8 of the PR #284 Copilot review caught
+   * this; advertising the served frontier closes the gap.
+   *
+   * # Why this field exists at all (defense-in-depth)
+   *
+   * The loader's PRIMARY binding (PR #284 r7) is derived structurally
+   * from `message.changes` / `message.snapshot` via
+   * `computeServedFrontier`, so a malicious peer that lies in `tips`
+   * cannot bypass the gate by simply claiming the agreed CIDs. The
+   * `tips` field is verified as a defense-in-depth attestation: if
+   * present, it MUST hash to the same value as the
+   * structurally-derived served frontier -- catching responders that
+   * equivocate between their attested heads and the actual served
+   * payload (e.g. tampered `changes` with a still-correct-looking
+   * `tips` array).
+   *
+   * Recomputing `tipsHash(loader._hashes)` after sync is unreliable
+   * because:
    *   - on a snapshot-load, only the snapshot boundary CID is added to
    *     `_hashes` -- the ancestor CIDs the snapshot compacts away are NOT
    *     restored, so `_hashes` does not represent the responder's full
@@ -236,15 +267,11 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
    *     based on sync history -- which is exactly the bug round 3 of the
    *     Copilot review flagged.
    *
-   * To avoid all of these, the responder explicitly includes its current
-   * frontier here (drawn from `_currentFrontier()`). The loader hashes
-   * `tips` directly and compares against the quorum-agreed
-   * `winningHashHex`, decoupling the binding from either peer's local
-   * history retention. Because the load response is signed by the
-   * responder, this is a responder-signed attestation of "my current
-   * frontier"; a peer that voted hash X but then serves a load with a
-   * different `tips` array (and thus a different `tipsHash(tips)`) is
-   * caught by the binding.
+   * Because the load response is signed by the responder, `tips` is a
+   * responder-signed attestation of "the heads of what I am serving";
+   * a peer that voted hash X but then serves a load with a `tips` array
+   * that hashes to anything other than the served-payload frontier is
+   * caught by the defense-in-depth check.
    *
    * `tips` is REQUIRED on v3 load responses (responder always populates,
    * loader rejects absence when the quorum gate is enabled). The field

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -157,6 +157,28 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
   pathUpdateEpochId?: Uint8Array;
 
   /**
+   * Optional canonical hash of the responder's current tip set, used by the
+   * initial-load quorum protocol (`tipAdvertiseV1`, see `wire-protocols.ts`
+   * and `tips-hash.ts`).
+   *
+   * When a new node opens a document it queries up to K peers in parallel
+   * via `tipAdvertiseV1`; each peer responds with a `CRDTSyncMessage` whose
+   * only populated payload field is `tipsHash` (computed deterministically
+   * from the peer's `_hashes` set so peers with the same view produce
+   * byte-identical hashes). The loader counts how many peers returned the
+   * same hash and proceeds with a full documentLoadV3/snapshotLoadV3
+   * against one of the agreeing peers only when at least Q peers agree.
+   *
+   * The field is also tolerated (but optional) on regular load responses,
+   * so a future optimization can fold quorum into the full load. It is
+   * base64-encoded for JSON-safe transport by the sync-message serializers
+   * (same pattern as `welcomeEpochId`).
+   *
+   * Closes the gap tracked under issue #189 §5.4 item 2.
+   */
+  tipsHash?: Uint8Array;
+
+  /**
    * Signature of the sync message.
    */
   signature?: string;

--- a/packages/collabswarm/src/crdt-sync-message.ts
+++ b/packages/collabswarm/src/crdt-sync-message.ts
@@ -179,6 +179,41 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
   tipsHash?: Uint8Array;
 
   /**
+   * Optional explicit tip-set advertisement, populated by load responses
+   * (doc-load and snapshot-load) to bind the served full state to the
+   * responder's current frontier.
+   *
+   * The initial-load quorum gate binds the loader's accepted state to the
+   * tip-advertise hash a Q-of-K cohort voted for. Recomputing
+   * `tipsHash(loader._hashes)` after sync is unreliable because:
+   *   - on a snapshot-load, only the snapshot boundary CID is added to
+   *     `_hashes` — the ancestor CIDs the snapshot compacts away are NOT
+   *     restored, so `_hashes` does not represent the responder's full
+   *     history;
+   *   - on a regular doc-load, the loader's pre-existing local CIDs (if
+   *     any) inflate `_hashes` beyond what the responder advertised;
+   *   - on a compacted/pruned peer, the responder's own `_hashes` is the
+   *     responder's *current* frontier, NOT the full historical CID bag,
+   *     so two honest pruned peers could advertise different hashes if
+   *     the loader hashed reconstructed history.
+   *
+   * To avoid both, the responder explicitly includes its current tip set
+   * here (drawn from the same `_hashes` source it would use to respond to
+   * a fresh `tipAdvertiseV1` probe). The loader hashes `tips` directly
+   * and compares against the quorum-agreed `winningHashHex`, decoupling
+   * the binding from either peer's local history retention. Because the
+   * load response is signed by the responder, this is a responder-signed
+   * attestation of "my current frontier"; a peer that voted hash X but
+   * then serves a load with a different `tips` array (and thus a
+   * different `tipsHash(tips)`) is caught by the binding.
+   *
+   * Optional on the wire so legacy peers without quorum support don't
+   * break; the loader treats absence as a binding failure only when the
+   * quorum gate is enabled (i.e. when `winningHashHex` is non-null).
+   */
+  tips?: string[];
+
+  /**
    * Signature of the sync message.
    */
   signature?: string;

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -114,6 +114,7 @@ import {
   effectiveK,
   effectiveQ,
   LoadQuorumFailedError,
+  LoadQuorumFailedReason,
 } from './load-quorum';
 import { documentTopic, DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 import type { CRDTSnapshotNode } from './snapshot-node';
@@ -216,6 +217,7 @@ export {
   effectiveK,
   effectiveQ,
   LoadQuorumFailedError,
+  LoadQuorumFailedReason,
   // Compaction
   defaultCompactionConfig,
   // Network statistics

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -95,6 +95,7 @@ import {
   beekemPathUpdateV1,
   beekemWelcomeV1,
   bloomFilterUpdateV1,
+  tipAdvertiseV1,
 } from './wire-protocols';
 import {
   DOC_KEY_INFO,
@@ -107,6 +108,13 @@ import {
   deserializePathUpdateFromWire,
   serializePathUpdateForWire,
 } from './path-update-wire';
+import { tipsHash, tipsHashToHex, TIPS_HASH_LENGTH } from './tips-hash';
+import {
+  decideLoadQuorum,
+  effectiveK,
+  effectiveQ,
+  LoadQuorumFailedError,
+} from './load-quorum';
 import { documentTopic, DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 import type { CRDTSnapshotNode } from './snapshot-node';
 import type { CompactionConfig } from './compaction-config';
@@ -192,6 +200,7 @@ export {
   bloomFilterUpdateV1,
   beekemWelcomeV1,
   beekemPathUpdateV1,
+  tipAdvertiseV1,
   // BeeKEM document-key derivation
   DOC_KEY_INFO,
   deriveDocumentKeyFromRootSecret,
@@ -199,6 +208,14 @@ export {
   // BeeKEM PathUpdate wire serialization
   serializePathUpdateForWire,
   deserializePathUpdateFromWire,
+  // Initial-load quorum (#189 §5.4.2)
+  tipsHash,
+  tipsHashToHex,
+  TIPS_HASH_LENGTH,
+  decideLoadQuorum,
+  effectiveK,
+  effectiveQ,
+  LoadQuorumFailedError,
   // Compaction
   defaultCompactionConfig,
   // Network statistics
@@ -210,6 +227,10 @@ export {
 };
 
 export type { NetworkStatsSnapshot } from './network-stats';
+export type {
+  PeerTipAdvertisement,
+  LoadQuorumDecision,
+} from './load-quorum';
 
 // Re-export types
 export type { AuthProvider, AesAlgorithmName } from './auth-provider';

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -115,6 +115,7 @@ import {
   effectiveQ,
   LoadQuorumFailedError,
   LoadQuorumFailedReason,
+  validateLoadQuorumConfig,
 } from './load-quorum';
 import { documentTopic, DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 import type { CRDTSnapshotNode } from './snapshot-node';
@@ -218,6 +219,7 @@ export {
   effectiveQ,
   LoadQuorumFailedError,
   LoadQuorumFailedReason,
+  validateLoadQuorumConfig,
   // Compaction
   defaultCompactionConfig,
   // Network statistics

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -116,12 +116,6 @@ import {
   LoadQuorumFailedError,
   validateLoadQuorumConfig,
 } from './load-quorum';
-// `LoadQuorumFailedReason` is a type alias (`export type` in `load-quorum.ts`);
-// re-exporting it through the value-side `export { ... }` block produces a
-// runtime-undefined export that breaks under stricter TS module settings
-// (`isolatedModules`, `verbatimModuleSyntax`). Keep the import/re-export
-// strictly type-only. See PR #284 r23 Copilot review.
-import type { LoadQuorumFailedReason } from './load-quorum';
 import { documentTopic, DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 import type { CRDTSnapshotNode } from './snapshot-node';
 import type { CompactionConfig } from './compaction-config';

--- a/packages/collabswarm/src/index.ts
+++ b/packages/collabswarm/src/index.ts
@@ -114,9 +114,14 @@ import {
   effectiveK,
   effectiveQ,
   LoadQuorumFailedError,
-  LoadQuorumFailedReason,
   validateLoadQuorumConfig,
 } from './load-quorum';
+// `LoadQuorumFailedReason` is a type alias (`export type` in `load-quorum.ts`);
+// re-exporting it through the value-side `export { ... }` block produces a
+// runtime-undefined export that breaks under stricter TS module settings
+// (`isolatedModules`, `verbatimModuleSyntax`). Keep the import/re-export
+// strictly type-only. See PR #284 r23 Copilot review.
+import type { LoadQuorumFailedReason } from './load-quorum';
 import { documentTopic, DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
 import type { CRDTSnapshotNode } from './snapshot-node';
 import type { CompactionConfig } from './compaction-config';
@@ -218,7 +223,6 @@ export {
   effectiveK,
   effectiveQ,
   LoadQuorumFailedError,
-  LoadQuorumFailedReason,
   validateLoadQuorumConfig,
   // Compaction
   defaultCompactionConfig,
@@ -234,6 +238,7 @@ export type { NetworkStatsSnapshot } from './network-stats';
 export type {
   PeerTipAdvertisement,
   LoadQuorumDecision,
+  LoadQuorumFailedReason,
 } from './load-quorum';
 
 // Re-export types

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Integration tests for the load-quorum orchestrator (#186 / #189 §5.4.2).
+ *
+ * The pure helpers in `load-quorum.ts` (decision logic) and `tips-hash.ts`
+ * (canonical hashing) have their own unit tests that prove the trust-critical
+ * primitives are correct in isolation. Those tests do NOT exercise the
+ * orchestration the production loader runs end-to-end -- probe K peers,
+ * narrow to the agreeing cohort, surface single-peer fallback with a strict
+ * binding, raise `LoadQuorumFailedError` on the right reasons.
+ *
+ * The orchestration code path lives in
+ * `runLoadQuorum` (called by `CollabswarmDocument.load()`) and was extracted
+ * here specifically so the security gate can be regression-tested without a
+ * real libp2p/Helia stack. (The codebase has no precedent for full libp2p
+ * test doubles: existing tests in `collabswarm.test.ts` replicate logic
+ * against mocks rather than instantiating `CollabswarmDocument`, since the
+ * module's top-level imports drag in ESM-only libp2p packages that Jest's
+ * default CommonJS resolver cannot load. Standing up that infrastructure
+ * inside this PR is the explicit "stop and report" threshold flagged for
+ * load-quorum testing; extracting the orchestration into a pure-ish module
+ * gives the equivalent coverage with no new test-infra debt.)
+ *
+ * This file closes the gap raised by Copilot's PR #284 r4 review: the
+ * production quorum path is now covered by a test matrix that exercises all
+ * five flagged cases (a) all-agree, (b) majority-agree-with-dissenter,
+ * (c) vote-vs-serve mismatch, (d) insufficient responses (timeouts), and
+ * (e) single-peer fallback path.
+ */
+
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import { runLoadQuorum } from './load-quorum-orchestrator';
+import { LoadQuorumFailedError } from './load-quorum';
+import { tipsHashToHex } from './tips-hash';
+
+/**
+ * Fixture hashes. Each is a 32-byte fixed-byte buffer so the hex form is
+ * trivial to compute and assert against. Mirrors the pattern in
+ * `load-quorum.test.ts`.
+ */
+function fixedByteHash(byte: number): Uint8Array {
+  const buf = new Uint8Array(32);
+  buf.fill(byte);
+  return buf;
+}
+const HASH_X = fixedByteHash(0xaa);
+const HASH_Y = fixedByteHash(0xbb);
+const HASH_X_HEX = tipsHashToHex(HASH_X);
+const HASH_Y_HEX = tipsHashToHex(HASH_Y);
+
+/**
+ * Test "peer" type. The orchestrator is generic on `T`; in production T is
+ * `Multiaddr` but for tests a string is enough -- the orchestrator only ever
+ * passes peers back through the caller-supplied `peerIdOf` extractor and into
+ * the caller-supplied `probeFn`.
+ */
+type TestPeer = string;
+const peerIdOf = (p: TestPeer) => p;
+
+/**
+ * Mirror of how `CollabswarmDocument.load()` uses the orchestrator: probe
+ * peers, then perform the full document-load against any peer in the
+ * narrowed cohort, with the responder's served `tips` hash bound to the
+ * quorum's `winningHashHex`. The harness below stands in for the
+ * snapshot/doc-load loop so the binding check is exercised against the
+ * narrowed peer list this orchestrator produces.
+ */
+async function simulateFullLoad(opts: {
+  narrowedPeers: TestPeer[];
+  winningHashHex: string;
+  serveFn: (peer: TestPeer) => Promise<string>; // returns served-tips hash hex
+}): Promise<{
+  loadedFromPeer: TestPeer | null;
+  attempts: TestPeer[];
+}> {
+  const attempts: TestPeer[] = [];
+  for (const peer of opts.narrowedPeers) {
+    attempts.push(peer);
+    const servedHashHex = await opts.serveFn(peer);
+    if (servedHashHex === opts.winningHashHex) {
+      return { loadedFromPeer: peer, attempts };
+    }
+    // else: binding fails; the production `_sendLoadRequestAndSync`
+    // would throw LoadQuorumFailedError. Mirror that here so the test
+    // also asserts the load aborts on mismatch.
+    throw new LoadQuorumFailedError({
+      documentPath: '/test',
+      reason: 'no-majority',
+      respondingCount: 0,
+      requiredQ: 0,
+      agreement: new Map([
+        [opts.winningHashHex, 0],
+        [servedHashHex, 0],
+      ]),
+    });
+  }
+  return { loadedFromPeer: null, attempts };
+}
+
+describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => {
+  // Typed `any` because Jest's generic `jest.fn()` typings are awkward to
+  // satisfy alongside `mockImplementation((peer) => ...)`, and the call
+  // sites explicitly annotate `peer: TestPeer` where it matters.
+  let probeMock: any;
+
+  beforeEach(() => {
+    probeMock = jest.fn();
+  });
+
+  test('(a) 3 peers, all vote the same hash and serve a matching load => load succeeds', async () => {
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockResolvedValue(HASH_X);
+
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    });
+
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+    expect(result.winningHashHex).toBe(HASH_X_HEX);
+    expect(result.narrowedPeers).toEqual(['p1', 'p2', 'p3']);
+    expect(probeMock).toHaveBeenCalledTimes(3);
+
+    // Drive the simulated full-load step: all agreeing peers serve a
+    // matching hash, so the first attempt succeeds.
+    const serveFn = jest.fn(async () => HASH_X_HEX);
+    const loadOutcome = await simulateFullLoad({
+      narrowedPeers: result.narrowedPeers,
+      winningHashHex: result.winningHashHex,
+      serveFn,
+    });
+    expect(loadOutcome.loadedFromPeer).toBe('p1');
+    expect(loadOutcome.attempts).toEqual(['p1']);
+  });
+
+  test('(b) 3 peers, 2 vote X / 1 votes Y => agreeing cohort narrowed; disagreeing peer never loaded from', async () => {
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockImplementation(async (peer: TestPeer) => {
+      return peer === 'p3' ? HASH_Y : HASH_X;
+    });
+
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    });
+
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+    expect(result.winningHashHex).toBe(HASH_X_HEX);
+    // p3 (the dissenter) must not be in the narrowed cohort.
+    expect(result.narrowedPeers).toEqual(['p1', 'p2']);
+    expect(result.narrowedPeers).not.toContain('p3');
+
+    // Drive the simulated load: only the narrowed cohort is asked, and the
+    // load must never touch p3.
+    const serveFn = jest.fn(async () => HASH_X_HEX);
+    const loadOutcome = await simulateFullLoad({
+      narrowedPeers: result.narrowedPeers,
+      winningHashHex: result.winningHashHex,
+      serveFn,
+    });
+    expect(loadOutcome.attempts).not.toContain('p3');
+    expect(loadOutcome.loadedFromPeer).toBe('p1');
+  });
+
+  test('(c) 3 peers all vote X but the chosen peer serves tips hashing to Y => LoadQuorumFailedError', async () => {
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockResolvedValue(HASH_X);
+
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    });
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+
+    // The first agreeing peer (p1) serves tips that don't match the
+    // winning hash -- exactly the equivocation case from the comment.
+    const serveFn = jest.fn(async () => HASH_Y_HEX);
+    await expect(
+      simulateFullLoad({
+        narrowedPeers: result.narrowedPeers,
+        winningHashHex: result.winningHashHex,
+        serveFn,
+      }),
+    ).rejects.toBeInstanceOf(LoadQuorumFailedError);
+  });
+
+  test('(d) 3 peers, only 1 responds in time => LoadQuorumFailedError(insufficient-responses); no full-load attempted', async () => {
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockImplementation(async (peer: TestPeer) => {
+      // p1 responds; p2 and p3 simulate timeouts (null = non-vote).
+      return peer === 'p1' ? HASH_X : null;
+    });
+
+    const err = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe(
+      'insufficient-responses',
+    );
+    expect(probeMock).toHaveBeenCalledTimes(3);
+  });
+
+  test('(e) single-peer fallback: K=1 + allowSinglePeer + matching served tips => load succeeds', async () => {
+    const peers: TestPeer[] = ['p1'];
+    probeMock.mockResolvedValue(HASH_X);
+
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 1, allowSinglePeer: true },
+    });
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+    expect(result.winningHashHex).toBe(HASH_X_HEX);
+    expect(result.narrowedPeers).toEqual(['p1']);
+    expect(probeMock).toHaveBeenCalledTimes(1);
+
+    const serveFn = jest.fn(async () => HASH_X_HEX);
+    const loadOutcome = await simulateFullLoad({
+      narrowedPeers: result.narrowedPeers,
+      winningHashHex: result.winningHashHex,
+      serveFn,
+    });
+    expect(loadOutcome.loadedFromPeer).toBe('p1');
+  });
+
+  test('(e2) single-peer fallback: K=1 + allowSinglePeer + probe TIMEOUT => LoadQuorumFailedError', async () => {
+    // Complement of (e): the single-peer pass-through is NOT a free pass.
+    // If the one probed peer doesn't return a hash within the timeout, the
+    // gate must still fail closed.
+    const peers: TestPeer[] = ['p1'];
+    probeMock.mockResolvedValue(null);
+
+    const err = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 1, allowSinglePeer: true },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe(
+      'insufficient-responses',
+    );
+  });
+
+  test('single-peer fallback DENIED when allowSinglePeer=false (default)', async () => {
+    // The orchestrator must refuse to run quorum against a single peer
+    // unless the caller opts in. This protects against silently degrading
+    // BFT semantics in small/partitioned meshes.
+    const peers: TestPeer[] = ['p1'];
+    probeMock.mockResolvedValue(HASH_X);
+
+    const err = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 1, allowSinglePeer: false },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    // The probe must NOT have been issued -- we refuse before talking to
+    // the lone peer.
+    expect(probeMock).not.toHaveBeenCalled();
+  });
+
+  test('quorum disabled: returns { skipped: true } so caller falls through to legacy load', async () => {
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockResolvedValue(HASH_X);
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: false },
+    });
+    expect(result).toEqual({ skipped: true });
+    expect(probeMock).not.toHaveBeenCalled();
+  });
+
+  test('empty peer list: returns { skipped: true } so caller treats as new document', async () => {
+    const peers: TestPeer[] = [];
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3 },
+    });
+    expect(result).toEqual({ skipped: true });
+    expect(probeMock).not.toHaveBeenCalled();
+  });
+
+  test('size-cap-triggered non-vote does NOT poison quorum when honest majority still responds', async () => {
+    // Regression for the DoS hardening fix from PR #284 r4: an
+    // oversized tip-advertise response is surfaced as `null` (non-vote)
+    // by `_probeTipAdvertise`'s outer catch. Verify that a single peer
+    // hitting the size cap does not flip the quorum into a Byzantine
+    // verdict -- the remaining honest peers must still be able to form
+    // a Q-of-K majority.
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockImplementation(async (peer: TestPeer) => {
+      // p3 simulates the size-cap RangeError surface (null = non-vote);
+      // p1 and p2 vote X honestly.
+      return peer === 'p3' ? null : HASH_X;
+    });
+
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    });
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+    expect(result.narrowedPeers).toEqual(['p1', 'p2']);
+    expect(result.winningHashHex).toBe(HASH_X_HEX);
+  });
+});

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -27,7 +27,14 @@
  * (e) single-peer fallback path.
  */
 
-import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import {
+  describe,
+  expect,
+  test,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
 import { runLoadQuorum } from './load-quorum-orchestrator';
 import { dedupePeersByPeerId, LoadQuorumFailedError } from './load-quorum';
 import { tipsHashToHex } from './tips-hash';
@@ -872,6 +879,256 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
       });
       expect('ok' in result && result.ok).toBe(true);
       expect(probeMock).toHaveBeenCalledTimes(3);
+    });
+
+    // -----------------------------------------------------------------
+    // loadQuorumTimeoutMs post-init mutation guard (PR #284 r15)
+    // -----------------------------------------------------------------
+    // `loadQuorumTimeoutMs` flows directly into `setTimeout(...)` inside
+    // the probe race. A post-init mutation to `NaN`/`Infinity`/`0`/
+    // negative would coerce the timer to immediate-fire / overflow,
+    // every probe would resolve as a non-vote, and quorum would fail on
+    // every load even with a fully healthy mesh — silently breaking the
+    // gate without surfacing the root cause as a config error. The
+    // orchestrator now re-validates `timeoutMs` alongside K/Q on every
+    // call and throws `LoadQuorumFailedError(invalid-config)` so the
+    // misconfiguration is loud at the load-attempt boundary.
+
+    test('timeoutMs = NaN throws LoadQuorumFailedError(invalid-config) (was: setTimeout immediate-fire => every probe non-vote)', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, timeoutMs: NaN },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+      expect((err as LoadQuorumFailedError).message).toMatch(
+        /loadQuorumTimeoutMs must be a positive integer.*got NaN/,
+      );
+      expect((err as LoadQuorumFailedError).message).not.toMatch(/got null/);
+      expect(probeMock).not.toHaveBeenCalled();
+    });
+
+    test('timeoutMs = Infinity throws LoadQuorumFailedError(invalid-config)', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, timeoutMs: Infinity },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+      expect((err as LoadQuorumFailedError).message).toMatch(
+        /loadQuorumTimeoutMs must be a positive integer.*got Infinity/,
+      );
+      expect(probeMock).not.toHaveBeenCalled();
+    });
+
+    test('timeoutMs = 0 throws LoadQuorumFailedError(invalid-config) (would fire immediately)', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, timeoutMs: 0 },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+      expect((err as LoadQuorumFailedError).message).toMatch(
+        /loadQuorumTimeoutMs must be a positive integer.*got 0/,
+      );
+      expect(probeMock).not.toHaveBeenCalled();
+    });
+
+    test('timeoutMs = -1 throws LoadQuorumFailedError(invalid-config)', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, timeoutMs: -1 },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+      expect((err as LoadQuorumFailedError).message).toMatch(
+        /loadQuorumTimeoutMs must be a positive integer.*got -1/,
+      );
+      expect(probeMock).not.toHaveBeenCalled();
+    });
+
+    test('timeoutMs = 1.5 (fractional) throws LoadQuorumFailedError(invalid-config)', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, timeoutMs: 1.5 },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+      expect((err as LoadQuorumFailedError).message).toMatch(
+        /loadQuorumTimeoutMs must be a positive integer.*got 1\.5/,
+      );
+      expect(probeMock).not.toHaveBeenCalled();
+    });
+
+    test('timeoutMs = valid integer (5000 ms) passes through and probes run', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2, timeoutMs: 5000 },
+      });
+      expect('ok' in result && result.ok).toBe(true);
+      expect(probeMock).toHaveBeenCalledTimes(3);
+    });
+
+    test('timeoutMs = undefined passes through (orchestrator default applies)', async () => {
+      // `undefined` means the operator did not override; the orchestrator
+      // doesn't use the value directly (the caller does) but the
+      // defensive validator must NOT reject `undefined`.
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2, timeoutMs: undefined },
+      });
+      expect('ok' in result && result.ok).toBe(true);
+    });
+
+    test('rethrown invalid-config (timeoutMs) carries the actual documentPath', async () => {
+      const err = await runLoadQuorum({
+        peers: ['p1', 'p2'] as TestPeer[],
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/docs/y',
+        config: { enabled: true, k: 2, timeoutMs: NaN },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).documentPath).toBe('/docs/y');
+      expect((err as LoadQuorumFailedError).message).toMatch(/\/docs\/y/);
+      expect((err as LoadQuorumFailedError).message).not.toMatch(/<config>/);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // single-peer warning text (PR #284 r15 Copilot review issue #2)
+  // ---------------------------------------------------------------------
+  // The legacy wording was "only one peer known", which is accurate when
+  // the mesh truly has one peer but actively misleading when the operator
+  // configured `loadQuorumK = 1` with more peers available — they would
+  // see the warning and assume their mesh had collapsed even though it
+  // hadn't. The rewritten message includes both the configured K and the
+  // actual peer count so the cause is unambiguous in either case.
+
+  describe('single-peer fallback warning text reflects both cause cases (PR #284 r15)', () => {
+    let warnSpy: ReturnType<typeof jest.spyOn>;
+    beforeEach(() => {
+      warnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation((() => {}) as never);
+    });
+    afterEach(() => {
+      // Restore so the next test (which re-spies) starts from a clean
+      // call history. Without this, `jest.spyOn` returns the SAME spy
+      // and `mock.calls[0]` leaks from earlier tests in this describe.
+      warnSpy.mockRestore();
+    });
+
+    test('case 1: peer scarcity (1 peer in mesh) — message mentions "1 peer known"', async () => {
+      const peers: TestPeer[] = ['only-peer'];
+      probeMock.mockResolvedValue(HASH_X);
+      await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/scarcity',
+        config: { enabled: true, k: 1, allowSinglePeer: true },
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const msg = warnSpy.mock.calls[0][0] as string;
+      expect(msg).toMatch(/only one peer will be probed/);
+      expect(msg).toMatch(/loadQuorumK=1/);
+      expect(msg).toMatch(/1 peer known/);
+      expect(msg).toMatch(/loadQuorumAllowSinglePeer=true/);
+      expect(msg).toMatch(/Configure additional peers/);
+    });
+
+    test('case 2: configured K=1 with multiple peers known — message mentions actual peer count', async () => {
+      // The exact bug: 2 peers are in the mesh, but the operator pinned
+      // `loadQuorumK = 1` so only one is probed. The previous wording
+      // "only one peer known" was a lie — more peers ARE known. The new
+      // wording reflects that the cause is the configured K.
+      const peers: TestPeer[] = ['p1', 'p2'];
+      probeMock.mockResolvedValue(HASH_X);
+      await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/configured-k',
+        config: { enabled: true, k: 1, allowSinglePeer: true },
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const msg = warnSpy.mock.calls[0][0] as string;
+      expect(msg).toMatch(/only one peer will be probed/);
+      expect(msg).toMatch(/loadQuorumK=1/);
+      // The actual peer count must be reflected — NOT a misleading "1".
+      expect(msg).toMatch(/2 peers known/);
+      // Operator guidance should point at the actual remediation
+      // (raising K), not at "configure more peers" which is irrelevant.
+      expect(msg).toMatch(/Increase loadQuorumK/);
+      expect(msg).not.toMatch(/Configure additional peers/);
+      // Sanity: must NOT use the misleading legacy "only one peer known"
+      // phrasing, which was accurate only for case 1.
+      expect(msg).not.toMatch(/only one peer known/);
+    });
+
+    test('case 2 (larger): K=1 with 5 peers known — message reports 5', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3', 'p4', 'p5'];
+      probeMock.mockResolvedValue(HASH_X);
+      await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/big-mesh-k1',
+        config: { enabled: true, k: 1, allowSinglePeer: true },
+      });
+      const msg = warnSpy.mock.calls[0][0] as string;
+      expect(msg).toMatch(/5 peers known/);
+      expect(msg).toMatch(/Increase loadQuorumK/);
+    });
+
+    test('warning includes the documentPath prefix for operator log triage', async () => {
+      const peers: TestPeer[] = ['p1'];
+      probeMock.mockResolvedValue(HASH_X);
+      await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/docs/my-doc',
+        config: { enabled: true, k: 1, allowSinglePeer: true },
+      });
+      const msg = warnSpy.mock.calls[0][0] as string;
+      expect(msg).toMatch(/\[\/docs\/my-doc\]/);
     });
   });
 

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -630,6 +630,13 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
     // The probe must NOT have been issued -- we refuse before talking to
     // the lone peer.
     expect(probeMock).not.toHaveBeenCalled();
+    // Surfaced `requiredQ` is the load-bearing policy threshold (2 -- the
+    // smallest cohort that gives any Byzantine fault tolerance), NOT the
+    // numeric `defaultQuorumQ(1) = 1` that would falsely suggest the
+    // lone peer's vote was "almost enough". See PR #284 r25 Copilot
+    // review.
+    expect((err as LoadQuorumFailedError).requiredQ).toBe(2);
+    expect((err as LoadQuorumFailedError).respondingCount).toBe(0);
   });
 
   test('quorum disabled: returns { skipped: true } so caller falls through to legacy load', async () => {

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -279,6 +279,92 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
     expect(serveFn).not.toHaveBeenCalledWith('p3');
   });
 
+  test('(c2-missing-tips) PR #284 r9 issue #1: responder omits `tips` on v3 quorum-enabled load => per-peer bind failure; loader tries next agreeing peer', async () => {
+    // PR #284 r9 Copilot review (issue #1): the v3 load-response
+    // contract requires `tips` to be present on every quorum-enabled
+    // load response so the responder commits to an explicit frontier
+    // attestation. A v3 responder that omits `tips` previously slipped
+    // through the bind path (the `Array.isArray(message.tips)` defense-
+    // in-depth branch simply skipped). Now the omission is treated as
+    // a per-peer bind failure with the sentinel `'(missing tips)'` so
+    // the loader retries the next agreeing peer (mirrors the PR #284
+    // r6 DoS fix: one peer cannot unilaterally DoS the load).
+    //
+    // The simulated harness models the missing-tips case by having the
+    // peer's `serveFn` return the `'(missing tips)'` sentinel (which
+    // production `_sendLoadRequestAndSync` uses inside
+    // `_QuorumBindCheckFailedError.advertisedHex` for the same path).
+    // The sentinel is never byte-equal to the `winningHashHex`, so the
+    // harness records the peer as bind-failed and continues.
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockResolvedValue(HASH_X);
+
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    });
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+    expect(result.narrowedPeers).toEqual(['p1', 'p2', 'p3']);
+
+    // p1 voted X but omits `tips` on the load response (v3 protocol
+    // violation). p2 is honest: voted X, serves X with tips. p3 should
+    // never be touched -- p2 succeeds.
+    const MISSING_TIPS = '(missing tips)';
+    const serveFn = jest.fn(async (peer: TestPeer) => {
+      if (peer === 'p1') return MISSING_TIPS;
+      return HASH_X_HEX;
+    });
+    const loadOutcome = await simulateFullLoad({
+      narrowedPeers: result.narrowedPeers,
+      winningHashHex: result.winningHashHex,
+      serveFn,
+    });
+    expect(loadOutcome.loadedFromPeer).toBe('p2');
+    expect(loadOutcome.attempts).toEqual(['p1', 'p2']);
+    expect(serveFn).toHaveBeenCalledWith('p1');
+    expect(serveFn).toHaveBeenCalledWith('p2');
+    expect(serveFn).not.toHaveBeenCalledWith('p3');
+  });
+
+  test('(c2-missing-tips-all) PR #284 r9 issue #1: ALL agreeing peers omit `tips` => LoadQuorumFailedError(bind-check-failed-all-agreeing-peers) with `(missing tips)` sentinel', async () => {
+    // The whole cohort violates the v3 protocol contract by omitting
+    // `tips` on every load response. Loader must exhaust the cohort,
+    // escalate with the dedicated reason, and record the
+    // `'(missing tips)'` sentinel per peer so operators can tell
+    // missing-tips equivocation apart from served-vs-claimed mismatch.
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockResolvedValue(HASH_X);
+
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    });
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+
+    const MISSING_TIPS = '(missing tips)';
+    const serveFn = jest.fn(async () => MISSING_TIPS);
+    const err = await simulateFullLoad({
+      narrowedPeers: result.narrowedPeers,
+      winningHashHex: result.winningHashHex,
+      serveFn,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    const lqfe = err as LoadQuorumFailedError;
+    expect(lqfe.reason).toBe('bind-check-failed-all-agreeing-peers');
+    expect(serveFn).toHaveBeenCalledTimes(3);
+    expect(lqfe.agreeingPeerBindFailures.get('p1')).toBe(MISSING_TIPS);
+    expect(lqfe.agreeingPeerBindFailures.get('p2')).toBe(MISSING_TIPS);
+    expect(lqfe.agreeingPeerBindFailures.get('p3')).toBe(MISSING_TIPS);
+  });
+
   test('(c3) all agreeing peers Byzantine on load: error carries per-peer agreeingPeerBindFailures with what each served', async () => {
     // Complement of (c2): when EVERY agreeing peer equivocates between
     // probe and load, the loader must escalate -- with the new

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -643,7 +643,7 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
     expect(err).toBeInstanceOf(LoadQuorumFailedError);
     expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
     expect((err as LoadQuorumFailedError).message).toMatch(
-      /loadQuorumK must be >= 1; got 0/,
+      /loadQuorumK must be a positive integer; got 0/,
     );
     expect(probeMock).not.toHaveBeenCalled();
   });
@@ -661,7 +661,7 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
     expect(err).toBeInstanceOf(LoadQuorumFailedError);
     expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
     expect((err as LoadQuorumFailedError).message).toMatch(
-      /loadQuorumK must be >= 1; got -1/,
+      /loadQuorumK must be a positive integer; got -1/,
     );
   });
 
@@ -682,6 +682,197 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
     expect(err).toBeInstanceOf(LoadQuorumFailedError);
     expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
     expect(probeMock).not.toHaveBeenCalled();
+  });
+
+  describe('post-init mutation of K/Q is caught as invalid-config (PR #284 r10)', () => {
+    // Regression for PR #284 r10 Copilot review issue #2: `runLoadQuorum`
+    // previously only rejected `K <= 0`. If a caller's `config.loadQuorumK`
+    // was valid at `initialize()` but later mutated to `NaN`/`Infinity`/`-1`
+    // BEFORE `load()` ran, `effectiveK(NaN, peers)` returned 0 (per the r9
+    // defensive guards), the K=0 branch returned `{ skipped: true }`, and
+    // `load()` fell through to the legacy unbound load — but
+    // `loadQuorumEnabled` was still `true`, so the operator's intent
+    // (quorum-protected load) was silently violated. The defensive
+    // re-validation at the top of `runLoadQuorum` now catches this as a
+    // hard `invalid-config` error rather than a silent skip.
+    //
+    // The legitimate `{ skipped: true }` paths (`enabled: false`, zero
+    // peers with a valid default K) are NOT config errors and must NOT
+    // throw — those are covered by the existing "quorum disabled" and
+    // "empty peer list" tests above, plus the explicit re-check below.
+
+    test('K = NaN throws LoadQuorumFailedError(invalid-config) (was: silent skip => legacy unbound load)', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: NaN },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+      // The error message must show `NaN` (not the misleading `null`
+      // produced by `JSON.stringify(NaN)`) — that's the PR #284 r10
+      // issue #1 fix for `formatConfigValue`.
+      expect((err as LoadQuorumFailedError).message).toMatch(
+        /loadQuorumK must be a positive integer; got NaN/,
+      );
+      expect(probeMock).not.toHaveBeenCalled();
+    });
+
+    test('K = Infinity throws LoadQuorumFailedError(invalid-config) with operator-visible "Infinity"', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: Infinity },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+      expect((err as LoadQuorumFailedError).message).toMatch(
+        /loadQuorumK must be a positive integer; got Infinity/,
+      );
+      expect(probeMock).not.toHaveBeenCalled();
+    });
+
+    test('K = -Infinity throws LoadQuorumFailedError(invalid-config)', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: -Infinity },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+      expect((err as LoadQuorumFailedError).message).toMatch(
+        /loadQuorumK must be a positive integer; got -Infinity/,
+      );
+    });
+
+    test('K = 1.5 (fractional) throws LoadQuorumFailedError(invalid-config)', async () => {
+      // Was a silent single-peer probe (`peers.slice(0, 1.5)` => 1 peer)
+      // under the original bug; now refused loud-and-early.
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 1.5 },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+      expect((err as LoadQuorumFailedError).message).toMatch(
+        /loadQuorumK must be a positive integer; got 1\.5/,
+      );
+      expect(probeMock).not.toHaveBeenCalled();
+    });
+
+    test('Q = NaN throws LoadQuorumFailedError(invalid-config) (was: silent single-peer quorum pass)', async () => {
+      // Symmetric case for Q. Without the validator, `effectiveQ(NaN, k)`
+      // returned `defaultQuorumQ(k)` via the r9 fallback — so the gate
+      // ran with a sensible Q but the operator's *intent* (their
+      // explicitly-set Q) had been silently corrupted. Surface the
+      // mutation as a hard error instead.
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: NaN },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+      expect((err as LoadQuorumFailedError).message).toMatch(
+        /loadQuorumQ must be a positive integer; got NaN/,
+      );
+      expect(probeMock).not.toHaveBeenCalled();
+    });
+
+    test('rethrown invalid-config carries the actual documentPath (NOT the validator placeholder)', async () => {
+      // `validateLoadQuorumConfig` uses `'<config>'` because it has no
+      // doc path at startup. The orchestrator must replace that with the
+      // load-attempt's actual `documentPath` so operator logs identify
+      // which document's load tripped the post-init mutation.
+      const err = await runLoadQuorum({
+        peers: ['p1', 'p2'] as TestPeer[],
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/docs/x',
+        config: { enabled: true, k: NaN },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).documentPath).toBe('/docs/x');
+      expect((err as LoadQuorumFailedError).message).toMatch(/\/docs\/x/);
+      expect((err as LoadQuorumFailedError).message).not.toMatch(
+        /<config>/,
+      );
+    });
+
+    test('loadQuorumEnabled: false still returns { skipped: true } even with invalid K (early-exit precedes validation)', async () => {
+      // When the operator has explicitly disabled the gate, validation of
+      // K/Q is irrelevant — the values won't be consulted at all. The
+      // `enabled` short-circuit precedes the validator so an
+      // already-disabled gate doesn't suddenly start throwing on a
+      // pre-existing bad K.
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: false, k: NaN },
+      });
+      expect(result).toEqual({ skipped: true });
+      expect(probeMock).not.toHaveBeenCalled();
+    });
+
+    test('valid K with zero peers still returns { skipped: true } (NOT a config error)', async () => {
+      // Zero peers with a valid K is the legitimate founder/partition
+      // case: `effectiveK(3, 0) === 0` => `{ skipped: true }`. The
+      // validator must NOT misfire here because the configured K is
+      // perfectly valid; the absence of peers is a runtime fact, not a
+      // config error.
+      const result = await runLoadQuorum({
+        peers: [] as TestPeer[],
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3 },
+      });
+      expect(result).toEqual({ skipped: true });
+      expect(probeMock).not.toHaveBeenCalled();
+    });
+
+    test('idempotent: post-init validation is a no-op for already-valid config (matches initialize-time pass)', async () => {
+      // Defence-in-depth must not double-throw on the happy path. A
+      // config that passed `Collabswarm.initialize()`'s validator must
+      // continue to pass `runLoadQuorum`'s identical check on every
+      // load attempt.
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2 },
+      });
+      expect('ok' in result && result.ok).toBe(true);
+      expect(probeMock).toHaveBeenCalledTimes(3);
+    });
   });
 
   test('multi-peer probe that REJECTS is recorded as a non-vote; other peers still tally', async () => {

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -1678,21 +1678,31 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
       expect(probeMock).toHaveBeenCalledTimes(3);
     });
 
-    test("majority 'unknown-doc' (2 of 3) with 1 tip-hash dissenter => { newDoc: true }", async () => {
+    test("majority 'unknown-doc' (2 of 3) with 1 tip-hash dissenter => no-majority (tip-hash priority, PR #284 r19)", async () => {
+      // r19 Copilot review: tip-hash votes take PRIORITY over
+      // unknown-doc disclaims because the probe samples the WHOLE libp2p
+      // mesh (`getConnections()`), not only peers that hold this
+      // document. Two unrelated peers in the mesh legitimately
+      // returning 'unknown-doc' must NOT outvote the one peer that
+      // actually has the document and force a fork via new-doc
+      // creation. With Q=2 here, the lone HASH_X vote does not meet
+      // quorum on its own, so the orchestrator throws no-majority
+      // rather than surfacing { newDoc: true }.
       const peers: TestPeer[] = ['p1', 'p2', 'p3'];
       probeMock.mockImplementation(async (peer: TestPeer) =>
         peer === 'p3' ? HASH_X : 'unknown-doc',
       );
 
-      const result = await runLoadQuorum({
+      const err = await runLoadQuorum({
         peers,
         peerIdOf,
         probeFn: probeMock,
         documentPath: '/test',
         config: { enabled: true, k: 3, q: 2 },
-      });
+      }).catch((e: unknown) => e);
 
-      expect('newDoc' in result && result.newDoc).toBe(true);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('no-majority');
     });
 
     test("single lying 'unknown-doc' in a 3-peer mesh whose other peers have the doc CANNOT force new-doc creation", async () => {

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -29,7 +29,7 @@
 
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import { runLoadQuorum } from './load-quorum-orchestrator';
-import { LoadQuorumFailedError } from './load-quorum';
+import { dedupePeersByPeerId, LoadQuorumFailedError } from './load-quorum';
 import { tipsHashToHex } from './tips-hash';
 
 /**
@@ -598,6 +598,169 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
     if (!('ok' in result)) throw new Error('expected ok=true');
     expect(result.narrowedPeers).toEqual(['p1', 'p2']);
     expect(result.winningHashHex).toBe(HASH_X_HEX);
+  });
+
+  describe('legacy load loop preserves un-deduped peer list (PR #284 r7)', () => {
+    // Regression for PR #284 r7 Copilot review: the load loop previously
+    // deduped peers by peer id UNCONDITIONALLY -- before the quorum probe,
+    // affecting BOTH the quorum probe AND the legacy single-peer load
+    // loop. When `loadQuorumEnabled: false`, the legacy loop should keep
+    // multiple multiaddrs for the same peer id (e.g. direct connection +
+    // relay-circuit fallback) so the second can be tried if the first
+    // fails. The fix uses `quorumPeers = dedupePeersByPeerId(orderedPeers)`
+    // for the probe only; `orderedPeers` (un-deduped) is preserved for
+    // the legacy loop.
+    //
+    // The control-flow snippet under test mirrors the relevant slice of
+    // `CollabswarmDocument.load()`: build `quorumPeers` for the probe,
+    // keep `orderedPeers` for the loop. The tests here do NOT use real
+    // multiaddrs -- they use `{ id, addr }` test doubles where `id` is
+    // the peer id and `addr` is a per-connection sentinel. The
+    // `peerIdOf` extractor returns `id` so dedup collapses entries
+    // sharing the same `id` but different `addr`.
+
+    interface MultiAddrPeer {
+      id: string;
+      addr: string;
+    }
+    const idOf = (p: MultiAddrPeer) => p.id;
+
+    function simulateLegacyLoop(opts: {
+      orderedPeers: MultiAddrPeer[];
+      // Per-connection result. Returns `true` if the load succeeded for
+      // this connection, `false` to fall through to the next one.
+      loadFn: (peer: MultiAddrPeer) => Promise<boolean>;
+    }): Promise<{
+      attempts: MultiAddrPeer[];
+      loadedFromAddr: string | null;
+    }> {
+      const attempts: MultiAddrPeer[] = [];
+      return (async () => {
+        for (const peer of opts.orderedPeers) {
+          attempts.push(peer);
+          const ok = await opts.loadFn(peer);
+          if (ok) return { attempts, loadedFromAddr: peer.addr };
+        }
+        return { attempts, loadedFromAddr: null };
+      })();
+    }
+
+    test('quorum disabled: legacy loop iterates ALL multiaddrs for the same peer id', async () => {
+      // Two connections to the same peer id "alice": a direct dial that
+      // fails, and a relay-circuit fallback that succeeds. The legacy
+      // loop must try BOTH (the fallback is the whole point of having
+      // multiple connections). Under the bug, dedup collapses the two
+      // entries to one and the loader gives up after the direct dial
+      // fails.
+      const orderedPeers: MultiAddrPeer[] = [
+        { id: 'alice', addr: '/direct/alice' },
+        { id: 'alice', addr: '/p2p-circuit/alice' },
+      ];
+
+      // Dedup is for the QUORUM probe only; the legacy loop keeps
+      // `orderedPeers` un-deduped (this mirrors the production code in
+      // `CollabswarmDocument.load()` after the PR #284 r7 fix).
+      const quorumPeers = dedupePeersByPeerId(orderedPeers, idOf);
+      expect(quorumPeers).toEqual([
+        { id: 'alice', addr: '/direct/alice' },
+      ]);
+
+      // Quorum disabled => legacy loop walks `orderedPeers` (un-deduped).
+      const loadFn = jest.fn(async (peer: MultiAddrPeer) => {
+        // Direct fails; circuit succeeds.
+        return peer.addr === '/p2p-circuit/alice';
+      });
+      const outcome = await simulateLegacyLoop({
+        orderedPeers,
+        loadFn,
+      });
+      expect(outcome.attempts).toEqual([
+        { id: 'alice', addr: '/direct/alice' },
+        { id: 'alice', addr: '/p2p-circuit/alice' },
+      ]);
+      expect(outcome.loadedFromAddr).toBe('/p2p-circuit/alice');
+      // Both connections were tried.
+      expect(loadFn).toHaveBeenCalledTimes(2);
+    });
+
+    test('quorum disabled: prior buggy behaviour (loop over deduped list) would have stopped after the failed direct dial', async () => {
+      // Documenting the regression we are guarding against: under the
+      // pre-fix code, the loop iterated `dedupePeersByPeerId(orderedPeers)`,
+      // i.e. only ONE entry per peer id. The fallback connection was
+      // never tried.
+      const orderedPeers: MultiAddrPeer[] = [
+        { id: 'alice', addr: '/direct/alice' },
+        { id: 'alice', addr: '/p2p-circuit/alice' },
+      ];
+      const dedupedAsBug = dedupePeersByPeerId(orderedPeers, idOf);
+      const loadFn = jest.fn(async (peer: MultiAddrPeer) => {
+        return peer.addr === '/p2p-circuit/alice';
+      });
+      const outcome = await simulateLegacyLoop({
+        orderedPeers: dedupedAsBug,
+        loadFn,
+      });
+      // Bug behaviour: only the direct dial is attempted, so the load
+      // fails even though a valid fallback existed.
+      expect(outcome.attempts).toEqual([
+        { id: 'alice', addr: '/direct/alice' },
+      ]);
+      expect(outcome.loadedFromAddr).toBeNull();
+      expect(loadFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('quorum disabled: distinct peer ids are unaffected', async () => {
+      // Sanity check: dedup-by-peer-id is a no-op when each peer id
+      // appears once. The fix doesn't regress this path.
+      const orderedPeers: MultiAddrPeer[] = [
+        { id: 'alice', addr: '/direct/alice' },
+        { id: 'bob', addr: '/direct/bob' },
+      ];
+      const quorumPeers = dedupePeersByPeerId(orderedPeers, idOf);
+      expect(quorumPeers).toEqual(orderedPeers);
+      const loadFn = jest.fn(async (peer: MultiAddrPeer) => peer.id === 'alice');
+      const outcome = await simulateLegacyLoop({ orderedPeers, loadFn });
+      expect(outcome.loadedFromAddr).toBe('/direct/alice');
+      expect(loadFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('quorum enabled: probe-only dedup still applies (single vote per peer id)', async () => {
+      // Complementary case: when quorum IS enabled, the probe round uses
+      // the deduped list so a peer with two connections can't cast two
+      // votes. The narrowed cohort returned by `runLoadQuorum` is a
+      // filter of the deduped list, so the subsequent load loop only
+      // sees one connection per peer id in the narrowed cohort. This is
+      // the intended behaviour for the quorum path.
+      const orderedPeers: MultiAddrPeer[] = [
+        { id: 'alice', addr: '/direct/alice' },
+        { id: 'alice', addr: '/p2p-circuit/alice' },
+        { id: 'bob', addr: '/direct/bob' },
+        { id: 'carol', addr: '/direct/carol' },
+      ];
+      const quorumPeers = dedupePeersByPeerId(orderedPeers, idOf);
+      expect(quorumPeers.map(idOf)).toEqual(['alice', 'bob', 'carol']);
+
+      probeMock.mockResolvedValue(HASH_X);
+      const result = await runLoadQuorum({
+        peers: quorumPeers,
+        peerIdOf: idOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2 },
+      });
+      expect('ok' in result && result.ok).toBe(true);
+      if (!('ok' in result)) throw new Error('expected ok=true');
+      // Each peer voted exactly once -- alice's duplicate connection did
+      // not give her a second vote.
+      expect(probeMock).toHaveBeenCalledTimes(3);
+      // The narrowed cohort carries one entry per peer id, mirroring the
+      // probe input.
+      expect(result.narrowedPeers.map(idOf)).toEqual([
+        'alice',
+        'bob',
+        'carol',
+      ]);
+    });
   });
 
   describe('default Q is derived from EFFECTIVE K, not configured K (PR #284 r7)', () => {

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -85,7 +85,7 @@ const peerIdOf = (p: TestPeer) => p;
 async function simulateFullLoad(opts: {
   narrowedPeers: TestPeer[];
   winningHashHex: string;
-  serveFn: (peer: TestPeer) => Promise<string>; // returns served-tips hash hex
+  serveFn: (peer: TestPeer) => Promise<string>; // returns served-tips hash hex; throw for transport failure
 }): Promise<{
   loadedFromPeer: TestPeer | null;
   attempts: TestPeer[];
@@ -94,7 +94,16 @@ async function simulateFullLoad(opts: {
   const agreeingPeerBindFailures = new Map<string, string>();
   for (const peer of opts.narrowedPeers) {
     attempts.push(peer);
-    const servedHashHex = await opts.serveFn(peer);
+    let servedHashHex: string;
+    try {
+      servedHashHex = await opts.serveFn(peer);
+    } catch {
+      // Transport/protocol failure: peer didn't even return a hash.
+      // Production `load()` catches transport errors inside the loop and
+      // continues to the next peer WITHOUT recording a bind failure.
+      // See PR #284 r17 Copilot review for the mixed-cohort distinction.
+      continue;
+    }
     if (servedHashHex === opts.winningHashHex) {
       return { loadedFromPeer: peer, attempts };
     }
@@ -105,10 +114,22 @@ async function simulateFullLoad(opts: {
     // for the harness.
     agreeingPeerBindFailures.set(peer, servedHashHex);
   }
-  // Loop exhausted with at least one bind failure recorded => every peer
-  // in the agreeing cohort equivocated between the probe round and the
-  // load round. Escalate with the dedicated reason.
-  if (agreeingPeerBindFailures.size > 0) {
+  // Loop exhausted. Failure-reason decision mirrors production
+  // `CollabswarmDocument.load()` post-r17:
+  //
+  //   - `bindFailures.size === cohortSize` -- EVERY peer bind-failed
+  //     (coordinated Byzantine equivocation). Escalate with the
+  //     dedicated reason.
+  //   - `bindFailures.size > 0 && < cohortSize` -- MIXED failure (some
+  //     bind-failed, others transport-failed). Surface as
+  //     `agreeing-peers-unreachable` so callers don't wrongly treat a
+  //     transient retrieval failure as coordinated Byzantine behaviour.
+  //   - `bindFailures.size === 0` -- all transport-failed; same
+  //     `agreeing-peers-unreachable` reason.
+  if (opts.narrowedPeers.length === 0) {
+    return { loadedFromPeer: null, attempts };
+  }
+  if (agreeingPeerBindFailures.size === opts.narrowedPeers.length) {
     throw new LoadQuorumFailedError({
       documentPath: '/test',
       reason: 'bind-check-failed-all-agreeing-peers',
@@ -118,7 +139,14 @@ async function simulateFullLoad(opts: {
       agreeingPeerBindFailures,
     });
   }
-  return { loadedFromPeer: null, attempts };
+  throw new LoadQuorumFailedError({
+    documentPath: '/test',
+    reason: 'agreeing-peers-unreachable',
+    respondingCount: 0,
+    requiredQ: 0,
+    agreement: new Map([[opts.winningHashHex, 0]]),
+    agreeingPeerBindFailures,
+  });
 }
 
 describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => {
@@ -1515,6 +1543,112 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
       // 2 votes available but 3 required => insufficient-responses.
       expect((err as LoadQuorumFailedError).reason).toBe(
         'insufficient-responses',
+      );
+    });
+  });
+
+  // PR #284 r17: when the agreeing cohort partly bind-fails and partly
+  // transport-fails, the loader must NOT use the
+  // `bind-check-failed-all-agreeing-peers` reason -- that reason's public
+  // docs explicitly say EVERY peer in the cohort equivocated, and using
+  // it for mixed failure modes can make callers wrongly conclude
+  // coordinated Byzantine behaviour when the underlying cause was a
+  // mixture of one bad actor + transient network errors. Mixed failures
+  // surface as `agreeing-peers-unreachable` (still threading the per-peer
+  // bind-failure map through for diagnostics).
+  describe("mixed bind/transport failure cohort uses 'agreeing-peers-unreachable' (PR #284 r17)", () => {
+    test("(c-mixed-1) 1 bind-failure + 2 transport-failures => 'agreeing-peers-unreachable'", async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2 },
+      });
+      expect('ok' in result && result.ok).toBe(true);
+      if (!('ok' in result)) throw new Error('expected ok=true');
+
+      // p1 bind-fails (serves Y), p2/p3 transport-fail (throw).
+      const serveFn = jest.fn(async (peer: TestPeer) => {
+        if (peer === 'p1') return HASH_Y_HEX;
+        throw new Error('transport error');
+      });
+      const err = await simulateFullLoad({
+        narrowedPeers: result.narrowedPeers,
+        winningHashHex: result.winningHashHex,
+        serveFn,
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      // CRITICAL: mixed cohort failures must NOT use the
+      // bind-check-failed-all-agreeing-peers reason.
+      expect((err as LoadQuorumFailedError).reason).toBe(
+        'agreeing-peers-unreachable',
+      );
+      // Per-peer bind-failure map still surfaces for operator diagnostics.
+      expect(
+        (err as LoadQuorumFailedError).agreeingPeerBindFailures,
+      ).toEqual(new Map([['p1', HASH_Y_HEX]]));
+    });
+
+    test("(c-mixed-2) 2 bind-failures + 1 transport-failure => 'agreeing-peers-unreachable'", async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2 },
+      });
+      if (!('ok' in result)) throw new Error('expected ok=true');
+
+      // p1, p2 bind-fail; p3 transport-fails. Still mixed; reason stays
+      // `agreeing-peers-unreachable` (the bind-failure count < cohort size).
+      const serveFn = jest.fn(async (peer: TestPeer) => {
+        if (peer === 'p3') throw new Error('transport error');
+        return HASH_Y_HEX;
+      });
+      const err = await simulateFullLoad({
+        narrowedPeers: result.narrowedPeers,
+        winningHashHex: result.winningHashHex,
+        serveFn,
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe(
+        'agreeing-peers-unreachable',
+      );
+      expect(
+        (err as LoadQuorumFailedError).agreeingPeerBindFailures.size,
+      ).toBe(2);
+    });
+
+    test("(c-mixed-3) only when EVERY peer bind-fails does the dedicated reason fire", async () => {
+      // Sanity check: the dedicated reason is still reachable when the
+      // cohort is fully bind-failed. Regression guard so the fix for the
+      // mixed-cohort issue doesn't accidentally suppress the coordinated-
+      // Byzantine reason.
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2 },
+      });
+      if (!('ok' in result)) throw new Error('expected ok=true');
+
+      const serveFn = jest.fn(async () => HASH_Y_HEX);
+      const err = await simulateFullLoad({
+        narrowedPeers: result.narrowedPeers,
+        winningHashHex: result.winningHashHex,
+        serveFn,
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe(
+        'bind-check-failed-all-agreeing-peers',
       );
     });
   });

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -58,11 +58,22 @@ const peerIdOf = (p: TestPeer) => p;
 
 /**
  * Mirror of how `CollabswarmDocument.load()` uses the orchestrator: probe
- * peers, then perform the full document-load against any peer in the
- * narrowed cohort, with the responder's served `tips` hash bound to the
- * quorum's `winningHashHex`. The harness below stands in for the
- * snapshot/doc-load loop so the binding check is exercised against the
- * narrowed peer list this orchestrator produces.
+ * peers, then perform the full document-load against the narrowed cohort,
+ * with the responder's served `tips` hash bound to the quorum's
+ * `winningHashHex`. The harness below stands in for the snapshot/doc-load
+ * loop so the binding check is exercised against the narrowed peer list
+ * this orchestrator produces.
+ *
+ * Per-peer bind failures are NOT fatal: a peer whose served hash does not
+ * match `winningHashHex` is recorded in `agreeingPeerBindFailures` and the
+ * harness continues to the NEXT peer in the cohort. Only after EVERY peer
+ * in the narrowed cohort has bind-failed (and at least one bind failure
+ * was recorded) does the harness throw
+ * `LoadQuorumFailedError(reason: 'bind-check-failed-all-agreeing-peers')`.
+ * This mirrors the PR #284 r6 DoS fix in production `load()` -- a single
+ * malicious peer in the agreeing cohort that votes for the majority hash
+ * and then serves a mismatched full load can NOT unilaterally abort the
+ * whole load.
  */
 async function simulateFullLoad(opts: {
   narrowedPeers: TestPeer[];
@@ -73,24 +84,31 @@ async function simulateFullLoad(opts: {
   attempts: TestPeer[];
 }> {
   const attempts: TestPeer[] = [];
+  const agreeingPeerBindFailures = new Map<string, string>();
   for (const peer of opts.narrowedPeers) {
     attempts.push(peer);
     const servedHashHex = await opts.serveFn(peer);
     if (servedHashHex === opts.winningHashHex) {
       return { loadedFromPeer: peer, attempts };
     }
-    // else: binding fails; the production `_sendLoadRequestAndSync`
-    // would throw LoadQuorumFailedError. Mirror that here so the test
-    // also asserts the load aborts on mismatch.
+    // Bind check failed for THIS peer. Record it and continue to the
+    // next peer in the agreeing cohort. Production `_sendLoadRequestAndSync`
+    // throws an internal `_QuorumBindCheckFailedError` here and `load()`
+    // catches it inside the loop; we collapse that into a "record + continue"
+    // for the harness.
+    agreeingPeerBindFailures.set(peer, servedHashHex);
+  }
+  // Loop exhausted with at least one bind failure recorded => every peer
+  // in the agreeing cohort equivocated between the probe round and the
+  // load round. Escalate with the dedicated reason.
+  if (agreeingPeerBindFailures.size > 0) {
     throw new LoadQuorumFailedError({
       documentPath: '/test',
-      reason: 'no-majority',
+      reason: 'bind-check-failed-all-agreeing-peers',
       respondingCount: 0,
       requiredQ: 0,
-      agreement: new Map([
-        [opts.winningHashHex, 0],
-        [servedHashHex, 0],
-      ]),
+      agreement: new Map([[opts.winningHashHex, 0]]),
+      agreeingPeerBindFailures,
     });
   }
   return { loadedFromPeer: null, attempts };
@@ -169,7 +187,13 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
     expect(loadOutcome.loadedFromPeer).toBe('p1');
   });
 
-  test('(c) 3 peers all vote X but the chosen peer serves tips hashing to Y => LoadQuorumFailedError', async () => {
+  test('(c) 3 peers all vote X but EVERY peer serves tips hashing to Y => LoadQuorumFailedError(bind-check-failed-all-agreeing-peers)', async () => {
+    // The whole cohort is Byzantine on the load step: every agreeing peer
+    // voted X in the probe round but serves Y on the full load. The
+    // harness must exhaust the cohort BEFORE escalating, so the
+    // serveFn is called for every peer and the final error carries the
+    // dedicated `bind-check-failed-all-agreeing-peers` reason plus a
+    // per-peer `agreeingPeerBindFailures` map. See PR #284 r6.
     const peers: TestPeer[] = ['p1', 'p2', 'p3'];
     probeMock.mockResolvedValue(HASH_X);
 
@@ -183,16 +207,121 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
     expect('ok' in result && result.ok).toBe(true);
     if (!('ok' in result)) throw new Error('expected ok=true');
 
-    // The first agreeing peer (p1) serves tips that don't match the
-    // winning hash -- exactly the equivocation case from the comment.
     const serveFn = jest.fn(async () => HASH_Y_HEX);
-    await expect(
-      simulateFullLoad({
-        narrowedPeers: result.narrowedPeers,
-        winningHashHex: result.winningHashHex,
-        serveFn,
-      }),
-    ).rejects.toBeInstanceOf(LoadQuorumFailedError);
+    const err = await simulateFullLoad({
+      narrowedPeers: result.narrowedPeers,
+      winningHashHex: result.winningHashHex,
+      serveFn,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe(
+      'bind-check-failed-all-agreeing-peers',
+    );
+    // Every agreeing peer must have been tried before the escalation.
+    expect(serveFn).toHaveBeenCalledTimes(3);
+    // Per-peer record of what each Byzantine peer served instead.
+    expect(
+      (err as LoadQuorumFailedError).agreeingPeerBindFailures,
+    ).toEqual(
+      new Map([
+        ['p1', HASH_Y_HEX],
+        ['p2', HASH_Y_HEX],
+        ['p3', HASH_Y_HEX],
+      ]),
+    );
+  });
+
+  test('(c2) DoS regression: ONE Byzantine agreeing peer cannot abort the whole load; honest peer is tried next', async () => {
+    // Regression for the critical PR #284 r6 finding: previously, if the
+    // first peer chosen for the full load was Byzantine on the load
+    // step (voted hash X, served tips hashing to Y), the loader threw
+    // `LoadQuorumFailedError` and aborted -- never trying the OTHER
+    // honest agreeing peers who WOULD have served a matching response.
+    // That was a DoS vector: a single malicious peer in the agreeing
+    // cohort could unilaterally prevent any load. After the fix, the
+    // loader records the bind failure against the offending peer and
+    // falls through to the next peer in the cohort.
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockResolvedValue(HASH_X);
+
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    });
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+    expect(result.narrowedPeers).toEqual(['p1', 'p2', 'p3']);
+
+    // p1 is Byzantine on the load step: voted X, serves Y.
+    // p2 is honest: voted X, serves X.
+    // p3 should never be reached because p2 succeeds.
+    const serveFn = jest.fn(async (peer: TestPeer) => {
+      if (peer === 'p1') return HASH_Y_HEX;
+      return HASH_X_HEX;
+    });
+    const loadOutcome = await simulateFullLoad({
+      narrowedPeers: result.narrowedPeers,
+      winningHashHex: result.winningHashHex,
+      serveFn,
+    });
+    // Load succeeded against p2 (the honest peer immediately after
+    // the Byzantine p1) -- NOT thrown.
+    expect(loadOutcome.loadedFromPeer).toBe('p2');
+    // Both p1 (bind-failed) and p2 (success) were attempted in order.
+    expect(loadOutcome.attempts).toEqual(['p1', 'p2']);
+    // p3 must NOT have been touched -- the load short-circuits on
+    // the first successful bind.
+    expect(serveFn).toHaveBeenCalledWith('p1');
+    expect(serveFn).toHaveBeenCalledWith('p2');
+    expect(serveFn).not.toHaveBeenCalledWith('p3');
+  });
+
+  test('(c3) all agreeing peers Byzantine on load: error carries per-peer agreeingPeerBindFailures with what each served', async () => {
+    // Complement of (c2): when EVERY agreeing peer equivocates between
+    // probe and load, the loader must escalate -- with the new
+    // `bind-check-failed-all-agreeing-peers` reason and a per-peer
+    // record of what each Byzantine peer served instead, so callers
+    // can tell "the whole cohort lied on the load step" apart from
+    // "no peer responded at all".
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockResolvedValue(HASH_X);
+
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    });
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+
+    // Each Byzantine peer can serve a DIFFERENT mismatched hash; the
+    // per-peer record must preserve the distinction.
+    const HASH_Z_HEX = 'cc'.repeat(32);
+    const serveFn = jest.fn(async (peer: TestPeer) => {
+      if (peer === 'p1') return HASH_Y_HEX;
+      if (peer === 'p2') return HASH_Z_HEX;
+      return HASH_Y_HEX; // p3 mirrors p1, exercising shared-hex case
+    });
+    const err = await simulateFullLoad({
+      narrowedPeers: result.narrowedPeers,
+      winningHashHex: result.winningHashHex,
+      serveFn,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    const lqfe = err as LoadQuorumFailedError;
+    expect(lqfe.reason).toBe('bind-check-failed-all-agreeing-peers');
+    // Per-peer record carries the specific hash each peer served.
+    expect(lqfe.agreeingPeerBindFailures.get('p1')).toBe(HASH_Y_HEX);
+    expect(lqfe.agreeingPeerBindFailures.get('p2')).toBe(HASH_Z_HEX);
+    expect(lqfe.agreeingPeerBindFailures.get('p3')).toBe(HASH_Y_HEX);
+    expect(lqfe.agreeingPeerBindFailures.size).toBe(3);
+    // Error message mentions the cohort-wide failure and the count.
+    expect(lqfe.message).toMatch(/bind-check|agreeing cohort|3 peer/);
   });
 
   test('(d) 3 peers, only 1 responds in time => LoadQuorumFailedError(insufficient-responses); no full-load attempted', async () => {

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -324,6 +324,105 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
     expect(lqfe.message).toMatch(/bind-check|agreeing cohort|3 peer/);
   });
 
+  test('(c4) multi-head honest responder: advertise=served frontier hash binds; loader accepts even when responder has un-served concurrent heads (PR #284 r8)', async () => {
+    // Regression for the PR #284 r8 Copilot finding: previously, an
+    // honest peer with multiple concurrent heads in `_currentFrontier()`
+    // would advertise tipsHash({H1, H2, H3}) in the probe round but
+    // only serve a tree rooted at H1 (the wire shape carries one tree).
+    // The loader's structural derivation `computeServedFrontier` over
+    // the served payload yielded {H1}, hashed differently from the
+    // advertise, and rejected the honest peer.
+    //
+    // The fix advertises the SERVED frontier (the heads of the tree
+    // this peer would actually ship), so probe and load round agree
+    // for honest responders. This test models a 3-peer cohort where
+    // all three peers have un-served concurrent heads but the same
+    // served frontier {H1}: all three vote tipsHash({H1}), all three
+    // serve a payload whose structural frontier is {H1}, and the bind
+    // check accepts.
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    // Every honest peer advertises tipsHash(servedFrontier). HASH_X
+    // stands in for tipsHash({H1}) here -- the orchestrator is
+    // hash-agnostic, so we just need the value to be the same across
+    // all three peers (probe round) AND match what each peer serves
+    // on the load round.
+    probeMock.mockResolvedValue(HASH_X);
+
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    });
+
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+    expect(result.winningHashHex).toBe(HASH_X_HEX);
+    expect(result.narrowedPeers).toEqual(['p1', 'p2', 'p3']);
+
+    // Each peer's load response structurally hashes to HASH_X (the
+    // served-frontier hash). Before the fix this would have been
+    // tipsHash({served-only}) while the probe was tipsHash({served +
+    // un-served}), so the bind check would have rejected. After the
+    // fix both sides agree.
+    const serveFn = jest.fn(async () => HASH_X_HEX);
+    const loadOutcome = await simulateFullLoad({
+      narrowedPeers: result.narrowedPeers,
+      winningHashHex: result.winningHashHex,
+      serveFn,
+    });
+    expect(loadOutcome.loadedFromPeer).toBe('p1');
+    // The first honest peer in the cohort serves a matching response;
+    // no fallback to subsequent peers was needed.
+    expect(loadOutcome.attempts).toEqual(['p1']);
+  });
+
+  test('(c5) Byzantine responder that lies about heads: advertises tipsHash(claimed-full-frontier) but serves a tree hashing to served-only => bind check rejects', async () => {
+    // Complement to (c4): a peer that DIDN'T apply the PR #284 r8 fix
+    // (or is actively malicious) would compute its advertise hash
+    // over its full local DAG frontier {H1, H2, H3} but only ship H1's
+    // tree. The probe-round hash is HASH_Y_HEX (the bigger set); the
+    // load-round structural derivation is HASH_X_HEX (the served-only
+    // frontier). If two such liars somehow agreed on the same lie and
+    // narrowed the cohort, the loader's bind check still rejects --
+    // the structural derivation does not match the agreed-upon
+    // advertise. This is the safety guarantee independent of the
+    // honest-peer fix.
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    // All three peers lie consistently: probe advertises HASH_Y (full
+    // local frontier), load serves a tree hashing to HASH_X (served
+    // only). Quorum agrees on HASH_Y; bind rejects on every peer.
+    probeMock.mockResolvedValue(HASH_Y);
+
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    });
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+    expect(result.winningHashHex).toBe(HASH_Y_HEX);
+
+    // The loader's structural derivation produces HASH_X for every
+    // served payload (because the served tree only contains H1, and
+    // computeServedFrontier yields {H1}). HASH_X != HASH_Y, so every
+    // peer's bind check fails.
+    const serveFn = jest.fn(async () => HASH_X_HEX);
+    const err = await simulateFullLoad({
+      narrowedPeers: result.narrowedPeers,
+      winningHashHex: result.winningHashHex,
+      serveFn,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe(
+      'bind-check-failed-all-agreeing-peers',
+    );
+    expect(serveFn).toHaveBeenCalledTimes(3);
+  });
+
   test('(d) 3 peers, only 1 responds in time => LoadQuorumFailedError(insufficient-responses); no full-load attempted', async () => {
     const peers: TestPeer[] = ['p1', 'p2', 'p3'];
     probeMock.mockImplementation(async (peer: TestPeer) => {

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -1765,4 +1765,50 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
       expect('newDoc' in result && result.newDoc).toBe(true);
     });
   });
+
+  describe('quorum agreement maps to zero peers => fail closed (PR #284 r12)', () => {
+    // If `peerIdOf` returns a stable id for the probe round but the post-
+    // probe narrowing step somehow loses every agreeing peer (e.g. a bug
+    // in `peerIdOf` produces a different id on the second call, or the
+    // agreement map references peer ids that are not in the peer list),
+    // the orchestrator must FAIL CLOSED rather than silently fall back to
+    // probing every original peer -- including the ones that voted for
+    // the LOSING hash. The previous behaviour widened trust scope to
+    // escape this edge case, defeating the very narrowing the gate
+    // exists to enforce. The fix raises a structured
+    // `LoadQuorumFailedError(no-majority)` so the caller sees the same
+    // contract as any other quorum failure.
+
+    test('unstable peerIdOf that maps probe-round ids to non-existent post-narrowing ids => LoadQuorumFailedError(no-majority)', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue(HASH_X);
+      // Probe round sees ids `p1/p2/p3`; narrowing round sees totally
+      // different ids (`probed-p1`, etc.) so `agreeingSet.has(...)` is
+      // never true on any peer. This is the "should-be-impossible-but-
+      // happened" branch the fail-closed guard exists for.
+      let callCount = 0;
+      const unstablePeerIdOf = (p: TestPeer): string => {
+        callCount++;
+        return callCount <= peers.length ? p : `probed-${p}`;
+      };
+
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf: unstablePeerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2 },
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      expect((err as LoadQuorumFailedError).reason).toBe('no-majority');
+      // Agreement map carries the winning hex + the count of agreeing
+      // peers so observability is preserved across the fail-closed path.
+      const agreement = (err as LoadQuorumFailedError).agreement;
+      expect(agreement.size).toBe(1);
+      const [[hex, count]] = [...agreement.entries()];
+      expect(hex).toBe(HASH_X_HEX);
+      expect(count).toBe(3);
+    });
+  });
 });

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -310,6 +310,140 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
     expect(probeMock).not.toHaveBeenCalled();
   });
 
+  test('loadQuorumK = 0 throws LoadQuorumFailedError(invalid-config) even with peers connected', async () => {
+    // Regression for PR #284 r5: a `loadQuorumK <= 0` previously
+    // collapsed `effectiveK(...)` to 0, the orchestrator returned
+    // `{ skipped: true }`, and `CollabswarmDocument.open()` then treated
+    // the load as "new document" and forked any existing copy held by
+    // peers. The orchestrator must now refuse loud-and-early on
+    // misconfigured K so the fork can never happen silently.
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockResolvedValue(HASH_X);
+    const err = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 0 },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumK must be >= 1; got 0/,
+    );
+    expect(probeMock).not.toHaveBeenCalled();
+  });
+
+  test('loadQuorumK = -1 throws LoadQuorumFailedError(invalid-config)', async () => {
+    const peers: TestPeer[] = ['p1', 'p2'];
+    probeMock.mockResolvedValue(HASH_X);
+    const err = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: -1 },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumK must be >= 1; got -1/,
+    );
+  });
+
+  test('loadQuorumK = 0 with no peers also throws (config error, not founder case)', async () => {
+    // The "no peers + K=0" combination is NOT a legitimate founder case:
+    // the founder case is "no peers + K=default", which falls through
+    // `effectiveK -> 0` -> `{ skipped: true }`. K=0 is always a static
+    // operator misconfiguration regardless of peer count, so the
+    // orchestrator throws unconditionally rather than silently bypassing
+    // the gate.
+    const err = await runLoadQuorum({
+      peers: [],
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 0 },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect(probeMock).not.toHaveBeenCalled();
+  });
+
+  test('multi-peer probe that REJECTS is recorded as a non-vote; other peers still tally', async () => {
+    // Contract regression for PR #284 r5: a `probeFn` that throws/rejects
+    // must NOT escape the orchestrator. Without the per-probe catch the
+    // whole `Promise.all` would reject and bubble past the
+    // `LoadQuorumFailedError` API contract `load()` callers are written
+    // against. With the catch, the rejected peer is counted as a
+    // non-vote and the remaining honest peers can still form quorum.
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockImplementation(async (peer: TestPeer) => {
+      if (peer === 'p3') throw new Error('synthetic probe failure');
+      return HASH_X;
+    });
+    const result = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    });
+    expect('ok' in result && result.ok).toBe(true);
+    if (!('ok' in result)) throw new Error('expected ok=true');
+    expect(result.narrowedPeers).toEqual(['p1', 'p2']);
+    expect(result.narrowedPeers).not.toContain('p3');
+    expect(result.winningHashHex).toBe(HASH_X_HEX);
+    // Sanity: probe still called for ALL peers, including the rejecter.
+    expect(probeMock).toHaveBeenCalledTimes(3);
+  });
+
+  test('multi-peer with ALL probeFns rejecting => LoadQuorumFailedError(insufficient-responses), no raw probe error escapes', async () => {
+    const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+    probeMock.mockImplementation(async () => {
+      throw new Error('synthetic probe failure');
+    });
+    const err = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 3, q: 2 },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe(
+      'insufficient-responses',
+    );
+    // The synthetic probe error MUST NOT escape — only the structured
+    // LoadQuorumFailedError surfaces.
+    expect((err as Error).message).not.toMatch(/synthetic probe failure/);
+  });
+
+  test('single-peer fallback with rejected probeFn => LoadQuorumFailedError(insufficient-responses), not the raw probe error', async () => {
+    // Single-peer pass-through must also contain probe errors. The
+    // single-peer code path was a separate `await probeFn(...)` (not
+    // inside the multi-peer `Promise.all`) — a regression risk if only
+    // one of the two paths was fixed.
+    const peers: TestPeer[] = ['p1'];
+    probeMock.mockImplementation(async () => {
+      throw new Error('synthetic single-peer probe failure');
+    });
+    const err = await runLoadQuorum({
+      peers,
+      peerIdOf,
+      probeFn: probeMock,
+      documentPath: '/test',
+      config: { enabled: true, k: 1, allowSinglePeer: true },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe(
+      'insufficient-responses',
+    );
+    expect((err as Error).message).not.toMatch(
+      /synthetic single-peer probe failure/,
+    );
+  });
+
   test('size-cap-triggered non-vote does NOT poison quorum when honest majority still responds', async () => {
     // Regression for the DoS hardening fix from PR #284 r4: an
     // oversized tip-advertise response is surfaced as `null` (non-vote)

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -599,4 +599,127 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
     expect(result.narrowedPeers).toEqual(['p1', 'p2']);
     expect(result.winningHashHex).toBe(HASH_X_HEX);
   });
+
+  describe('default Q is derived from EFFECTIVE K, not configured K (PR #284 r7)', () => {
+    // Regression for PR #284 r7 Copilot review: previously `defaultQuorumQ`
+    // was passed the CONFIGURED K, so a configured K=7 against a peer list
+    // of size 3 required `effectiveQ(defaultQuorumQ(7), effectiveK(7, 3))`
+    // = `effectiveQ(4, 3)` = 3 -- i.e. ALL 3 reachable peers had to agree,
+    // losing the one-fault tolerance the formula targets. The fix passes
+    // the effective K to `defaultQuorumQ`, so the default Q tracks the
+    // actual quorum size in use.
+    //
+    // To prove the default-Q derivation: arrange a setup where exactly
+    // `defaultQuorumQ(effective K)` peers vote the same hash and the rest
+    // do not respond. Under the fix, the agreeing minority crosses the
+    // (lower) threshold and quorum passes. Under the bug, the threshold is
+    // higher and quorum fails. The tests below use `q: undefined` so the
+    // default kicks in.
+    test('configured K=7 but only 3 peers: effective K=3, default Q=2 (was 4 with bug)', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockImplementation(async (peer: TestPeer) => {
+        // p1 + p2 vote X (2 votes = strict-majority for K=3); p3 times out.
+        // Under the BUG, defaultQuorumQ(7) = 4 > 3 votes available => quorum
+        // could never pass. Under the FIX, defaultQuorumQ(3) = 2 votes
+        // required => quorum passes.
+        return peer === 'p3' ? null : HASH_X;
+      });
+
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 7 /* q: undefined => derive from effective K */ },
+      });
+      expect('ok' in result && result.ok).toBe(true);
+      if (!('ok' in result)) throw new Error('expected ok=true');
+      expect(result.winningHashHex).toBe(HASH_X_HEX);
+      expect(result.narrowedPeers).toEqual(['p1', 'p2']);
+    });
+
+    test('configured K=3 with 3 peers: default Q=2 (unchanged from previous behaviour)', async () => {
+      // Sanity: the canonical configured-K matches-effective-K case still
+      // resolves to defaultQuorumQ(3) = 2. The bug only fired when
+      // configured K > peers.length.
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockImplementation(async (peer: TestPeer) => {
+        return peer === 'p3' ? null : HASH_X;
+      });
+
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3 },
+      });
+      expect('ok' in result && result.ok).toBe(true);
+      if (!('ok' in result)) throw new Error('expected ok=true');
+      expect(result.narrowedPeers).toEqual(['p1', 'p2']);
+    });
+
+    test('configured K=5 with 5 peers: default Q=3 (unchanged)', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3', 'p4', 'p5'];
+      probeMock.mockImplementation(async (peer: TestPeer) => {
+        // 3 vote X (strict majority of 5), 2 time out.
+        return peer === 'p4' || peer === 'p5' ? null : HASH_X;
+      });
+
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 5 },
+      });
+      expect('ok' in result && result.ok).toBe(true);
+      if (!('ok' in result)) throw new Error('expected ok=true');
+      expect(result.narrowedPeers).toEqual(['p1', 'p2', 'p3']);
+    });
+
+    test('configured K=7 with 7 peers: default Q=4 (unchanged)', async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7'];
+      probeMock.mockImplementation(async (peer: TestPeer) => {
+        // 4 vote X (strict majority of 7), 3 time out.
+        return ['p5', 'p6', 'p7'].includes(peer) ? null : HASH_X;
+      });
+
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 7 },
+      });
+      expect('ok' in result && result.ok).toBe(true);
+      if (!('ok' in result)) throw new Error('expected ok=true');
+      expect(result.narrowedPeers).toEqual(['p1', 'p2', 'p3', 'p4']);
+    });
+
+    test('explicit Q is honoured (??-fallback no-op): configured K=7, 3 peers, explicit Q=3 still requires all 3', async () => {
+      // When the operator explicitly sets `loadQuorumQ`, the `??` fallback
+      // does not fire and the explicit value flows through `effectiveQ`'s
+      // `[1, k]` clamp. Verify the fix did not accidentally clamp the
+      // explicit value too aggressively. With explicit Q=3 and effective
+      // K=3, all 3 peers must agree.
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockImplementation(async (peer: TestPeer) => {
+        return peer === 'p3' ? null : HASH_X;
+      });
+
+      const err = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 7, q: 3 },
+      }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(LoadQuorumFailedError);
+      // 2 votes available but 3 required => insufficient-responses.
+      expect((err as LoadQuorumFailedError).reason).toBe(
+        'insufficient-responses',
+      );
+    });
+  });
 });

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -1518,4 +1518,107 @@ describe('runLoadQuorum: production orchestration coverage (PR #284 r4)', () => 
       );
     });
   });
+
+  // PR #284 r16: `'unknown-doc'` probe results let the orchestrator
+  // detect the new-doc-creation case in an existing swarm. A Q-of-K
+  // majority of disclaims surfaces `{ newDoc: true }`; the loader uses
+  // this to return `false` so a fresh `open()` can create the document.
+  describe("'unknown-doc' new-document-creation path (PR #284 r16)", () => {
+    test("3 peers all probe 'unknown-doc' => orchestrator returns { newDoc: true }", async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockResolvedValue('unknown-doc');
+
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2 },
+      });
+
+      expect('newDoc' in result && result.newDoc).toBe(true);
+      // Should NOT surface as ok=true with narrowedPeers (that would
+      // drag the loader into a full-load round-trip).
+      expect('ok' in result).toBe(false);
+      expect('skipped' in result).toBe(false);
+      expect(probeMock).toHaveBeenCalledTimes(3);
+    });
+
+    test("majority 'unknown-doc' (2 of 3) with 1 tip-hash dissenter => { newDoc: true }", async () => {
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockImplementation(async (peer: TestPeer) =>
+        peer === 'p3' ? HASH_X : 'unknown-doc',
+      );
+
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2 },
+      });
+
+      expect('newDoc' in result && result.newDoc).toBe(true);
+    });
+
+    test("single lying 'unknown-doc' in a 3-peer mesh whose other peers have the doc CANNOT force new-doc creation", async () => {
+      // Defense: a single Byzantine peer claiming 'unknown-doc' while
+      // the others honestly serve HASH_X must lose the tally and let
+      // the loader proceed with the normal tip-hash quorum.
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockImplementation(async (peer: TestPeer) =>
+        peer === 'p3' ? 'unknown-doc' : HASH_X,
+      );
+
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2 },
+      });
+
+      expect('ok' in result && result.ok).toBe(true);
+      if (!('ok' in result)) throw new Error('expected ok=true');
+      expect(result.winningHashHex).toBe(HASH_X_HEX);
+      expect(result.narrowedPeers).toEqual(['p1', 'p2']);
+    });
+
+    test("single-peer fallback (k=1, allowSinglePeer=true) with 'unknown-doc' returns { newDoc: true }", async () => {
+      // Symmetric with the K-of-Q new-doc path: a single probed peer
+      // that disclaims the document still surfaces as new-doc.
+      const peers: TestPeer[] = ['p1'];
+      probeMock.mockResolvedValue('unknown-doc');
+
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 1, q: 1, allowSinglePeer: true },
+      });
+
+      expect('newDoc' in result && result.newDoc).toBe(true);
+      expect(probeMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("'unknown-doc' votes alongside null non-votes still reach Q and surface { newDoc: true }", async () => {
+      // 2 disclaims + 1 timeout: disclaims meet Q=2 even with one
+      // non-vote. Mirrors the tip-hash 2-of-3-with-timeout path.
+      const peers: TestPeer[] = ['p1', 'p2', 'p3'];
+      probeMock.mockImplementation(async (peer: TestPeer) =>
+        peer === 'p3' ? null : 'unknown-doc',
+      );
+
+      const result = await runLoadQuorum({
+        peers,
+        peerIdOf,
+        probeFn: probeMock,
+        documentPath: '/test',
+        config: { enabled: true, k: 3, q: 2 },
+      });
+
+      expect('newDoc' in result && result.newDoc).toBe(true);
+    });
+  });
 });

--- a/packages/collabswarm/src/load-quorum-orchestrator.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.ts
@@ -112,7 +112,6 @@ export async function runLoadQuorum<T>(opts: {
     return { skipped: true };
   }
   const configuredK = config?.k ?? 3;
-  const configuredQ = config?.q ?? defaultQuorumQ(configuredK);
   const allowSinglePeer = config?.allowSinglePeer ?? false;
 
   // Validate `loadQuorumK >= 1` up-front. A `configuredK <= 0` would
@@ -136,6 +135,17 @@ export async function runLoadQuorum<T>(opts: {
   }
 
   const k = effectiveK(configuredK, peers.length);
+  // Compute the default Q from the EFFECTIVE K (after clamping against the
+  // known peer count), not the CONFIGURED K. With configured K=7 but only
+  // 3 peers reachable, `defaultQuorumQ(7) = 4` but `effectiveK(7, 3) = 3`,
+  // so `effectiveQ(4, 3) = 3` would require ALL 3 peers to agree -- losing
+  // the one-fault tolerance the formula is meant to provide. Deriving the
+  // default from `k` (effective) gives `defaultQuorumQ(3) = 2`, which
+  // tolerates one non-vote among the 3 reachable peers. When the operator
+  // explicitly set `loadQuorumQ`, the `??` is a no-op and the explicit
+  // value flows through `effectiveQ`'s `[1, k]` clamp as before. See PR
+  // #284 r7 Copilot review.
+  const configuredQ = config?.q ?? defaultQuorumQ(k);
   const q = effectiveQ(configuredQ, k);
 
   if (k === 0) {

--- a/packages/collabswarm/src/load-quorum-orchestrator.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.ts
@@ -83,10 +83,13 @@ export type LoadQuorumOrchestratorResult<T> =
  *   caller's preferred-peer placement survives.
  * @param peerIdOf Extracts a stable peer-id key from each peer entry; used
  *   to match agreeing-cohort PeerIds back to the original peer entries.
- * @param probeFn Probes one peer for a `tipsHash`. Must return `null` for any
- *   non-vote outcome (timeout, decline, decryption failure, malformed hash,
- *   etc.) — never throw. Throwing surfaces as a non-vote here but the caller
- *   should still treat it as a bug.
+ * @param probeFn Probes one peer for a `tipsHash`. Should return `null` for
+ *   any non-vote outcome (timeout, decline, decryption failure, malformed
+ *   hash, etc.). If `probeFn` throws or rejects, the orchestrator catches
+ *   it at the boundary, logs the error, and records the peer as a non-vote
+ *   so the surrounding `LoadQuorumFailedError` contract is preserved. Even
+ *   so, a thrown probe still indicates a bug in the caller's probe
+ *   implementation and should be fixed at the source.
  * @param documentPath Used to construct the `LoadQuorumFailedError` on
  *   failure; carries the document name into operator-visible logs.
  * @param config Quorum tuning knobs (see `LoadQuorumOrchestratorConfig`).
@@ -111,6 +114,26 @@ export async function runLoadQuorum<T>(opts: {
   const configuredK = config?.k ?? 3;
   const configuredQ = config?.q ?? defaultQuorumQ(configuredK);
   const allowSinglePeer = config?.allowSinglePeer ?? false;
+
+  // Validate `loadQuorumK >= 1` up-front. A `configuredK <= 0` would
+  // collapse `effectiveK(...)` to 0 and the K=0 branch below would return
+  // `{ skipped: true }` — which `CollabswarmDocument.load()` then surfaces
+  // to `open()` as a "no peer could provide the document" outcome, and
+  // `open()` would silently re-initialize the document as brand-new
+  // (forking any existing copy held by other peers). Refuse loudly
+  // instead. The misconfiguration is a static operator mistake, not a
+  // recoverable runtime condition, so we throw regardless of peer count.
+  // See PR #284 r5 Copilot review.
+  if (configuredK <= 0) {
+    throw new LoadQuorumFailedError({
+      documentPath,
+      reason: 'invalid-config',
+      respondingCount: 0,
+      requiredQ: 0,
+      agreement: new Map(),
+      detail: `loadQuorumK must be >= 1; got ${configuredK}`,
+    });
+  }
 
   const k = effectiveK(configuredK, peers.length);
   const q = effectiveQ(configuredQ, k);
@@ -145,7 +168,24 @@ export async function runLoadQuorum<T>(opts: {
         `to restore Byzantine-fault-tolerant quorum semantics.`,
     );
     const probedPeer = peers[0];
-    const probe = await probeFn(probedPeer);
+    // Contain probe errors at the orchestrator boundary. The orchestrator
+    // contract (see module docstring + the per-peer note above on
+    // `probeFn`) is that any non-vote outcome — including a thrown/rejected
+    // probe — is surfaced as a non-vote. Without this catch a misbehaving
+    // `probeFn` would let the underlying error escape past the orchestrator
+    // and bypass the `LoadQuorumFailedError` API contract `load()` callers
+    // are written against. See PR #284 r5 Copilot review.
+    let probe: Uint8Array | null;
+    try {
+      probe = await probeFn(probedPeer);
+    } catch (err) {
+      console.warn(
+        `[${documentPath}] Initial-load quorum single-peer probe threw; ` +
+          `recording as non-vote.`,
+        err,
+      );
+      probe = null;
+    }
     if (probe === null) {
       throw new LoadQuorumFailedError({
         documentPath,
@@ -167,10 +207,31 @@ export async function runLoadQuorum<T>(opts: {
 
   // Standard K-of-Q quorum path. Probe the first K peers in parallel,
   // decide agreement, narrow.
+  //
+  // Contain probe errors at the orchestrator boundary. The contract is
+  // that any non-vote outcome — including a thrown/rejected `probeFn` —
+  // is surfaced as a non-vote (`hash: null`). Without the per-probe
+  // catch, a single rejecting `probeFn` would reject the whole
+  // `Promise.all`, bubble past the orchestrator, and bypass the
+  // `LoadQuorumFailedError` API the caller is written against —
+  // surfacing a raw probe error from `load()` instead of the structured
+  // `LoadQuorumFailedError(insufficient-responses)` callers expect.
+  // See PR #284 r5 Copilot review.
   const probedPeers = peers.slice(0, k);
   const advertisements: PeerTipAdvertisement[] = await Promise.all(
     probedPeers.map(async (peer) => {
-      const hash = await probeFn(peer);
+      let hash: Uint8Array | null;
+      try {
+        hash = await probeFn(peer);
+      } catch (err) {
+        console.warn(
+          `[${documentPath}] Initial-load quorum probe for peer ${peerIdOf(
+            peer,
+          )} threw; recording as non-vote.`,
+          err,
+        );
+        hash = null;
+      }
       return { peerId: peerIdOf(peer), hash };
     }),
   );

--- a/packages/collabswarm/src/load-quorum-orchestrator.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.ts
@@ -1,0 +1,214 @@
+/**
+ * Orchestration helper for the initial-load quorum gate (#186 / #189 §5.4.2).
+ *
+ * The pure quorum decision module (`load-quorum.ts`) is responsible for
+ * computing whether a set of tip-advertise responses meets the agreement
+ * threshold. It is intentionally I/O-free so the trust-critical decision
+ * logic can be audited and unit-tested in isolation.
+ *
+ * This module sits one layer up: it takes a peer list and a caller-supplied
+ * probe function and orchestrates the K-of-Q probe round, returning the
+ * narrowed agreeing-cohort peer list plus the winning hash (or throwing
+ * `LoadQuorumFailedError` on any failure mode). It is also pure with respect
+ * to libp2p/Helia -- the only network coupling lives in the `probeFn`
+ * callback that `CollabswarmDocument.load()` passes in. That decoupling
+ * exists so the production orchestration path can be exercised by unit tests
+ * without a real libp2p/Helia stack (the codebase has no precedent for full
+ * libp2p test doubles, and the load orchestration is the security gate
+ * Copilot's PR #284 r4 review asked to be regression-tested).
+ *
+ * Callers wire this module by:
+ *
+ *   1. Computing the peer list (already-deduped by libp2p PeerId so a single
+ *      peer with multiple open connections cannot cast multiple votes).
+ *   2. Passing a `probeFn` that, given a peer, returns a `Promise<Uint8Array
+ *      | null>` -- the peer's advertised `tipsHash` bytes, or `null` for any
+ *      non-vote outcome (timeout, decline, decryption failure, etc.).
+ *   3. Passing a `peerIdOf` extractor so this module can narrow the peer list
+ *      down to the agreeing cohort without knowing about Multiaddrs.
+ *
+ * The return value is either:
+ *   - `{ skipped: true }` — quorum disabled, or no peers (caller falls through
+ *     to the legacy single-peer load loop / treats as new document).
+ *   - `{ ok: true, narrowedPeers, winningHashHex }` — quorum passed; caller
+ *     does the full document-load against `narrowedPeers` with the binding
+ *     check pinned to `winningHashHex`.
+ *
+ * Failures (insufficient responses, no majority, etc.) are thrown as
+ * `LoadQuorumFailedError` so the caller's existing `instanceof`-based
+ * propagation works unchanged.
+ */
+
+import {
+  decideLoadQuorum,
+  defaultQuorumQ,
+  effectiveK,
+  effectiveQ,
+  LoadQuorumFailedError,
+  PeerTipAdvertisement,
+} from './load-quorum';
+import { tipsHashToHex } from './tips-hash';
+
+/**
+ * Config inputs for `runLoadQuorum`. Mirrors the relevant subset of
+ * `CollabswarmConfig` so the orchestrator does not import the heavy config
+ * module.
+ */
+export interface LoadQuorumOrchestratorConfig {
+  enabled?: boolean;
+  /** Maximum number of peers to probe. Defaults to 3. */
+  k?: number;
+  /** Minimum agreement threshold. Defaults to `defaultQuorumQ(k)`. */
+  q?: number;
+  /** Per-probe timeout in ms (caller-enforced inside `probeFn`). Stored here
+   * for symmetry with `CollabswarmConfig`; this module does not use it
+   * directly because `probeFn` is responsible for the wall-clock timeout. */
+  timeoutMs?: number;
+  /** Allow a single-peer fallback path when only one peer is reachable. */
+  allowSinglePeer?: boolean;
+}
+
+/**
+ * Result of running the quorum orchestration over a peer list.
+ */
+export type LoadQuorumOrchestratorResult<T> =
+  | { skipped: true }
+  | { ok: true; narrowedPeers: T[]; winningHashHex: string };
+
+/**
+ * Run the initial-load quorum orchestration round.
+ *
+ * @param peers The de-duplicated list of candidate peers (typically Multiaddrs
+ *   from `getConnections()`). Order is preserved into `narrowedPeers` so the
+ *   caller's preferred-peer placement survives.
+ * @param peerIdOf Extracts a stable peer-id key from each peer entry; used
+ *   to match agreeing-cohort PeerIds back to the original peer entries.
+ * @param probeFn Probes one peer for a `tipsHash`. Must return `null` for any
+ *   non-vote outcome (timeout, decline, decryption failure, malformed hash,
+ *   etc.) — never throw. Throwing surfaces as a non-vote here but the caller
+ *   should still treat it as a bug.
+ * @param documentPath Used to construct the `LoadQuorumFailedError` on
+ *   failure; carries the document name into operator-visible logs.
+ * @param config Quorum tuning knobs (see `LoadQuorumOrchestratorConfig`).
+ *
+ * @returns Either `{ skipped }` (gate disabled or no peers) or
+ *   `{ ok: true, narrowedPeers, winningHashHex }` on success. Throws
+ *   `LoadQuorumFailedError` on any failure mode (no responses, no majority,
+ *   insufficient single-peer probe).
+ */
+export async function runLoadQuorum<T>(opts: {
+  peers: readonly T[];
+  peerIdOf: (peer: T) => string;
+  probeFn: (peer: T) => Promise<Uint8Array | null>;
+  documentPath: string;
+  config?: LoadQuorumOrchestratorConfig;
+}): Promise<LoadQuorumOrchestratorResult<T>> {
+  const { peers, peerIdOf, probeFn, documentPath, config } = opts;
+  const enabled = config?.enabled ?? true;
+  if (!enabled) {
+    return { skipped: true };
+  }
+  const configuredK = config?.k ?? 3;
+  const configuredQ = config?.q ?? defaultQuorumQ(configuredK);
+  const allowSinglePeer = config?.allowSinglePeer ?? false;
+
+  const k = effectiveK(configuredK, peers.length);
+  const q = effectiveQ(configuredQ, k);
+
+  if (k === 0) {
+    // No peers known. Treat as "new document" — caller falls through to
+    // the legacy "no peer could load" branch.
+    return { skipped: true };
+  }
+
+  if (k === 1 && !allowSinglePeer) {
+    // Only one peer reachable but quorum requires Q>=2 by default. Without
+    // a second opinion we cannot distinguish "honest solo peer" from
+    // "malicious peer serving a forged state". Refuse.
+    throw new LoadQuorumFailedError({
+      documentPath,
+      reason: 'insufficient-responses',
+      respondingCount: 0,
+      requiredQ: q,
+      agreement: new Map(),
+    });
+  }
+
+  if (k === 1 && allowSinglePeer) {
+    // Single-peer pass-through. Probe the one known peer; if it responds at
+    // all we proceed with the legacy load. Warn loudly so operators can
+    // spot the regression. Q is forced to 1 here.
+    console.warn(
+      `[${documentPath}] Initial-load quorum: only one peer known; ` +
+        `proceeding under loadQuorumAllowSinglePeer (trust assumptions ` +
+        `degraded back to single-peer load). Configure additional peers ` +
+        `to restore Byzantine-fault-tolerant quorum semantics.`,
+    );
+    const probedPeer = peers[0];
+    const probe = await probeFn(probedPeer);
+    if (probe === null) {
+      throw new LoadQuorumFailedError({
+        documentPath,
+        reason: 'insufficient-responses',
+        respondingCount: 0,
+        requiredQ: 1,
+        agreement: new Map(),
+      });
+    }
+    const winningHashHex = tipsHashToHex(probe);
+    // Narrow to ONLY the probed peer. Without this, the subsequent
+    // snapshot/doc-load loop would also try the other peers in the original
+    // peer list (which were never probed) and bind their served state
+    // against THIS peer's hash — a non-sequitur that could either pass the
+    // binding by coincidence or fail it even though single-peer mode was
+    // opted-into.
+    return { ok: true, narrowedPeers: [probedPeer], winningHashHex };
+  }
+
+  // Standard K-of-Q quorum path. Probe the first K peers in parallel,
+  // decide agreement, narrow.
+  const probedPeers = peers.slice(0, k);
+  const advertisements: PeerTipAdvertisement[] = await Promise.all(
+    probedPeers.map(async (peer) => {
+      const hash = await probeFn(peer);
+      return { peerId: peerIdOf(peer), hash };
+    }),
+  );
+  const decision = decideLoadQuorum(advertisements, q);
+  if (!decision.ok) {
+    console.warn(
+      `[${documentPath}] Initial-load quorum FAILED: ` +
+        `${decision.reason} (${decision.respondingCount} responses, ` +
+        `required ${decision.effectiveQ}). Aborting load.`,
+    );
+    throw new LoadQuorumFailedError({
+      documentPath,
+      reason: decision.reason,
+      respondingCount: decision.respondingCount,
+      requiredQ: decision.effectiveQ,
+      agreement: decision.agreement,
+    });
+  }
+  console.log(
+    `[${documentPath}] Initial-load quorum passed: ` +
+      `${decision.agreeingPeerIds.length}/${decision.respondingCount} ` +
+      `peers agreed on tipsHash=${decision.winningHashHex.slice(0, 12)}...`,
+  );
+  // Narrow `peers` to only the agreeing cohort. The caller then asks one of
+  // these peers for the full state; with quorum agreement, any single
+  // agreeing peer's load is defended by Q-1 other peers attesting to the
+  // same tip set. Order is preserved.
+  const agreeingSet = new Set(decision.agreeingPeerIds);
+  const narrowed = peers.filter((p) => agreeingSet.has(peerIdOf(p)));
+  // Defensive: at least one agreeing peer must remain. If peer-id
+  // extraction loses a peer (should never happen given we built the same
+  // set above), fall back to the full list so we don't accidentally
+  // degrade to "no peers to load from".
+  const finalNarrowed =
+    narrowed.length > 0 ? narrowed : ([...peers] as T[]);
+  return {
+    ok: true,
+    narrowedPeers: finalNarrowed,
+    winningHashHex: decision.winningHashHex,
+  };
+}

--- a/packages/collabswarm/src/load-quorum-orchestrator.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.ts
@@ -219,14 +219,26 @@ export async function runLoadQuorum<T>(opts: {
   }
 
   if (k === 1 && !allowSinglePeer) {
-    // Only one peer reachable but quorum requires Q>=2 by default. Without
-    // a second opinion we cannot distinguish "honest solo peer" from
-    // "malicious peer serving a forged state". Refuse.
+    // Only one peer reachable AND the operator did not opt into the
+    // single-peer pass-through. With a lone peer we cannot distinguish
+    // "honest solo peer" from "malicious peer serving a forged state",
+    // so we refuse on policy grounds rather than on the BFT majority
+    // formula -- with `effectiveK = 1`, `defaultQuorumQ(1) = 1`, so
+    // surfacing the computed `q` (which is 1) as `requiredQ` would be
+    // misleading: it would suggest "the lone peer's vote was sufficient
+    // numerically but happened not to land", when the truth is "we
+    // explicitly refuse to trust any single peer regardless of how it
+    // voted". Surface the load-bearing policy requirement (`requiredQ =
+    // 2`, the smallest cohort that gives any Byzantine fault tolerance)
+    // so the error message reads as a policy refusal, not a vote-count
+    // shortfall. Operators who genuinely want single-peer behaviour
+    // must set `loadQuorumAllowSinglePeer: true` explicitly. See PR
+    // #284 r25 Copilot review.
     throw new LoadQuorumFailedError({
       documentPath,
       reason: 'insufficient-responses',
       respondingCount: 0,
-      requiredQ: q,
+      requiredQ: 2,
       agreement: new Map(),
     });
   }

--- a/packages/collabswarm/src/load-quorum-orchestrator.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.ts
@@ -173,17 +173,16 @@ export async function runLoadQuorum<T>(opts: {
       err instanceof LoadQuorumFailedError &&
       err.reason === 'invalid-config'
     ) {
-      // Re-extract the structured detail (everything between the
-      // documentPath prefix and the trailing operator-guidance trailer)
-      // so the rethrown error carries the validator's "<name> must be a
-      // positive integer; got <value>" wording without the
-      // `'<config>'` placeholder leaking through.
-      const detailMatch = err.message.match(
-        /^Initial-load quorum failed for "<config>": (.+?)\. Configure/,
-      );
-      const detail = detailMatch
-        ? detailMatch[1]
-        : 'invalid load-quorum configuration';
+      // Forward the validator's structured `detail` directly so the
+      // rethrown error carries the "<name> must be a positive integer;
+      // got <value>" wording without the `'<config>'` placeholder
+      // leaking through. The previous implementation regex-parsed
+      // `err.message`, which was brittle: any future change to the
+      // error-message format (e.g. moving the operator-guidance
+      // trailer) would silently degrade the surfaced config error to
+      // the generic fallback. The structured field is the load-bearing
+      // path now. See PR #284 r23 Copilot review.
+      const detail = err.detail ?? 'invalid load-quorum configuration';
       throw new LoadQuorumFailedError({
         documentPath,
         reason: 'invalid-config',

--- a/packages/collabswarm/src/load-quorum-orchestrator.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.ts
@@ -62,8 +62,14 @@ export interface LoadQuorumOrchestratorConfig {
   /** Minimum agreement threshold. Defaults to `defaultQuorumQ(k)`. */
   q?: number;
   /** Per-probe timeout in ms (caller-enforced inside `probeFn`). Stored here
-   * for symmetry with `CollabswarmConfig`; this module does not use it
-   * directly because `probeFn` is responsible for the wall-clock timeout. */
+   * for symmetry with `CollabswarmConfig` and validated alongside K/Q so a
+   * `NaN`/`Infinity`/`0`/negative/over-bound value (which would coerce
+   * `setTimeout` to immediate-fire / overflow and silently turn every probe
+   * into a non-vote) is caught loud-and-early. This module does not consume
+   * the value itself — `probeFn` is responsible for the wall-clock timeout
+   * — but it MUST flow through {@link validateLoadQuorumConfig} on every
+   * load attempt as defence-in-depth against post-`initialize()` mutation.
+   * See PR #284 r15 Copilot review. */
   timeoutMs?: number;
   /** Allow a single-peer fallback path when only one peer is reachable. */
   allowSinglePeer?: boolean;
@@ -113,14 +119,15 @@ export async function runLoadQuorum<T>(opts: {
     return { skipped: true };
   }
 
-  // Re-validate K/Q on every `runLoadQuorum` call as defence-in-depth
-  // against post-`initialize()` mutation of the shared config object
-  // (direct mutation, deep-clone reuse with a corrupt field, an operator
-  // helper that writes back `NaN`, etc.). `Collabswarm.initialize()` runs
-  // `validateLoadQuorumConfig` once at startup so the static
-  // misconfiguration case (typo, bad cast at config load) is already
-  // covered; this second-line check exists for the dynamic case where a
-  // previously-valid K or Q has since become `NaN`/`Infinity`/0/-1/1.5.
+  // Re-validate K/Q/timeoutMs on every `runLoadQuorum` call as
+  // defence-in-depth against post-`initialize()` mutation of the shared
+  // config object (direct mutation, deep-clone reuse with a corrupt
+  // field, an operator helper that writes back `NaN`, etc.).
+  // `Collabswarm.initialize()` runs `validateLoadQuorumConfig` once at
+  // startup so the static misconfiguration case (typo, bad cast at
+  // config load) is already covered; this second-line check exists for
+  // the dynamic case where a previously-valid K, Q, or timeoutMs has
+  // since become `NaN`/`Infinity`/0/-1/1.5/over-bound.
   //
   // Without this guard, a mutated `K = NaN` would slip through to
   // `effectiveK(NaN, peers)` which returns 0 (per the r9 defensive
@@ -128,9 +135,13 @@ export async function runLoadQuorum<T>(opts: {
   // `{ skipped: true }`, and `CollabswarmDocument.load()` would fall
   // through to the legacy unbound load even though `loadQuorumEnabled`
   // is still `true` — silently violating the operator's intent of a
-  // quorum-protected load. Throw a structured `invalid-config`
-  // `LoadQuorumFailedError` so the failure is loud at the
-  // load-attempt boundary instead.
+  // quorum-protected load. A mutated `timeoutMs = NaN`/`Infinity`/`0`/
+  // negative similarly would flow into `setTimeout(...)` inside the
+  // probe race, coerce to immediate-fire, and turn every probe into a
+  // non-vote so quorum fails on every load even with a healthy mesh.
+  // Throw a structured `invalid-config` `LoadQuorumFailedError` so the
+  // failure is loud at the load-attempt boundary instead. See PR #284
+  // r15 Copilot review for the `timeoutMs` extension.
   //
   // The validator's documentPath placeholder (`<config>`) is replaced
   // with the actual `documentPath` here so operator logs surface which
@@ -140,6 +151,7 @@ export async function runLoadQuorum<T>(opts: {
     validateLoadQuorumConfig({
       loadQuorumK: config?.k,
       loadQuorumQ: config?.q,
+      loadQuorumTimeoutMs: config?.timeoutMs,
     });
   } catch (err) {
     if (
@@ -209,10 +221,26 @@ export async function runLoadQuorum<T>(opts: {
     // Single-peer pass-through. Probe the one known peer; if it responds at
     // all we proceed with the legacy load. Warn loudly so operators can
     // spot the regression. Q is forced to 1 here.
+    //
+    // The warning text covers BOTH causes of `k === 1`:
+    //   1. peer scarcity — only one peer is reachable in the mesh
+    //      (`peers.length === 1`), OR
+    //   2. configured K — the operator set `loadQuorumK = 1` even though
+    //      more peers ARE known (`peers.length > 1`); `effectiveK` clamps
+    //      the slice to 1 and only that one peer is probed.
+    // The previous wording "only one peer known" was accurate for case 1
+    // but actively misleading for case 2 — operators saw the warning even
+    // though their mesh had multiple peers, making it impossible to tell
+    // whether the regression was peer-availability (a runtime fact) or a
+    // misconfigured K (their own knob). Include the configured K and the
+    // actual peer count so both cases read accurately. See PR #284 r15
+    // Copilot review.
     console.warn(
-      `[${documentPath}] Initial-load quorum: only one peer known; ` +
-        `proceeding under loadQuorumAllowSinglePeer (trust assumptions ` +
-        `degraded back to single-peer load). Configure additional peers ` +
+      `[${documentPath}] Initial-load quorum: only one peer will be probed ` +
+        `(loadQuorumK=${configuredK}, ${peers.length} peer${peers.length === 1 ? '' : 's'} known; ` +
+        `loadQuorumAllowSinglePeer=true); trust assumptions degraded back ` +
+        `to single-peer load. ` +
+        `${peers.length > 1 ? 'Increase loadQuorumK above 1' : 'Configure additional peers'} ` +
         `to restore Byzantine-fault-tolerant quorum semantics.`,
     );
     const probedPeer = peers[0];

--- a/packages/collabswarm/src/load-quorum-orchestrator.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.ts
@@ -77,9 +77,24 @@ export interface LoadQuorumOrchestratorConfig {
 
 /**
  * Result of running the quorum orchestration over a peer list.
+ *
+ *   - `{ skipped: true }` — gate disabled or no peers known. Caller
+ *     falls through to the legacy single-peer load loop.
+ *   - `{ newDoc: true }` — a Q-of-K majority of probed peers explicitly
+ *     disclaimed the document (returned `'unknown-doc'` from the probe).
+ *     Caller should treat as "document does not exist yet" and let
+ *     `load()` return `false` so a fresh `open()` creates the document
+ *     on top of the existing swarm. See PR #284 r16 Copilot review for
+ *     the rationale: the previous design conflated unknown-doc with
+ *     partition / timeout and made new-doc creation fail in an existing
+ *     mesh.
+ *   - `{ ok: true, narrowedPeers, winningHashHex }` — quorum passed on
+ *     a tip-set hash; caller does the full document-load against
+ *     `narrowedPeers` with the binding check pinned to `winningHashHex`.
  */
 export type LoadQuorumOrchestratorResult<T> =
   | { skipped: true }
+  | { newDoc: true }
   | { ok: true; narrowedPeers: T[]; winningHashHex: string };
 
 /**
@@ -109,7 +124,7 @@ export type LoadQuorumOrchestratorResult<T> =
 export async function runLoadQuorum<T>(opts: {
   peers: readonly T[];
   peerIdOf: (peer: T) => string;
-  probeFn: (peer: T) => Promise<Uint8Array | null>;
+  probeFn: (peer: T) => Promise<Uint8Array | 'unknown-doc' | null>;
   documentPath: string;
   config?: LoadQuorumOrchestratorConfig;
 }): Promise<LoadQuorumOrchestratorResult<T>> {
@@ -251,7 +266,7 @@ export async function runLoadQuorum<T>(opts: {
     // `probeFn` would let the underlying error escape past the orchestrator
     // and bypass the `LoadQuorumFailedError` API contract `load()` callers
     // are written against. See PR #284 r5 Copilot review.
-    let probe: Uint8Array | null;
+    let probe: Uint8Array | 'unknown-doc' | null;
     try {
       probe = await probeFn(probedPeer);
     } catch (err) {
@@ -270,6 +285,18 @@ export async function runLoadQuorum<T>(opts: {
         requiredQ: 1,
         agreement: new Map(),
       });
+    }
+    if (probe === 'unknown-doc') {
+      // The single probed peer explicitly disclaims the document. Treat
+      // as new-doc-creation -- `load()` will return `false` so a fresh
+      // `open()` can create the document on top of the swarm. This is
+      // symmetric with the K-of-Q `kind === 'new-doc'` branch below.
+      // See PR #284 r16 Copilot review.
+      console.warn(
+        `[${documentPath}] Initial-load quorum single-peer probe returned ` +
+          `'unknown-doc'; treating as new-document path (load() will return false).`,
+      );
+      return { newDoc: true };
     }
     const winningHashHex = tipsHashToHex(probe);
     // Narrow to ONLY the probed peer. Without this, the subsequent
@@ -296,7 +323,7 @@ export async function runLoadQuorum<T>(opts: {
   const probedPeers = peers.slice(0, k);
   const advertisements: PeerTipAdvertisement[] = await Promise.all(
     probedPeers.map(async (peer) => {
-      let hash: Uint8Array | null;
+      let hash: Uint8Array | 'unknown-doc' | null;
       try {
         hash = await probeFn(peer);
       } catch (err) {
@@ -325,6 +352,22 @@ export async function runLoadQuorum<T>(opts: {
       requiredQ: decision.effectiveQ,
       agreement: decision.agreement,
     });
+  }
+  if (decision.kind === 'new-doc') {
+    // Q-of-K peers all returned the `'unknown-doc'` sentinel: the swarm
+    // collectively disclaims the document. Surface as the new-doc path
+    // so `CollabswarmDocument.load()` returns `false` and a fresh
+    // `open()` can create the document on top of the existing swarm.
+    // Defense remains Q-Byzantine: a single lying peer in a 3-of-3 mesh
+    // whose other peers hold the doc cannot force this branch (their
+    // tip-hash bucket wins the tally). See PR #284 r16 Copilot review.
+    console.log(
+      `[${documentPath}] Initial-load quorum passed (new-doc): ` +
+        `${decision.agreeingPeerIds.length}/${decision.respondingCount} ` +
+        `peers disclaimed the document; treating as new-document path ` +
+        `(load() will return false).`,
+    );
+    return { newDoc: true };
   }
   console.log(
     `[${documentPath}] Initial-load quorum passed: ` +

--- a/packages/collabswarm/src/load-quorum-orchestrator.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.ts
@@ -46,6 +46,7 @@ import {
   effectiveQ,
   LoadQuorumFailedError,
   PeerTipAdvertisement,
+  validateLoadQuorumConfig,
 } from './load-quorum';
 import { tipsHashToHex } from './tips-hash';
 
@@ -111,28 +112,65 @@ export async function runLoadQuorum<T>(opts: {
   if (!enabled) {
     return { skipped: true };
   }
+
+  // Re-validate K/Q on every `runLoadQuorum` call as defence-in-depth
+  // against post-`initialize()` mutation of the shared config object
+  // (direct mutation, deep-clone reuse with a corrupt field, an operator
+  // helper that writes back `NaN`, etc.). `Collabswarm.initialize()` runs
+  // `validateLoadQuorumConfig` once at startup so the static
+  // misconfiguration case (typo, bad cast at config load) is already
+  // covered; this second-line check exists for the dynamic case where a
+  // previously-valid K or Q has since become `NaN`/`Infinity`/0/-1/1.5.
+  //
+  // Without this guard, a mutated `K = NaN` would slip through to
+  // `effectiveK(NaN, peers)` which returns 0 (per the r9 defensive
+  // floor/finiteness guards), the K=0 branch below would return
+  // `{ skipped: true }`, and `CollabswarmDocument.load()` would fall
+  // through to the legacy unbound load even though `loadQuorumEnabled`
+  // is still `true` — silently violating the operator's intent of a
+  // quorum-protected load. Throw a structured `invalid-config`
+  // `LoadQuorumFailedError` so the failure is loud at the
+  // load-attempt boundary instead.
+  //
+  // The validator's documentPath placeholder (`<config>`) is replaced
+  // with the actual `documentPath` here so operator logs surface which
+  // document's load attempt tripped the post-init mutation. See
+  // PR #284 r10 Copilot review.
+  try {
+    validateLoadQuorumConfig({
+      loadQuorumK: config?.k,
+      loadQuorumQ: config?.q,
+    });
+  } catch (err) {
+    if (
+      err instanceof LoadQuorumFailedError &&
+      err.reason === 'invalid-config'
+    ) {
+      // Re-extract the structured detail (everything between the
+      // documentPath prefix and the trailing operator-guidance trailer)
+      // so the rethrown error carries the validator's "<name> must be a
+      // positive integer; got <value>" wording without the
+      // `'<config>'` placeholder leaking through.
+      const detailMatch = err.message.match(
+        /^Initial-load quorum failed for "<config>": (.+?)\. Configure/,
+      );
+      const detail = detailMatch
+        ? detailMatch[1]
+        : 'invalid load-quorum configuration';
+      throw new LoadQuorumFailedError({
+        documentPath,
+        reason: 'invalid-config',
+        respondingCount: 0,
+        requiredQ: 0,
+        agreement: new Map(),
+        detail,
+      });
+    }
+    throw err;
+  }
+
   const configuredK = config?.k ?? 3;
   const allowSinglePeer = config?.allowSinglePeer ?? false;
-
-  // Validate `loadQuorumK >= 1` up-front. A `configuredK <= 0` would
-  // collapse `effectiveK(...)` to 0 and the K=0 branch below would return
-  // `{ skipped: true }` — which `CollabswarmDocument.load()` then surfaces
-  // to `open()` as a "no peer could provide the document" outcome, and
-  // `open()` would silently re-initialize the document as brand-new
-  // (forking any existing copy held by other peers). Refuse loudly
-  // instead. The misconfiguration is a static operator mistake, not a
-  // recoverable runtime condition, so we throw regardless of peer count.
-  // See PR #284 r5 Copilot review.
-  if (configuredK <= 0) {
-    throw new LoadQuorumFailedError({
-      documentPath,
-      reason: 'invalid-config',
-      respondingCount: 0,
-      requiredQ: 0,
-      agreement: new Map(),
-      detail: `loadQuorumK must be >= 1; got ${configuredK}`,
-    });
-  }
 
   const k = effectiveK(configuredK, peers.length);
   // Compute the default Q from the EFFECTIVE K (after clamping against the

--- a/packages/collabswarm/src/load-quorum-orchestrator.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.ts
@@ -381,14 +381,36 @@ export async function runLoadQuorum<T>(opts: {
   const agreeingSet = new Set(decision.agreeingPeerIds);
   const narrowed = peers.filter((p) => agreeingSet.has(peerIdOf(p)));
   // Defensive: at least one agreeing peer must remain. If peer-id
-  // extraction loses a peer (should never happen given we built the same
-  // set above), fall back to the full list so we don't accidentally
-  // degrade to "no peers to load from".
-  const finalNarrowed =
-    narrowed.length > 0 ? narrowed : ([...peers] as T[]);
+  // extraction loses every peer (should be impossible because we built
+  // `agreeingSet` from `peerIdOf` outputs over the same `peers` array),
+  // FAIL CLOSED rather than silently widening the load to ALL peers --
+  // which would re-introduce non-agreeing peers into the load path and
+  // bypass the very narrowing the quorum gate is meant to enforce. The
+  // previous fallback (`narrowed.length > 0 ? narrowed : [...peers]`)
+  // expanded trust scope to escape a no-op edge case, which is exactly
+  // the kind of silent-degrade-to-unsafe-default that the gate exists to
+  // prevent. Surface as a structured `LoadQuorumFailedError` so callers
+  // see the same error contract as any other quorum failure. See PR #284
+  // r12 CodeRabbit review.
+  if (narrowed.length === 0) {
+    throw new LoadQuorumFailedError({
+      documentPath,
+      reason: 'no-majority',
+      respondingCount: decision.respondingCount,
+      requiredQ: decision.effectiveQ,
+      // Re-derive a `hash -> count` agreement summary from the agreeing
+      // cohort so the structured error carries the same observability
+      // payload as the normal `'no-majority'` path (decideLoadQuorum's
+      // success branch does not expose the full agreement map; we
+      // reconstruct just the winning bucket here).
+      agreement: new Map([
+        [decision.winningHashHex, decision.agreeingPeerIds.length],
+      ]),
+    });
+  }
   return {
     ok: true,
-    narrowedPeers: finalNarrowed,
+    narrowedPeers: narrowed,
     winningHashHex: decision.winningHashHex,
   };
 }

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -182,10 +182,17 @@ describe('decideLoadQuorum (initial-load quorum gate, #189 §5.4.2)', () => {
     }
   });
 
-  test("majority 'unknown-doc' vs minority tip-hash returns kind='new-doc'", () => {
-    // 2 disclaims, 1 dissenter that DOES have the doc — disclaims win
-    // the tally (Q=2). Defense-in-depth analogue of the tip-hash
-    // 2-of-3 majority case earlier in this suite.
+  test("majority 'unknown-doc' vs minority tip-hash: tip-hash takes PRIORITY (PR #284 r19)", () => {
+    // 2 disclaims, 1 peer reports HASH_A. The probe samples from the
+    // WHOLE libp2p mesh, not just peers that hold this document, so
+    // peers without the doc (legitimately returning unknown-doc) must
+    // NOT outvote the one peer that has it. Otherwise two unrelated
+    // peers in the mesh could fork an existing document into a new-doc
+    // creation -- silently splitting the swarm.
+    //
+    // New precedence rule: ANY tip-hash vote suppresses the unknown-doc
+    // bucket. With Q=2 here, the lone HASH_A vote does not meet Q on
+    // its own, so the decision is `no-majority` (NOT `kind: 'new-doc'`).
     const decision = decideLoadQuorum(
       [
         { peerId: 'p1', hash: 'unknown-doc' },
@@ -194,9 +201,32 @@ describe('decideLoadQuorum (initial-load quorum gate, #189 §5.4.2)', () => {
       ],
       2,
     );
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      // We expect `no-majority` because the tip-hash bucket has size 1
+      // and there were 3 responding peers (>= Q).
+      expect(decision.reason).toBe('no-majority');
+      // The agreement snapshot still records BOTH buckets for operator
+      // diagnostics.
+      expect(decision.agreement.size).toBe(2);
+    }
+  });
+
+  test("tip-hash quorum still passes when at least Q peers vote for the same hash, even alongside unknown-doc disclaims", () => {
+    // 2 vote HASH_A, 2 disclaim. Tip-hash bucket meets Q=2 and wins;
+    // the disclaim bucket is excluded from consideration entirely.
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: HASH_A },
+        { peerId: 'p2', hash: HASH_A },
+        { peerId: 'p3', hash: 'unknown-doc' },
+        { peerId: 'p4', hash: 'unknown-doc' },
+      ],
+      2,
+    );
     expect(decision.ok).toBe(true);
     if (decision.ok) {
-      expect(decision.kind).toBe('new-doc');
+      expect(decision.kind).toBe('tip-hash');
       expect(decision.agreeingPeerIds).toEqual(['p1', 'p2']);
     }
   });

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -118,6 +118,37 @@ describe('decideLoadQuorum (initial-load quorum gate, #189 §5.4.2)', () => {
     }
   });
 
+  // PR #284 r12 CodeRabbit review: `decideLoadQuorum` is exported, so a
+  // direct caller (or future refactor that bypasses `runLoadQuorum`)
+  // passing `q <= 0` or a non-integer would silently disable the quorum
+  // gate -- the largest-bucket size is always `>= 0 >= q` and a single
+  // peer's vote would pass. Throw on programming errors so the failure
+  // is loud at the first call site rather than relying on the docstring
+  // precondition.
+  test('non-positive q is a programming error and throws', () => {
+    expect(() =>
+      decideLoadQuorum([{ peerId: 'p1', hash: HASH_A }], 0),
+    ).toThrow(/q must be a positive integer.*got 0/);
+    expect(() =>
+      decideLoadQuorum([{ peerId: 'p1', hash: HASH_A }], -1),
+    ).toThrow(/q must be a positive integer.*got -1/);
+  });
+
+  test('non-integer q is a programming error and throws', () => {
+    expect(() =>
+      decideLoadQuorum([{ peerId: 'p1', hash: HASH_A }], 1.5),
+    ).toThrow(/q must be a positive integer.*got 1\.5/);
+    expect(() =>
+      decideLoadQuorum([{ peerId: 'p1', hash: HASH_A }], Number.NaN),
+    ).toThrow(/q must be a positive integer.*got NaN/);
+    expect(() =>
+      decideLoadQuorum(
+        [{ peerId: 'p1', hash: HASH_A }],
+        Number.POSITIVE_INFINITY,
+      ),
+    ).toThrow(/q must be a positive integer.*got Infinity/);
+  });
+
   test('single peer with Q=1 (allowSinglePeer path) passes', () => {
     const decision = decideLoadQuorum(
       [{ peerId: 'p1', hash: HASH_A }],

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
 import {
+  constantTimeHexEquals,
   decideLoadQuorum,
+  dedupePeersByPeerId,
+  defaultQuorumQ,
   effectiveK,
   effectiveQ,
   LoadQuorumFailedError,
@@ -164,6 +167,162 @@ describe('effectiveK / effectiveQ', () => {
     expect(effectiveQ(0, 3)).toBe(1); // Q < 1 -> 1
     expect(effectiveQ(-1, 3)).toBe(1);
     expect(effectiveQ(2, 0)).toBe(0); // no peers -> no quorum possible
+  });
+});
+
+describe('defaultQuorumQ (strict-majority formula, #189 §5.4.2)', () => {
+  // The PR description and config docstring require strict majority — i.e.
+  // `Math.floor(K/2) + 1`, NOT `Math.ceil(K/2) + 1`. The earlier ceil-based
+  // default produced Q=3 at K=3, which made the gate refuse to pass with
+  // even one non-vote and silently defeated the BFT intent ("tolerate one
+  // fault"). These tests pin the formula so a future change has to
+  // explicitly justify breaking the matrix.
+  test('K=1 -> Q=1', () => {
+    expect(defaultQuorumQ(1)).toBe(1);
+  });
+  test('K=2 -> Q=2', () => {
+    expect(defaultQuorumQ(2)).toBe(2);
+  });
+  test('K=3 -> Q=2 (one fault tolerated, NOT three-of-three)', () => {
+    expect(defaultQuorumQ(3)).toBe(2);
+  });
+  test('K=4 -> Q=3', () => {
+    expect(defaultQuorumQ(4)).toBe(3);
+  });
+  test('K=5 -> Q=3', () => {
+    expect(defaultQuorumQ(5)).toBe(3);
+  });
+  test('K=7 -> Q=4', () => {
+    expect(defaultQuorumQ(7)).toBe(4);
+  });
+  test('K=0 -> Q=0 (no peers, no quorum possible)', () => {
+    expect(defaultQuorumQ(0)).toBe(0);
+  });
+  test('K<0 -> Q=0 (clamped)', () => {
+    expect(defaultQuorumQ(-1)).toBe(0);
+  });
+
+  test('rejects the legacy ceil-based formula at K=3', () => {
+    // Math.ceil(3 / 2) + 1 === 3 — would require all three peers to agree,
+    // refusing a single timeout. defaultQuorumQ must NOT return 3 here.
+    expect(defaultQuorumQ(3)).not.toBe(Math.ceil(3 / 2) + 1);
+  });
+});
+
+describe('dedupePeersByPeerId (multi-connection vote inflation, #186)', () => {
+  // libp2p's `getConnections()` returns one entry per OPEN connection, not
+  // per remote peer. A peer with both a direct and a relay-circuit
+  // connection shows up twice; without dedup they cast two quorum votes,
+  // letting a single malicious peer with two connections out-vote one
+  // honest peer.
+  test('collapses two entries with the same peerId into one', () => {
+    const peers = [
+      { addr: '/ip4/1.1.1.1/tcp/1/p2p/A' },
+      { addr: '/ip4/2.2.2.2/tcp/2/p2p/A' }, // same peerId A, different multiaddr
+      { addr: '/ip4/3.3.3.3/tcp/3/p2p/B' },
+    ];
+    const out = dedupePeersByPeerId(peers, (p) => {
+      const m = [...p.addr.matchAll(/\/p2p\/([^/]+)/g)];
+      return m.length > 0 ? m[m.length - 1][1] : p.addr;
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0].addr).toBe('/ip4/1.1.1.1/tcp/1/p2p/A');
+    expect(out[1].addr).toBe('/ip4/3.3.3.3/tcp/3/p2p/B');
+  });
+
+  test('preserves first-seen order (preferredPeer at index 0 stays first)', () => {
+    const peers = ['preferred', 'a', 'preferred', 'b', 'a'];
+    const out = dedupePeersByPeerId(peers, (s) => s);
+    expect(out).toEqual(['preferred', 'a', 'b']);
+  });
+
+  test('treats relay-circuit + direct multiaddrs of one peer as one vote', () => {
+    // Real-world case: a peer reachable both directly and via a relay
+    // circuit shows up as `.../p2p/<remote>` and `.../p2p/<relay>/p2p-circuit/p2p/<remote>`.
+    // `_peerIdOf` extracts the LAST `/p2p/<id>` (the remote peer id), so
+    // both entries collapse to the same key.
+    const peers = [
+      { addr: '/ip4/1.1.1.1/tcp/9000/p2p/Q' },
+      { addr: '/ip4/2.2.2.2/tcp/9001/p2p/R/p2p-circuit/p2p/Q' },
+    ];
+    const out = dedupePeersByPeerId(peers, (p) => {
+      const m = [...p.addr.matchAll(/\/p2p\/([^/]+)/g)];
+      return m.length > 0 ? m[m.length - 1][1] : p.addr;
+    });
+    expect(out).toHaveLength(1);
+  });
+
+  test('empty input returns empty output', () => {
+    expect(dedupePeersByPeerId([], (s: string) => s)).toEqual([]);
+  });
+
+  test('does not mutate the input array', () => {
+    const input = ['a', 'a', 'b'];
+    const out = dedupePeersByPeerId(input, (s) => s);
+    expect(input).toEqual(['a', 'a', 'b']);
+    expect(out).toEqual(['a', 'b']);
+  });
+});
+
+describe('founding-case removal (#186, suppressed comment fix)', () => {
+  // Regression coverage for the unsafe `_hashes.size === 0` bypass. Before
+  // this fix, the loader skipped the quorum gate whenever its local
+  // `_hashes` was empty on the theory that an empty set could not be
+  // "poisoned" — but `_hashes` is ALSO empty on the very first `open()` of
+  // an EXISTING document (before load populates it), which is exactly the
+  // case the quorum check is meant to defend. The fix removes the bypass
+  // entirely; the gate now runs uniformly. These tests verify that the
+  // decision logic does not give the gate any escape hatch keyed on the
+  // local hash-set state — the only legitimate "no quorum" paths are
+  // `k === 0` (no peers at all) and the explicit `allowSinglePeer` knob.
+  test('with K>=2 known peers, decideLoadQuorum still requires Q votes regardless of caller state', () => {
+    // Caller passes Q=2; a single agreeing vote (the rest non-votes) is
+    // not enough. This holds whether the caller is a fresh founder or
+    // a partitioned existing-document opener — `decideLoadQuorum` is
+    // stateless w.r.t. the caller, by design.
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: new Uint8Array(32).fill(0xaa) },
+        { peerId: 'p2', hash: null },
+        { peerId: 'p3', hash: null },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.reason).toBe('insufficient-responses');
+    }
+  });
+
+  test('effectiveK + defaultQuorumQ together force the gate on K>=2 even when local state is empty', () => {
+    // Simulate "fresh open with peers available": local hashes empty
+    // (irrelevant to these pure helpers), known peers = 3, configured K = 3.
+    const k = effectiveK(3, 3);
+    const q = effectiveQ(defaultQuorumQ(3), k);
+    expect(k).toBe(3);
+    expect(q).toBe(2); // strict majority; founders no longer get a free pass
+  });
+});
+
+describe('constantTimeHexEquals (hash-binding comparison)', () => {
+  test('equal lowercase hex strings compare equal', () => {
+    expect(constantTimeHexEquals('aa'.repeat(32), 'aa'.repeat(32))).toBe(true);
+  });
+
+  test('different hex strings of the same length compare unequal', () => {
+    expect(constantTimeHexEquals('aa'.repeat(32), 'ab'.repeat(32))).toBe(false);
+  });
+
+  test('strings of different lengths compare unequal', () => {
+    expect(constantTimeHexEquals('aa', 'aabb')).toBe(false);
+  });
+
+  test('empty strings compare equal', () => {
+    expect(constantTimeHexEquals('', '')).toBe(true);
+  });
+
+  test('case-sensitive (matches `tipsHashToHex` lowercase output)', () => {
+    expect(constantTimeHexEquals('aabb', 'AABB')).toBe(false);
   });
 });
 

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -7,6 +7,7 @@ import {
   effectiveK,
   effectiveQ,
   formatConfigValue,
+  LOAD_QUORUM_TIMEOUT_MS_MAX,
   LoadQuorumFailedError,
   validateLoadQuorumConfig,
 } from './load-quorum';
@@ -446,6 +447,155 @@ describe('validateLoadQuorumConfig (startup input validation, PR #284 r9)', () =
     expect(err).toBeInstanceOf(LoadQuorumFailedError);
     expect((err as LoadQuorumFailedError).message).toMatch(/loadQuorumK/);
     expect((err as LoadQuorumFailedError).message).not.toMatch(/loadQuorumQ/);
+  });
+
+  // ---------------------------------------------------------------------
+  // loadQuorumTimeoutMs validation (PR #284 r15 Copilot review)
+  // ---------------------------------------------------------------------
+  // The bug: `loadQuorumTimeoutMs` is passed directly into `setTimeout(...)`
+  // inside the tip-advertise probe race in `_raceTipAdvertiseProbe`. Values
+  // like `NaN`, `Infinity`, `0`, and negative are coerced by the timer queue
+  // to immediate-fire / overflow behaviour — every probe then resolves as a
+  // non-vote, quorum fails on EVERY load even with a fully healthy mesh, and
+  // the operator has no visible signal pointing back at the misconfig. The
+  // validator now requires a finite positive integer in
+  // `[1, LOAD_QUORUM_TIMEOUT_MS_MAX]` so the misconfig is loud at startup.
+
+  test('accepts undefined loadQuorumTimeoutMs (orchestrator default applies)', () => {
+    expect(() =>
+      validateLoadQuorumConfig({ loadQuorumTimeoutMs: undefined }),
+    ).not.toThrow();
+  });
+
+  test('accepts valid integer loadQuorumTimeoutMs (1 ms, default 5 s, max)', () => {
+    expect(() =>
+      validateLoadQuorumConfig({ loadQuorumTimeoutMs: 1 }),
+    ).not.toThrow();
+    expect(() =>
+      validateLoadQuorumConfig({ loadQuorumTimeoutMs: 5000 }),
+    ).not.toThrow();
+    expect(() =>
+      validateLoadQuorumConfig({
+        loadQuorumTimeoutMs: LOAD_QUORUM_TIMEOUT_MS_MAX,
+      }),
+    ).not.toThrow();
+  });
+
+  test('rejects NaN loadQuorumTimeoutMs with "got NaN" in message', () => {
+    // Was: silently coerced to immediate-fire setTimeout, every probe
+    // recorded as non-vote, quorum failed every load.
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumTimeoutMs: NaN });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumTimeoutMs must be a positive integer.*got NaN/,
+    );
+    // Defence: must NOT render NaN as the misleading `null` from JSON.stringify.
+    expect((err as LoadQuorumFailedError).message).not.toMatch(/got null/);
+  });
+
+  test('rejects Infinity loadQuorumTimeoutMs', () => {
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumTimeoutMs: Infinity });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumTimeoutMs must be a positive integer.*got Infinity/,
+    );
+  });
+
+  test('rejects loadQuorumTimeoutMs = 0 (would fire setTimeout immediately)', () => {
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumTimeoutMs: 0 });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumTimeoutMs must be a positive integer.*got 0/,
+    );
+  });
+
+  test('rejects negative loadQuorumTimeoutMs (-1)', () => {
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumTimeoutMs: -1 });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumTimeoutMs must be a positive integer.*got -1/,
+    );
+  });
+
+  test('rejects fractional loadQuorumTimeoutMs (1.5)', () => {
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumTimeoutMs: 1.5 });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumTimeoutMs must be a positive integer.*got 1\.5/,
+    );
+  });
+
+  test('rejects loadQuorumTimeoutMs above the 5-minute upper bound (catches typos)', () => {
+    // The upper bound catches typos like `5000000` (5 000 s = 83 min)
+    // or mistakenly-passed nanosecond values — far larger than any
+    // realistic per-probe budget on a wide-area mesh.
+    const tooLarge = LOAD_QUORUM_TIMEOUT_MS_MAX + 1;
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumTimeoutMs: tooLarge });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumTimeoutMs must be a positive integer no greater than/,
+    );
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      new RegExp(String(tooLarge)),
+    );
+  });
+
+  test('accepts loadQuorumTimeoutMs combined with valid K/Q', () => {
+    expect(() =>
+      validateLoadQuorumConfig({
+        loadQuorumK: 3,
+        loadQuorumQ: 2,
+        loadQuorumTimeoutMs: 5000,
+      }),
+    ).not.toThrow();
   });
 });
 

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -739,13 +739,17 @@ describe('formatConfigValue (PR #284 r10 issue #1: non-finite numbers render as 
     expect(formatConfigValue(NaN)).not.toBe(formatConfigValue(null));
   });
 
-  test('undefined renders as JSON.stringify(undefined) === undefined-as-string', () => {
-    // Note: `JSON.stringify(undefined)` returns `undefined`, not a
-    // string. This is JSON.stringify's behaviour, surfaced through the
-    // helper for transparency. `validateLoadQuorumConfig` early-returns
-    // on `undefined` before calling the helper, so this branch is not
-    // hit in production — but the helper's behaviour is still pinned.
-    expect(formatConfigValue(undefined)).toBeUndefined();
+  test("undefined coerces to the string 'undefined'", () => {
+    // `JSON.stringify(undefined)` returns `undefined` (NOT a string),
+    // which would break the function's declared `string` return type
+    // under strict-mode TypeScript and also surface as `got undefined`
+    // through coercion in operator-visible error messages. PR #284 r18
+    // Copilot review tightened the helper to always return a string;
+    // for `undefined` we fall back to `String(undefined)` so callers
+    // (and the type system) see a clean string. `validateLoadQuorumConfig`
+    // still early-returns on `undefined` before calling the helper, so
+    // this fallback is defensive — the helper's behaviour is pinned here.
+    expect(formatConfigValue(undefined)).toBe('undefined');
   });
 
   test('strings, objects, arrays still flow through JSON.stringify', () => {

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -154,6 +154,105 @@ describe('decideLoadQuorum (initial-load quorum gate, #189 §5.4.2)', () => {
     );
     expect(decision.ok).toBe(true);
   });
+
+  // PR #284 r16: `'unknown-doc'` is a first-class vote alongside tip-hash
+  // values. A Q-of-K majority of disclaims surfaces a `kind: 'new-doc'`
+  // outcome that the orchestrator translates into `{ newDoc: true }` and
+  // the loader translates into a `false` return so a fresh `open()` can
+  // create the document on top of an existing swarm. A single lying
+  // disclaim cannot force this branch if the other peers actually have
+  // the document (their tip-hash bucket wins the tally).
+  test("'unknown-doc' majority returns kind='new-doc' with disclaim peers in agreeing cohort", () => {
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: 'unknown-doc' },
+        { peerId: 'p2', hash: 'unknown-doc' },
+        { peerId: 'p3', hash: 'unknown-doc' },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(true);
+    if (decision.ok) {
+      expect(decision.kind).toBe('new-doc');
+      expect(decision.respondingCount).toBe(3);
+      expect(decision.agreeingPeerIds).toEqual(['p1', 'p2', 'p3']);
+      // The reserved tally key is non-hex so it cannot collide with a
+      // real `tipsHashToHex` output (64-char lowercase hex).
+      expect(decision.winningHashHex).toBe('unknown-doc');
+    }
+  });
+
+  test("majority 'unknown-doc' vs minority tip-hash returns kind='new-doc'", () => {
+    // 2 disclaims, 1 dissenter that DOES have the doc — disclaims win
+    // the tally (Q=2). Defense-in-depth analogue of the tip-hash
+    // 2-of-3 majority case earlier in this suite.
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: 'unknown-doc' },
+        { peerId: 'p2', hash: 'unknown-doc' },
+        { peerId: 'p3', hash: HASH_A },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(true);
+    if (decision.ok) {
+      expect(decision.kind).toBe('new-doc');
+      expect(decision.agreeingPeerIds).toEqual(['p1', 'p2']);
+    }
+  });
+
+  test("majority tip-hash beats minority 'unknown-doc' (single lying peer cannot force new-doc)", () => {
+    // 2 honest peers vote HASH_A, 1 malicious peer lies 'unknown-doc'.
+    // Tip-hash bucket wins; loader proceeds with normal load.
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: HASH_A },
+        { peerId: 'p2', hash: HASH_A },
+        { peerId: 'p3', hash: 'unknown-doc' },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(true);
+    if (decision.ok) {
+      expect(decision.kind).toBe('tip-hash');
+      expect(decision.agreeingPeerIds).toEqual(['p1', 'p2']);
+    }
+  });
+
+  test("'unknown-doc' votes alongside null non-votes still produce kind='new-doc' when they reach Q", () => {
+    // 2 disclaims + 1 timeout: disclaims meet Q=2 even with a non-vote.
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: 'unknown-doc' },
+        { peerId: 'p2', hash: 'unknown-doc' },
+        { peerId: 'p3', hash: null },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(true);
+    if (decision.ok) {
+      expect(decision.kind).toBe('new-doc');
+      expect(decision.respondingCount).toBe(2);
+    }
+  });
+
+  test("split unknown-doc vs tip-hash with no Q majority fails with no-majority", () => {
+    // 1 disclaim, 1 HASH_A, 1 HASH_B, Q=2. No bucket reaches 2.
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: 'unknown-doc' },
+        { peerId: 'p2', hash: HASH_A },
+        { peerId: 'p3', hash: HASH_B },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.reason).toBe('no-majority');
+      // All three buckets show up in the diagnostic snapshot.
+      expect(decision.agreement.size).toBe(3);
+    }
+  });
 });
 
 describe('effectiveK / effectiveQ', () => {

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -820,6 +820,26 @@ describe('formatConfigValue (PR #284 r10 issue #1: non-finite numbers render as 
     expect(formatConfigValue(true)).toBe('true');
     expect(formatConfigValue(false)).toBe('false');
   });
+
+  // `JSON.stringify` raises a `TypeError` on BigInt values and another on
+  // any object that contains a cycle. Before guarding with try/catch those
+  // raw errors would escape the validator and surface to operators as a
+  // bare `TypeError`, masking the actual config-validation message. The
+  // helper now catches and falls back to `String(value)` so the surrounding
+  // `LoadQuorumFailedError(invalid-config, ...)` message stays well-formed.
+  test('BigInt falls back to String() instead of throwing TypeError', () => {
+    expect(() => formatConfigValue(BigInt(42))).not.toThrow();
+    expect(formatConfigValue(BigInt(42))).toBe('42');
+  });
+
+  test('circular object falls back to String() instead of throwing', () => {
+    const cyclic: Record<string, unknown> = { name: 'cycle' };
+    cyclic['self'] = cyclic;
+    expect(() => formatConfigValue(cyclic)).not.toThrow();
+    // `String({})` is `'[object Object]'`; we only pin that the helper
+    // returns *some* string and does not crash on a cycle.
+    expect(typeof formatConfigValue(cyclic)).toBe('string');
+  });
 });
 
 describe('defaultQuorumQ (strict-majority formula, #189 §5.4.2)', () => {

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  decideLoadQuorum,
+  effectiveK,
+  effectiveQ,
+  LoadQuorumFailedError,
+} from './load-quorum';
+
+function bytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) {
+    throw new Error('hex must be even-length');
+  }
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+const HASH_A = bytes('aa'.repeat(32));
+const HASH_B = bytes('bb'.repeat(32));
+const HASH_C = bytes('cc'.repeat(32));
+
+describe('decideLoadQuorum (initial-load quorum gate, #189 §5.4.2)', () => {
+  test('3-of-3 agreement passes quorum (Q=2)', () => {
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: HASH_A },
+        { peerId: 'p2', hash: HASH_A },
+        { peerId: 'p3', hash: HASH_A },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(true);
+    if (decision.ok) {
+      expect(decision.respondingCount).toBe(3);
+      expect(decision.agreeingPeerIds).toEqual(['p1', 'p2', 'p3']);
+    }
+  });
+
+  test('2-of-3 agreement still meets Q=2', () => {
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: HASH_A },
+        { peerId: 'p2', hash: HASH_A },
+        { peerId: 'p3', hash: HASH_B },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(true);
+    if (decision.ok) {
+      expect(decision.agreeingPeerIds).toEqual(['p1', 'p2']);
+    }
+  });
+
+  test('3-way disagreement fails quorum (no-majority)', () => {
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: HASH_A },
+        { peerId: 'p2', hash: HASH_B },
+        { peerId: 'p3', hash: HASH_C },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.reason).toBe('no-majority');
+      expect(decision.respondingCount).toBe(3);
+      expect(decision.agreement.size).toBe(3);
+    }
+  });
+
+  test('timeouts (null hashes) are not counted as disagreement', () => {
+    // Two real votes for HASH_A, one timeout. With Q=2 this should pass:
+    // the timeout is a non-vote, not a disagreement.
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: HASH_A },
+        { peerId: 'p2', hash: HASH_A },
+        { peerId: 'p3', hash: null },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(true);
+    if (decision.ok) {
+      expect(decision.respondingCount).toBe(2);
+      expect(decision.agreeingPeerIds).toEqual(['p1', 'p2']);
+    }
+  });
+
+  test('all timeouts fails with insufficient-responses', () => {
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: null },
+        { peerId: 'p2', hash: null },
+        { peerId: 'p3', hash: null },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.reason).toBe('insufficient-responses');
+      expect(decision.respondingCount).toBe(0);
+    }
+  });
+
+  test('empty advertisement list fails with no-peers-queried', () => {
+    const decision = decideLoadQuorum([], 2);
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.reason).toBe('no-peers-queried');
+    }
+  });
+
+  test('single peer with Q=1 (allowSinglePeer path) passes', () => {
+    const decision = decideLoadQuorum(
+      [{ peerId: 'p1', hash: HASH_A }],
+      1,
+    );
+    expect(decision.ok).toBe(true);
+    if (decision.ok) {
+      expect(decision.agreeingPeerIds).toEqual(['p1']);
+    }
+  });
+
+  test('single peer with Q=2 (allowSinglePeer false) fails', () => {
+    const decision = decideLoadQuorum(
+      [{ peerId: 'p1', hash: HASH_A }],
+      2,
+    );
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.reason).toBe('insufficient-responses');
+    }
+  });
+
+  test('two byte-identical hashes from different instances collide on the same bucket', () => {
+    // Reference inequality, value equality.
+    const a1 = bytes('11'.repeat(32));
+    const a2 = bytes('11'.repeat(32));
+    expect(a1).not.toBe(a2);
+    const decision = decideLoadQuorum(
+      [
+        { peerId: 'p1', hash: a1 },
+        { peerId: 'p2', hash: a2 },
+      ],
+      2,
+    );
+    expect(decision.ok).toBe(true);
+  });
+});
+
+describe('effectiveK / effectiveQ', () => {
+  test('effectiveK clamps to known-peer count', () => {
+    expect(effectiveK(3, 5)).toBe(3);
+    expect(effectiveK(3, 2)).toBe(2);
+    expect(effectiveK(3, 0)).toBe(0);
+    expect(effectiveK(0, 5)).toBe(0);
+  });
+
+  test('effectiveQ clamps to [1, K]', () => {
+    expect(effectiveQ(2, 3)).toBe(2);
+    expect(effectiveQ(5, 3)).toBe(3); // Q > K -> K
+    expect(effectiveQ(0, 3)).toBe(1); // Q < 1 -> 1
+    expect(effectiveQ(-1, 3)).toBe(1);
+    expect(effectiveQ(2, 0)).toBe(0); // no peers -> no quorum possible
+  });
+});
+
+describe('LoadQuorumFailedError', () => {
+  test('carries structured fields for application-level recovery', () => {
+    const err = new LoadQuorumFailedError({
+      documentPath: '/docs/x',
+      reason: 'no-majority',
+      respondingCount: 3,
+      requiredQ: 2,
+      agreement: new Map([
+        ['aa', 1],
+        ['bb', 1],
+        ['cc', 1],
+      ]),
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('LoadQuorumFailedError');
+    expect(err.documentPath).toBe('/docs/x');
+    expect(err.reason).toBe('no-majority');
+    expect(err.respondingCount).toBe(3);
+    expect(err.requiredQ).toBe(2);
+    expect(err.agreement.size).toBe(3);
+    expect(err.message).toMatch(/quorum failed/i);
+  });
+});

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -366,4 +366,50 @@ describe('LoadQuorumFailedError', () => {
     expect(err.reason).toBe('invalid-config');
     expect(err.message).toMatch(/loadQuorumK must be >= 1; got 0/);
   });
+
+  test('bind-check-failed-all-agreeing-peers carries per-peer agreeingPeerBindFailures (PR #284 r6)', () => {
+    // The 'bind-check-failed-all-agreeing-peers' variant is surfaced by
+    // `CollabswarmDocument.load()` after the agreeing cohort is exhausted
+    // and every peer failed the post-load tipsHash bind check. The
+    // `agreeingPeerBindFailures` field records, per peer, the hex hash
+    // the responder's served `tips` actually hashed to (or the sentinel
+    // `'(missing tips)'` for an omitted-tips response).
+    const failures = new Map<string, string>([
+      ['12D3KooWPeer1', 'ff'.repeat(32)],
+      ['12D3KooWPeer2', '(missing tips)'],
+    ]);
+    const err = new LoadQuorumFailedError({
+      documentPath: '/docs/x',
+      reason: 'bind-check-failed-all-agreeing-peers',
+      respondingCount: 0,
+      requiredQ: 0,
+      agreement: new Map([['aa'.repeat(32), 0]]),
+      agreeingPeerBindFailures: failures,
+    });
+    expect(err.reason).toBe('bind-check-failed-all-agreeing-peers');
+    expect(err.agreeingPeerBindFailures).toBe(failures);
+    expect(err.agreeingPeerBindFailures.size).toBe(2);
+    expect(err.agreeingPeerBindFailures.get('12D3KooWPeer2')).toBe(
+      '(missing tips)',
+    );
+    // The composed message names the cohort size for operator observability.
+    expect(err.message).toMatch(/agreeing cohort.*2 peer/);
+    expect(err.message).toMatch(/Byzantine equivocation/);
+  });
+
+  test('agreeingPeerBindFailures defaults to empty map for non-bind reasons', () => {
+    // Reasons other than `bind-check-failed-all-agreeing-peers` do not
+    // populate `agreeingPeerBindFailures`; the field must still be a
+    // readable empty map (NOT undefined) so callers can iterate
+    // unconditionally without a null-check.
+    const err = new LoadQuorumFailedError({
+      documentPath: '/docs/x',
+      reason: 'no-majority',
+      respondingCount: 1,
+      requiredQ: 2,
+      agreement: new Map(),
+    });
+    expect(err.agreeingPeerBindFailures).toBeInstanceOf(Map);
+    expect(err.agreeingPeerBindFailures.size).toBe(0);
+  });
 });

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -348,4 +348,22 @@ describe('LoadQuorumFailedError', () => {
     expect(err.agreement.size).toBe(3);
     expect(err.message).toMatch(/quorum failed/i);
   });
+
+  test("invalid-config reason carries operator-visible detail (PR #284 r5)", () => {
+    // The 'invalid-config' variant is surfaced by `runLoadQuorum` when
+    // `loadQuorumK <= 0`, where the structured `respondingCount`/
+    // `requiredQ` fields are not meaningful (no probes were run). The
+    // `detail` constructor field is the surface used to carry the
+    // offending value into the operator-visible message.
+    const err = new LoadQuorumFailedError({
+      documentPath: '/docs/x',
+      reason: 'invalid-config',
+      respondingCount: 0,
+      requiredQ: 0,
+      agreement: new Map(),
+      detail: 'loadQuorumK must be >= 1; got 0',
+    });
+    expect(err.reason).toBe('invalid-config');
+    expect(err.message).toMatch(/loadQuorumK must be >= 1; got 0/);
+  });
 });

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -6,6 +6,7 @@ import {
   defaultQuorumQ,
   effectiveK,
   effectiveQ,
+  formatConfigValue,
   LoadQuorumFailedError,
   validateLoadQuorumConfig,
 } from './load-quorum';
@@ -275,7 +276,12 @@ describe('validateLoadQuorumConfig (startup input validation, PR #284 r9)', () =
     expect((err as LoadQuorumFailedError).message).toMatch(/1\.5/);
   });
 
-  test('rejects NaN loadQuorumK', () => {
+  test('rejects NaN loadQuorumK with "got NaN" in message (PR #284 r10 issue #1: not "got null")', () => {
+    // PR #284 r10 Copilot review (issue #1): `JSON.stringify(NaN)` is
+    // the literal string `'null'`, so the previous error message read
+    // `got null` for a `NaN` input — indistinguishable from explicitly
+    // passing `null` and actively misleading. The fix renders non-finite
+    // numbers via `String(...)` so they show their JS literal.
     const err = (() => {
       try {
         validateLoadQuorumConfig({ loadQuorumK: NaN });
@@ -287,11 +293,15 @@ describe('validateLoadQuorumConfig (startup input validation, PR #284 r9)', () =
     expect(err).toBeInstanceOf(LoadQuorumFailedError);
     expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
     expect((err as LoadQuorumFailedError).message).toMatch(
-      /loadQuorumK must be a positive integer/,
+      /loadQuorumK must be a positive integer; got NaN/,
+    );
+    // Defence: the misleading legacy `got null` rendering must NOT appear.
+    expect((err as LoadQuorumFailedError).message).not.toMatch(
+      /got null/,
     );
   });
 
-  test('rejects Infinity loadQuorumK', () => {
+  test('rejects Infinity loadQuorumK with "got Infinity" in message (PR #284 r10 issue #1)', () => {
     const err = (() => {
       try {
         validateLoadQuorumConfig({ loadQuorumK: Infinity });
@@ -302,12 +312,26 @@ describe('validateLoadQuorumConfig (startup input validation, PR #284 r9)', () =
     })();
     expect(err).toBeInstanceOf(LoadQuorumFailedError);
     expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumK must be a positive integer; got Infinity/,
+    );
+    expect((err as LoadQuorumFailedError).message).not.toMatch(/got null/);
   });
 
-  test('rejects -Infinity loadQuorumK', () => {
-    expect(() =>
-      validateLoadQuorumConfig({ loadQuorumK: -Infinity }),
-    ).toThrow(LoadQuorumFailedError);
+  test('rejects -Infinity loadQuorumK with "got -Infinity" in message (PR #284 r10 issue #1)', () => {
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumK: -Infinity });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumK must be a positive integer; got -Infinity/,
+    );
+    expect((err as LoadQuorumFailedError).message).not.toMatch(/got null/);
   });
 
   test('rejects loadQuorumK = 0', () => {
@@ -348,10 +372,12 @@ describe('validateLoadQuorumConfig (startup input validation, PR #284 r9)', () =
     );
   });
 
-  test('rejects NaN loadQuorumQ (was: silent single-peer quorum pass)', () => {
+  test('rejects NaN loadQuorumQ with "got NaN" in message (was: silent single-peer quorum pass; PR #284 r10 issue #1: not "got null")', () => {
     // The exact bug: `effectiveQ(NaN, k)` returned `NaN`,
     // `decideLoadQuorum` evaluated `bestPeers.length < NaN` as false,
     // and quorum passed with a single responder. Now refused at startup.
+    // PR #284 r10: also verify the rendered value is `NaN`, not the
+    // misleading `null` from `JSON.stringify(NaN)`.
     const err = (() => {
       try {
         validateLoadQuorumConfig({ loadQuorumQ: NaN });
@@ -363,14 +389,26 @@ describe('validateLoadQuorumConfig (startup input validation, PR #284 r9)', () =
     expect(err).toBeInstanceOf(LoadQuorumFailedError);
     expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
     expect((err as LoadQuorumFailedError).message).toMatch(
-      /loadQuorumQ must be a positive integer/,
+      /loadQuorumQ must be a positive integer; got NaN/,
     );
+    expect((err as LoadQuorumFailedError).message).not.toMatch(/got null/);
   });
 
-  test('rejects Infinity loadQuorumQ', () => {
-    expect(() => validateLoadQuorumConfig({ loadQuorumQ: Infinity })).toThrow(
-      LoadQuorumFailedError,
+  test('rejects Infinity loadQuorumQ with "got Infinity" in message (PR #284 r10 issue #1)', () => {
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumQ: Infinity });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumQ must be a positive integer; got Infinity/,
     );
+    expect((err as LoadQuorumFailedError).message).not.toMatch(/got null/);
   });
 
   test('rejects loadQuorumQ = 0', () => {
@@ -408,6 +446,65 @@ describe('validateLoadQuorumConfig (startup input validation, PR #284 r9)', () =
     expect(err).toBeInstanceOf(LoadQuorumFailedError);
     expect((err as LoadQuorumFailedError).message).toMatch(/loadQuorumK/);
     expect((err as LoadQuorumFailedError).message).not.toMatch(/loadQuorumQ/);
+  });
+});
+
+describe('formatConfigValue (PR #284 r10 issue #1: non-finite numbers render as their literal, not "null")', () => {
+  // The root cause: `JSON.stringify(NaN)`, `JSON.stringify(Infinity)`,
+  // and `JSON.stringify(-Infinity)` all return the literal string
+  // `'null'` because JSON has no representation for those values. An
+  // operator who set `loadQuorumK: NaN` would then see `got null` in
+  // the error message, indistinguishable from explicitly passing
+  // `null` and actively misleading about which misconfiguration
+  // they triggered. The helper coerces non-finite numbers via
+  // `String(...)` so they render as their JS literal.
+
+  test('NaN renders as "NaN" (was: "null" under JSON.stringify)', () => {
+    expect(formatConfigValue(NaN)).toBe('NaN');
+    expect(formatConfigValue(NaN)).not.toBe('null');
+  });
+
+  test('Infinity renders as "Infinity"', () => {
+    expect(formatConfigValue(Infinity)).toBe('Infinity');
+    expect(formatConfigValue(Infinity)).not.toBe('null');
+  });
+
+  test('-Infinity renders as "-Infinity"', () => {
+    expect(formatConfigValue(-Infinity)).toBe('-Infinity');
+    expect(formatConfigValue(-Infinity)).not.toBe('null');
+  });
+
+  test('finite numbers pass through JSON.stringify unchanged', () => {
+    expect(formatConfigValue(0)).toBe('0');
+    expect(formatConfigValue(-1)).toBe('-1');
+    expect(formatConfigValue(1.5)).toBe('1.5');
+    expect(formatConfigValue(42)).toBe('42');
+  });
+
+  test('explicit null still renders as "null" (distinct from NaN now)', () => {
+    // An operator who explicitly passes `null` (e.g. via a YAML parse
+    // of an empty value) should see `null` in the error — and the
+    // rendered value must now be DISTINGUISHABLE from a NaN input.
+    expect(formatConfigValue(null)).toBe('null');
+    // Sanity contrast: NaN and null no longer collide.
+    expect(formatConfigValue(NaN)).not.toBe(formatConfigValue(null));
+  });
+
+  test('undefined renders as JSON.stringify(undefined) === undefined-as-string', () => {
+    // Note: `JSON.stringify(undefined)` returns `undefined`, not a
+    // string. This is JSON.stringify's behaviour, surfaced through the
+    // helper for transparency. `validateLoadQuorumConfig` early-returns
+    // on `undefined` before calling the helper, so this branch is not
+    // hit in production — but the helper's behaviour is still pinned.
+    expect(formatConfigValue(undefined)).toBeUndefined();
+  });
+
+  test('strings, objects, arrays still flow through JSON.stringify', () => {
+    expect(formatConfigValue('hello')).toBe('"hello"');
+    expect(formatConfigValue({ k: 3 })).toBe('{"k":3}');
+    expect(formatConfigValue([1, 2, 3])).toBe('[1,2,3]');
+    expect(formatConfigValue(true)).toBe('true');
+    expect(formatConfigValue(false)).toBe('false');
   });
 });
 

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -7,6 +7,7 @@ import {
   effectiveK,
   effectiveQ,
   LoadQuorumFailedError,
+  validateLoadQuorumConfig,
 } from './load-quorum';
 
 function bytes(hex: string): Uint8Array {
@@ -167,6 +168,246 @@ describe('effectiveK / effectiveQ', () => {
     expect(effectiveQ(0, 3)).toBe(1); // Q < 1 -> 1
     expect(effectiveQ(-1, 3)).toBe(1);
     expect(effectiveQ(2, 0)).toBe(0); // no peers -> no quorum possible
+  });
+
+  // PR #284 r9 Copilot review (issue #2): a fractional `configuredK`
+  // previously slipped through `Math.min(...)` to produce a non-integer
+  // value (e.g. 1.5), which `peers.slice(0, 1.5)` collapsed to a 1-peer
+  // probe — silent single-peer load. The `k === 1 && !allowSinglePeer`
+  // guard did not fire because `1.5 !== 1`. The defensive `Math.floor`
+  // in `effectiveK` now collapses fractional K to an integer.
+  describe('effectiveK defensive guards (PR #284 r9)', () => {
+    test('fractional K is floored to an integer', () => {
+      expect(effectiveK(1.5, 3)).toBe(1);
+      expect(effectiveK(2.99, 5)).toBe(2);
+      expect(effectiveK(3.7, 5)).toBe(3);
+    });
+
+    test('NaN configuredK collapses to 0 (defends against missed startup validation)', () => {
+      expect(effectiveK(NaN, 3)).toBe(0);
+    });
+
+    test('Infinity configuredK collapses to 0', () => {
+      expect(effectiveK(Infinity, 3)).toBe(0);
+      expect(effectiveK(-Infinity, 3)).toBe(0);
+    });
+
+    test('integer K still flows through unchanged', () => {
+      expect(effectiveK(3, 5)).toBe(3);
+      expect(effectiveK(1, 5)).toBe(1);
+      expect(effectiveK(7, 10)).toBe(7);
+    });
+  });
+
+  // PR #284 r9 Copilot review (issue #3, suppressed): `effectiveQ(NaN, 3)`
+  // previously returned `NaN` because all comparisons against NaN are
+  // false (so `configuredQ < 1` and `configuredQ > k` both fell through
+  // to `return configuredQ`). `decideLoadQuorum` then evaluated
+  // `bestPeers.length < NaN` as false and quorum passed with a single
+  // responding peer. The defensive guard collapses NaN/Infinity to
+  // `defaultQuorumQ(k)`.
+  describe('effectiveQ defensive guards (PR #284 r9)', () => {
+    test('NaN configuredQ collapses to defaultQuorumQ(k) (was: returned NaN, gate silently passed)', () => {
+      expect(effectiveQ(NaN, 3)).toBe(defaultQuorumQ(3)); // 2
+      expect(effectiveQ(NaN, 5)).toBe(defaultQuorumQ(5)); // 3
+      expect(effectiveQ(NaN, 1)).toBe(defaultQuorumQ(1)); // 1
+    });
+
+    test('Infinity configuredQ collapses to defaultQuorumQ(k)', () => {
+      expect(effectiveQ(Infinity, 3)).toBe(defaultQuorumQ(3));
+      expect(effectiveQ(-Infinity, 5)).toBe(defaultQuorumQ(5));
+    });
+
+    test('fractional Q is floored', () => {
+      expect(effectiveQ(2.5, 3)).toBe(2);
+      expect(effectiveQ(1.9, 3)).toBe(1);
+    });
+
+    test('integer Q still flows through unchanged', () => {
+      expect(effectiveQ(2, 3)).toBe(2);
+      expect(effectiveQ(3, 3)).toBe(3);
+    });
+  });
+});
+
+describe('validateLoadQuorumConfig (startup input validation, PR #284 r9)', () => {
+  // The validator runs at `Collabswarm.initialize()` time so a
+  // misconfigured `loadQuorumK`/`loadQuorumQ` surfaces immediately
+  // rather than silently degrading every subsequent `load()` call.
+  // Must reject all non-finite-positive-integer values; must accept
+  // `undefined` (operator did not override; orchestrator defaults apply).
+
+  test('accepts undefined (no operator override)', () => {
+    expect(() => validateLoadQuorumConfig({})).not.toThrow();
+    expect(() =>
+      validateLoadQuorumConfig({ loadQuorumK: undefined, loadQuorumQ: undefined }),
+    ).not.toThrow();
+  });
+
+  test('accepts positive integers', () => {
+    expect(() =>
+      validateLoadQuorumConfig({ loadQuorumK: 1, loadQuorumQ: 1 }),
+    ).not.toThrow();
+    expect(() =>
+      validateLoadQuorumConfig({ loadQuorumK: 3, loadQuorumQ: 2 }),
+    ).not.toThrow();
+    expect(() =>
+      validateLoadQuorumConfig({ loadQuorumK: 7, loadQuorumQ: 4 }),
+    ).not.toThrow();
+  });
+
+  test('rejects fractional loadQuorumK with invalid-config error (issue #2)', () => {
+    // The exact bug: `loadQuorumK: 1.5` slipped through to
+    // `peers.slice(0, 1.5)` and silently probed only 1 peer.
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumK: 1.5 });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumK must be a positive integer/,
+    );
+    expect((err as LoadQuorumFailedError).message).toMatch(/1\.5/);
+  });
+
+  test('rejects NaN loadQuorumK', () => {
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumK: NaN });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumK must be a positive integer/,
+    );
+  });
+
+  test('rejects Infinity loadQuorumK', () => {
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumK: Infinity });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+  });
+
+  test('rejects -Infinity loadQuorumK', () => {
+    expect(() =>
+      validateLoadQuorumConfig({ loadQuorumK: -Infinity }),
+    ).toThrow(LoadQuorumFailedError);
+  });
+
+  test('rejects loadQuorumK = 0', () => {
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumK: 0 });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumK must be a positive integer/,
+    );
+  });
+
+  test('rejects negative loadQuorumK', () => {
+    expect(() => validateLoadQuorumConfig({ loadQuorumK: -1 })).toThrow(
+      LoadQuorumFailedError,
+    );
+  });
+
+  test('rejects fractional loadQuorumQ with invalid-config error (issue #3)', () => {
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumQ: 1.5 });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumQ must be a positive integer/,
+    );
+  });
+
+  test('rejects NaN loadQuorumQ (was: silent single-peer quorum pass)', () => {
+    // The exact bug: `effectiveQ(NaN, k)` returned `NaN`,
+    // `decideLoadQuorum` evaluated `bestPeers.length < NaN` as false,
+    // and quorum passed with a single responder. Now refused at startup.
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumQ: NaN });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+    expect((err as LoadQuorumFailedError).message).toMatch(
+      /loadQuorumQ must be a positive integer/,
+    );
+  });
+
+  test('rejects Infinity loadQuorumQ', () => {
+    expect(() => validateLoadQuorumConfig({ loadQuorumQ: Infinity })).toThrow(
+      LoadQuorumFailedError,
+    );
+  });
+
+  test('rejects loadQuorumQ = 0', () => {
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumQ: 0 });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).reason).toBe('invalid-config');
+  });
+
+  test('rejects negative loadQuorumQ', () => {
+    expect(() => validateLoadQuorumConfig({ loadQuorumQ: -1 })).toThrow(
+      LoadQuorumFailedError,
+    );
+  });
+
+  test('only the FIRST offending knob is reported (K checked before Q)', () => {
+    // When both are invalid the validator throws on K first; the
+    // operator fixes K, re-runs, and then sees the Q error. Surfacing
+    // both at once would require an aggregate error which the existing
+    // LoadQuorumFailedError shape doesn't support.
+    const err = (() => {
+      try {
+        validateLoadQuorumConfig({ loadQuorumK: 0, loadQuorumQ: NaN });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(LoadQuorumFailedError);
+    expect((err as LoadQuorumFailedError).message).toMatch(/loadQuorumK/);
+    expect((err as LoadQuorumFailedError).message).not.toMatch(/loadQuorumQ/);
   });
 });
 

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -29,15 +29,35 @@ import { tipsHashToHex } from './tips-hash';
  * `hash`:
  *   - `Uint8Array` -- the peer returned a tip-set hash (32 bytes
  *     post-validation; see `tips-hash.ts`).
+ *   - `'unknown-doc'` -- the peer explicitly disclaimed the document
+ *     (received the 1-byte UNKNOWN_DOC sentinel from the wire). Counted
+ *     toward an "unknown-doc" tally exactly like a tip-hash vote: when a
+ *     Q-of-K majority of probed peers all disclaim the document, the
+ *     orchestrator returns `{ newDoc: true }` so `load()` can let a fresh
+ *     `open()` create the document on top of the existing swarm rather
+ *     than failing with `LoadQuorumFailedError`. Worst-case Byzantine
+ *     exposure is identical to the tip-hash case: Q lying peers can
+ *     force a wrong outcome, but a single lying peer cannot. See
+ *     `Collabswarm.tipAdvertiseHandler` for the wire sentinel and
+ *     PR #284 r16 Copilot review for the rationale.
  *   - `null` -- the peer did not return a usable hash. This covers BOTH
- *     timeouts AND explicit declines (empty response, unauthorized, wrong
- *     document id, deserialization failure, etc.). Non-responding peers
- *     are NOT counted toward "disagreement" -- they simply do not vote.
+ *     timeouts AND non-disclaim declines (unauthorized, wrong document
+ *     id, deserialization failure, etc.). Non-responding peers are NOT
+ *     counted toward "disagreement" -- they simply do not vote.
  */
 export interface PeerTipAdvertisement {
   peerId: string;
-  hash: Uint8Array | null;
+  hash: Uint8Array | 'unknown-doc' | null;
 }
+
+/**
+ * Reserved key used in the `decideLoadQuorum` agreement tally for peers
+ * that disclaimed the document (returned `'unknown-doc'` from the probe).
+ * Chosen so the key cannot collide with a real `tipsHashToHex` output:
+ * `tipsHashToHex` produces a 64-char lowercase hex string, while this
+ * sentinel is a 11-char string containing a hyphen.
+ */
+export const UNKNOWN_DOC_TALLY_KEY = 'unknown-doc';
 
 /**
  * Result of running `decideLoadQuorum` over a set of peer advertisements.
@@ -53,6 +73,17 @@ export interface PeerTipAdvertisement {
 export type LoadQuorumDecision =
   | {
       ok: true;
+      /**
+       * Discriminates whether the agreeing peers voted for a tip-set hash
+       * (the normal case) or all disclaimed the document via the
+       * `'unknown-doc'` sentinel (the new-doc-creation case). Callers
+       * branch on `kind` to decide whether to proceed with the full
+       * document-load (`'tip-hash'`) or to let the loader return `false`
+       * so a fresh `open()` creates the document on top of the swarm
+       * (`'new-doc'`). See `Collabswarm.tipAdvertiseHandler` and
+       * PR #284 r16 Copilot review for the unknown-doc wire signal.
+       */
+      kind: 'tip-hash' | 'new-doc';
       winningHashHex: string;
       agreeingPeerIds: string[];
       respondingCount: number;
@@ -93,23 +124,32 @@ export function decideLoadQuorum(
     };
   }
 
-  // Tally agreement keyed by the hex form of each peer's hash. Hex is used
-  // as the Map key because `Uint8Array` reference equality is not what we
-  // want -- two peers returning byte-identical hashes must collide on the
-  // same bucket. The hex encoding mirrors `tipsHashToHex`, so logged
-  // mismatches are human-readable.
+  // Tally agreement keyed by the hex form of each peer's hash (for
+  // tip-hash votes) or `UNKNOWN_DOC_TALLY_KEY` (for `'unknown-doc'`
+  // disclaim votes). Hex is used as the Map key for tip-hash buckets so
+  // two peers returning byte-identical hashes collide on the same bucket;
+  // the unknown-doc sentinel uses a non-hex literal key that cannot
+  // collide with any real `tipsHashToHex` output (64-char lowercase hex).
+  // Mismatches are human-readable in the logged `agreement` snapshot.
   const agreement = new Map<string, string[]>();
   let respondingCount = 0;
   for (const adv of advertisements) {
     if (adv.hash === null) {
-      // Non-vote: timeout or explicit decline. Skip without penalty -- a
-      // stale `knownPeers` cache that points at offline peers must not be
-      // counted as disagreement, otherwise a partition + small mesh would
-      // be indistinguishable from active Byzantine behaviour.
+      // Non-vote: timeout or non-disclaim decline. Skip without penalty
+      // -- a stale `knownPeers` cache that points at offline peers must
+      // not be counted as disagreement, otherwise a partition + small
+      // mesh would be indistinguishable from active Byzantine behaviour.
       continue;
     }
     respondingCount++;
-    const key = tipsHashToHex(adv.hash);
+    // `'unknown-doc'` votes tally under a dedicated reserved key so a
+    // Q-of-K majority of disclaims is detectable by the orchestrator
+    // exactly like a tip-hash majority. The key is intentionally NOT a
+    // hex string so it cannot collide with `tipsHashToHex` output.
+    const key =
+      adv.hash === 'unknown-doc'
+        ? UNKNOWN_DOC_TALLY_KEY
+        : tipsHashToHex(adv.hash);
     let bucket = agreement.get(key);
     if (!bucket) {
       bucket = [];
@@ -164,6 +204,7 @@ export function decideLoadQuorum(
 
   return {
     ok: true,
+    kind: bestKey === UNKNOWN_DOC_TALLY_KEY ? 'new-doc' : 'tip-hash',
     winningHashHex: bestKey,
     agreeingPeerIds: bestPeers,
     respondingCount,

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -1,0 +1,257 @@
+/**
+ * Pure quorum-decision logic for the initial-load quorum protocol.
+ *
+ * Closes the "no quorum protocol for verifying initial document state" gap
+ * tracked under issue #189 §5.4 item 2 (also a bullet under #186). The
+ * design:
+ *
+ *   - Loader asks up to K peers in parallel for a `tipsHash` (see
+ *     `tips-hash.ts`) advertising their view of the document's tip set.
+ *   - Each peer either returns a hash, returns `null` (decline, e.g. unknown
+ *     document or unauthorized), or fails to respond before the timeout
+ *     (also represented as `null` here).
+ *   - This module decides whether enough peers (>= Q) agreed on a single
+ *     tip-set hash. If so, the loader proceeds with a normal single-peer
+ *     document-load against any peer in the agreeing set. If not, the
+ *     loader raises `LoadQuorumFailedError` and the application can decide
+ *     how to recover (retry, surface to the user, etc.).
+ *
+ * The functions in this module are intentionally pure (no I/O, no clock,
+ * no network) so the decision logic can be unit-tested in isolation and
+ * audited as the trust-critical core of the gate.
+ */
+
+import { tipsHashToHex } from './tips-hash';
+
+/**
+ * A single peer's response to a tip-advertise probe.
+ *
+ * `hash`:
+ *   - `Uint8Array` -- the peer returned a tip-set hash (32 bytes
+ *     post-validation; see `tips-hash.ts`).
+ *   - `null` -- the peer did not return a usable hash. This covers BOTH
+ *     timeouts AND explicit declines (empty response, unauthorized, wrong
+ *     document id, deserialization failure, etc.). Non-responding peers
+ *     are NOT counted toward "disagreement" -- they simply do not vote.
+ */
+export interface PeerTipAdvertisement {
+  peerId: string;
+  hash: Uint8Array | null;
+}
+
+/**
+ * Result of running `decideLoadQuorum` over a set of peer advertisements.
+ *
+ * On success, `winningHashHex` identifies the agreeing tip set and
+ * `agreeingPeerIds` lists the peers that returned that hash -- the loader
+ * should pick any one of these for the follow-up full document-load.
+ *
+ * On failure, `reason` describes why quorum could not be met (used for
+ * error messages and observability) and `agreement` records the
+ * per-hash vote counts so callers can log the disagreement pattern.
+ */
+export type LoadQuorumDecision =
+  | {
+      ok: true;
+      winningHashHex: string;
+      agreeingPeerIds: string[];
+      respondingCount: number;
+      effectiveQ: number;
+    }
+  | {
+      ok: false;
+      reason:
+        | 'insufficient-responses'
+        | 'no-majority'
+        | 'no-peers-queried';
+      respondingCount: number;
+      effectiveQ: number;
+      agreement: Map<string, number>;
+    };
+
+/**
+ * Decide whether a set of tip-advertise responses meets quorum.
+ *
+ * @param advertisements One entry per peer queried. `hash: null` represents
+ *   a non-vote (timeout or decline). Order is irrelevant.
+ * @param q The minimum number of *agreeing* peers required. Already clamped
+ *   to `[1, K]` by the caller; this function does not re-clamp.
+ * @returns A {@link LoadQuorumDecision} describing the outcome. Pure: same
+ *   inputs always yield the same result.
+ */
+export function decideLoadQuorum(
+  advertisements: readonly PeerTipAdvertisement[],
+  q: number,
+): LoadQuorumDecision {
+  if (advertisements.length === 0) {
+    return {
+      ok: false,
+      reason: 'no-peers-queried',
+      respondingCount: 0,
+      effectiveQ: q,
+      agreement: new Map(),
+    };
+  }
+
+  // Tally agreement keyed by the hex form of each peer's hash. Hex is used
+  // as the Map key because `Uint8Array` reference equality is not what we
+  // want -- two peers returning byte-identical hashes must collide on the
+  // same bucket. The hex encoding mirrors `tipsHashToHex`, so logged
+  // mismatches are human-readable.
+  const agreement = new Map<string, string[]>();
+  let respondingCount = 0;
+  for (const adv of advertisements) {
+    if (adv.hash === null) {
+      // Non-vote: timeout or explicit decline. Skip without penalty -- a
+      // stale `knownPeers` cache that points at offline peers must not be
+      // counted as disagreement, otherwise a partition + small mesh would
+      // be indistinguishable from active Byzantine behaviour.
+      continue;
+    }
+    respondingCount++;
+    const key = tipsHashToHex(adv.hash);
+    let bucket = agreement.get(key);
+    if (!bucket) {
+      bucket = [];
+      agreement.set(key, bucket);
+    }
+    bucket.push(adv.peerId);
+  }
+
+  if (respondingCount === 0) {
+    // No peer voted -- partition, all timed out, all declined.
+    const summary = new Map<string, number>();
+    return {
+      ok: false,
+      reason: 'insufficient-responses',
+      respondingCount,
+      effectiveQ: q,
+      agreement: summary,
+    };
+  }
+
+  // Find the largest bucket. Ties are broken arbitrarily by Map iteration
+  // order (insertion order); ties never affect ok/!ok because both buckets
+  // would have the same size and we only accept if size >= q.
+  let bestKey: string | null = null;
+  let bestPeers: string[] = [];
+  for (const [key, peers] of agreement.entries()) {
+    if (peers.length > bestPeers.length) {
+      bestKey = key;
+      bestPeers = peers;
+    }
+  }
+
+  if (bestKey === null || bestPeers.length < q) {
+    // Either no responses (handled above) or the largest agreeing cohort
+    // is too small. Build a compact `hash -> count` snapshot for diagnostics.
+    const summary = new Map<string, number>();
+    for (const [key, peers] of agreement.entries()) {
+      summary.set(key, peers.length);
+    }
+    // Distinguish "we got responses but none agreed enough" from the
+    // earlier "no one responded" branch.
+    const reason =
+      respondingCount < q ? 'insufficient-responses' : 'no-majority';
+    return {
+      ok: false,
+      reason,
+      respondingCount,
+      effectiveQ: q,
+      agreement: summary,
+    };
+  }
+
+  return {
+    ok: true,
+    winningHashHex: bestKey,
+    agreeingPeerIds: bestPeers,
+    respondingCount,
+    effectiveQ: q,
+  };
+}
+
+/**
+ * Compute the effective `K` (number of peers to query) given a configured
+ * upper bound and the number of currently-known peers. Pulled out so the
+ * loader and the quorum decision can share a single source of truth and so
+ * the clamp is unit-testable.
+ */
+export function effectiveK(
+  configuredK: number,
+  knownPeersCount: number,
+): number {
+  // K should be at least 1 (otherwise no probes happen) and at most the
+  // number of peers we actually know about (otherwise we'd query the same
+  // peer twice or fewer-than-K real peers).
+  if (configuredK <= 0) return 0;
+  if (knownPeersCount <= 0) return 0;
+  return Math.min(configuredK, knownPeersCount);
+}
+
+/**
+ * Compute the effective `Q` (quorum threshold) given a configured value and
+ * the effective K. Clamped to `[1, K]` so a misconfigured `Q > K` cannot
+ * make quorum unreachable, and `Q <= 0` does not silently bypass the gate.
+ */
+export function effectiveQ(configuredQ: number, k: number): number {
+  if (k <= 0) return 0;
+  if (configuredQ < 1) return 1;
+  if (configuredQ > k) return k;
+  return configuredQ;
+}
+
+/**
+ * Error thrown by `CollabswarmDocument.load()` when the initial-load quorum
+ * gate fails -- i.e. fewer than `Q` peers agreed on a tip-set hash within
+ * the configured timeout. Applications should catch this and either retry
+ * later (peers may converge), surface the failure to the user, or fall
+ * back to an explicit `loadQuorumEnabled: false` path if they have an
+ * out-of-band trust model.
+ *
+ * Defined here (alongside the pure decision logic) so callers can `instanceof`
+ * test without importing the heavy `CollabswarmDocument` module.
+ */
+export class LoadQuorumFailedError extends Error {
+  /** The document path the quorum was being computed for. */
+  public readonly documentPath: string;
+  /** Why quorum failed -- mirrors `LoadQuorumDecision.reason` on the
+   *  failure case so callers can branch on the specific failure mode. */
+  public readonly reason:
+    | 'insufficient-responses'
+    | 'no-majority'
+    | 'no-peers-queried';
+  /** Number of peers that actually returned a usable hash. */
+  public readonly respondingCount: number;
+  /** The effective Q threshold the loader was holding peers to. */
+  public readonly requiredQ: number;
+  /** Snapshot of (hash hex -> vote count) at the moment of failure, used
+   *  for observability. Empty when no peer responded. */
+  public readonly agreement: ReadonlyMap<string, number>;
+
+  constructor(opts: {
+    documentPath: string;
+    reason: 'insufficient-responses' | 'no-majority' | 'no-peers-queried';
+    respondingCount: number;
+    requiredQ: number;
+    agreement: ReadonlyMap<string, number>;
+  }) {
+    const detail =
+      opts.reason === 'no-peers-queried'
+        ? 'no peers were queried'
+        : opts.reason === 'insufficient-responses'
+          ? `only ${opts.respondingCount} of the required ${opts.requiredQ} peers responded`
+          : `no tip-set hash reached the required ${opts.requiredQ}-of-${opts.respondingCount} agreement`;
+    super(
+      `Initial-load quorum failed for "${opts.documentPath}": ${detail}. ` +
+        `Configure CollabswarmConfig.loadQuorumK/Q/loadQuorumTimeoutMs, ` +
+        `or set loadQuorumEnabled: false to bypass (weakens trust assumptions).`,
+    );
+    this.name = 'LoadQuorumFailedError';
+    this.documentPath = opts.documentPath;
+    this.reason = opts.reason;
+    this.respondingCount = opts.respondingCount;
+    this.requiredQ = opts.requiredQ;
+    this.agreement = opts.agreement;
+  }
+}

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -634,6 +634,14 @@ export class LoadQuorumFailedError extends Error {
    *  they served instead. Empty for all other reasons. See PR #284 r6
    *  Copilot review. */
   public readonly agreeingPeerBindFailures: ReadonlyMap<string, string>;
+  /** Structured detail string for the `'invalid-config'` reason (e.g.
+   *  `loadQuorumK must be a positive integer; got NaN`). Exposed as a
+   *  field so callers (notably `runLoadQuorum`'s post-init guard) can
+   *  forward the validator's structured wording into a rethrown error
+   *  with a different `documentPath` WITHOUT regex-parsing
+   *  `error.message`. Empty/undefined for all other reasons. See PR
+   *  #284 r23 Copilot review. */
+  public readonly detail?: string;
 
   constructor(opts: {
     documentPath: string;
@@ -686,5 +694,11 @@ export class LoadQuorumFailedError extends Error {
     this.agreement = opts.agreement;
     this.agreeingPeerBindFailures =
       opts.agreeingPeerBindFailures ?? new Map();
+    // Persist the structured detail so callers can forward it across a
+    // rethrow without parsing the human-readable `error.message`. Only
+    // load-bearing for `reason === 'invalid-config'`; harmless for
+    // other reasons (where the constructor composes `detail` from the
+    // structured fields and `opts.detail` is ignored).
+    this.detail = opts.detail;
   }
 }

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -626,7 +626,11 @@ export class LoadQuorumFailedError extends Error {
    *  failure case so callers can branch on the specific failure mode.
    *  See {@link LoadQuorumFailedReason} for the full set. */
   public readonly reason: LoadQuorumFailedReason;
-  /** Number of peers that actually returned a usable hash. */
+  /** Number of peers that returned any non-null probe result — both
+   *  tip-hash votes AND the `'unknown-doc'` sentinel. Timeouts and
+   *  non-disclaim declines do NOT increment this. Used to distinguish
+   *  `'insufficient-responses'` (< Q peers responded at all) from
+   *  `'no-majority'` (≥ Q responded but no single bucket reached Q). */
   public readonly respondingCount: number;
   /** The effective Q threshold the loader was holding peers to. */
   public readonly requiredQ: number;

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -127,6 +127,24 @@ export function decideLoadQuorum(
   advertisements: readonly PeerTipAdvertisement[],
   q: number,
 ): LoadQuorumDecision {
+  // Fail fast on programming errors. `decideLoadQuorum` is exported, so a
+  // direct caller (or a future refactor that bypasses `runLoadQuorum`)
+  // could otherwise pass `q <= 0` / `NaN` / non-integer and silently
+  // disable the quorum gate -- the largest-bucket size would always be
+  // `>= 0 >= q` and a single peer's vote would pass. The orchestrator
+  // already clamps via `effectiveQ`, but this guard is the load-bearing
+  // backstop for any other code path that builds the advertisements list
+  // by hand. Coding-guideline rule applies here: throw on programming
+  // mistakes (vs. logging warnings for runtime issues) so the failure is
+  // loud at the first call site. See PR #284 r12 CodeRabbit review.
+  if (!Number.isInteger(q) || q < 1) {
+    throw new Error(
+      `decideLoadQuorum: q must be a positive integer; got ${String(q)}. ` +
+        `Pass the value through effectiveQ() / runLoadQuorum() so the ` +
+        `clamp against the responding cohort fires before reaching this ` +
+        `function.`,
+    );
+  }
   if (advertisements.length === 0) {
     return {
       ok: false,

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -305,6 +305,16 @@ export function effectiveQ(configuredQ: number, k: number): number {
 }
 
 /**
+ * Upper bound (milliseconds) for {@link validateLoadQuorumConfig}'s
+ * `loadQuorumTimeoutMs` check. Five minutes is comfortably larger than any
+ * realistic per-probe budget on a wide-area mesh (the default is 5 s) but
+ * small enough to catch a typo like `5000000` (5 000 s = ~83 min) or a
+ * mistakenly-passed nanosecond value before it stalls `open()` for an
+ * absurd duration. See PR #284 r15 Copilot review.
+ */
+export const LOAD_QUORUM_TIMEOUT_MS_MAX = 5 * 60 * 1000;
+
+/**
  * Validate the load-quorum tuning knobs from {@link CollabswarmConfig}.
  *
  * Runs at {@link Collabswarm.initialize} time so a misconfigured value is
@@ -317,14 +327,30 @@ export function effectiveQ(configuredQ: number, k: number): number {
  * evaluate as false (silent single-peer quorum pass). Both classes of
  * misconfig are now rejected here with a clear operator-visible error.
  *
- * Both knobs MUST be finite positive integers (Number.isInteger(x) && x >= 1).
+ * `loadQuorumTimeoutMs` is also validated here under PR #284 r15 Copilot
+ * review: the value flows directly into `setTimeout(...)` inside the
+ * tip-advertise probe race, where `NaN`/`Infinity`/`0`/negative are coerced
+ * to immediate-fire / overflow behaviour by the timer queue. Every probe
+ * then resolves as a non-vote and quorum fails on every load attempt even
+ * with a fully healthy mesh — silently breaking the gate. We require a
+ * finite positive integer no greater than
+ * {@link LOAD_QUORUM_TIMEOUT_MS_MAX} so an operator typo or a misplaced
+ * decimal is caught at startup.
+ *
+ * `loadQuorumK` and `loadQuorumQ` MUST be finite positive integers
+ * (Number.isInteger(x) && x >= 1).
+ * `loadQuorumTimeoutMs` MUST be a finite positive integer in the closed
+ * range `[1, LOAD_QUORUM_TIMEOUT_MS_MAX]`.
+ *
  * Rejects:
- *   - NaN / Infinity / -Infinity
- *   - non-integers (e.g. 1.5, 2.7)
- *   - zero and negative values (0, -1)
+ *   - NaN / Infinity / -Infinity (all knobs)
+ *   - non-integers (e.g. 1.5, 2.7) (all knobs)
+ *   - zero and negative values (0, -1) (all knobs)
+ *   - `loadQuorumTimeoutMs > LOAD_QUORUM_TIMEOUT_MS_MAX`
  * Accepts:
  *   - `undefined` (operator did not override; the orchestrator's defaults apply)
- *   - any positive integer (1, 2, 3, ...)
+ *   - any positive integer (1, 2, 3, ...) for K/Q
+ *   - integers in `[1, LOAD_QUORUM_TIMEOUT_MS_MAX]` for `loadQuorumTimeoutMs`
  *
  * Throws {@link LoadQuorumFailedError} with `reason: 'invalid-config'` so
  * the existing `instanceof`-based error handling in `CollabswarmDocument.load()`
@@ -332,13 +358,14 @@ export function effectiveQ(configuredQ: number, k: number): number {
  * offending value.
  *
  * @param config The {@link CollabswarmConfig} (or its load-quorum subset)
- *   to validate. Pass-through fields (`enabled`, `timeoutMs`,
- *   `allowSinglePeer`) are intentionally NOT validated here; only K and Q
- *   are the load-bearing trust knobs.
+ *   to validate. Pass-through fields (`enabled`, `allowSinglePeer`) are
+ *   intentionally NOT validated here; only K, Q, and timeoutMs are the
+ *   load-bearing trust/timing knobs.
  */
 export function validateLoadQuorumConfig(config: {
   loadQuorumK?: number;
   loadQuorumQ?: number;
+  loadQuorumTimeoutMs?: number;
 }): void {
   const checkPositiveInt = (name: string, value: number | undefined): void => {
     if (value === undefined) return;
@@ -361,8 +388,37 @@ export function validateLoadQuorumConfig(config: {
       });
     }
   };
+  const checkBoundedPositiveInt = (
+    name: string,
+    value: number | undefined,
+    max: number,
+  ): void => {
+    if (value === undefined) return;
+    if (
+      typeof value !== 'number' ||
+      !Number.isInteger(value) ||
+      value < 1 ||
+      value > max
+    ) {
+      throw new LoadQuorumFailedError({
+        documentPath: '<config>',
+        reason: 'invalid-config',
+        respondingCount: 0,
+        requiredQ: 0,
+        agreement: new Map(),
+        detail:
+          `${name} must be a positive integer no greater than ${max}; ` +
+          `got ${formatConfigValue(value)}`,
+      });
+    }
+  };
   checkPositiveInt('loadQuorumK', config.loadQuorumK);
   checkPositiveInt('loadQuorumQ', config.loadQuorumQ);
+  checkBoundedPositiveInt(
+    'loadQuorumTimeoutMs',
+    config.loadQuorumTimeoutMs,
+    LOAD_QUORUM_TIMEOUT_MS_MAX,
+  );
 }
 
 /**

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -481,7 +481,14 @@ export function formatConfigValue(value: unknown): string {
   if (typeof value === 'number' && !Number.isFinite(value)) {
     return String(value); // 'NaN' | 'Infinity' | '-Infinity'
   }
-  return JSON.stringify(value);
+  // `JSON.stringify(undefined)` returns `undefined` (not a string), and
+  // the function applies a structured replacer to `function` values that
+  // also yields `undefined`. Coerce the result so callers that read this
+  // in an error message always get a string (avoiding "got undefined")
+  // and so strict-mode TypeScript callers see a well-typed `string`
+  // return value. See PR #284 r18 Copilot review.
+  const json = JSON.stringify(value);
+  return json === undefined ? String(value) : json;
 }
 
 /**

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -420,7 +420,8 @@ export type LoadQuorumFailedReason =
   | 'no-majority'
   | 'no-peers-queried'
   | 'invalid-config'
-  | 'bind-check-failed-all-agreeing-peers';
+  | 'bind-check-failed-all-agreeing-peers'
+  | 'agreeing-peers-unreachable';
 
 /**
  * Error thrown by `CollabswarmDocument.load()` when the initial-load quorum

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -495,7 +495,12 @@ export class LoadQuorumFailedError extends Error {
                 `(${opts.agreeingPeerBindFailures?.size ?? 0} peer(s)) served a full-load ` +
                 `response whose tips did not hash to the agreed value (or omitted tips entirely); ` +
                 `treating as coordinated Byzantine equivocation on the load step`
-              : `no tip-set hash reached the required ${opts.requiredQ}-of-${opts.respondingCount} agreement`;
+              : opts.reason === 'agreeing-peers-unreachable'
+                ? `quorum agreed on a tip-set hash but every peer in the agreeing ` +
+                  `cohort failed to serve a full load (transport / protocol error, ` +
+                  `not a bind mismatch); the document is known to exist but cannot ` +
+                  `currently be retrieved from this peer set`
+                : `no tip-set hash reached the required ${opts.requiredQ}-of-${opts.respondingCount} agreement`;
     super(
       `Initial-load quorum failed for "${opts.documentPath}": ${detail}. ` +
         `Configure CollabswarmConfig.loadQuorumK/Q/loadQuorumTimeoutMs, ` +

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -277,12 +277,39 @@ export function effectiveQ(configuredQ: number, k: number): number {
 }
 
 /**
+ * The set of reasons `LoadQuorumFailedError` can be thrown with.
+ *
+ *   - `'insufficient-responses'` — fewer than `Q` peers returned a usable
+ *     tip-set hash within the configured timeout (timeouts, declines,
+ *     decryption failures).
+ *   - `'no-majority'` — peers responded but no single tip-set hash reached
+ *     the `Q`-of-respondingCount agreement threshold.
+ *   - `'no-peers-queried'` — `decideLoadQuorum` was called with an empty
+ *     advertisement list; surfaced for defensive completeness.
+ *   - `'invalid-config'` — the operator misconfigured the gate (e.g.
+ *     `loadQuorumK <= 0`) in a way that would silently disable trust
+ *     defences. Surfaced as a configuration error rather than a quorum
+ *     failure so the misconfiguration is loud at `open()` time. See
+ *     PR #284 r5 Copilot review.
+ */
+export type LoadQuorumFailedReason =
+  | 'insufficient-responses'
+  | 'no-majority'
+  | 'no-peers-queried'
+  | 'invalid-config';
+
+/**
  * Error thrown by `CollabswarmDocument.load()` when the initial-load quorum
  * gate fails -- i.e. fewer than `Q` peers agreed on a tip-set hash within
  * the configured timeout. Applications should catch this and either retry
  * later (peers may converge), surface the failure to the user, or fall
  * back to an explicit `loadQuorumEnabled: false` path if they have an
  * out-of-band trust model.
+ *
+ * The `'invalid-config'` reason is a special case that surfaces an operator
+ * misconfiguration (e.g. `loadQuorumK <= 0`) rather than a runtime quorum
+ * failure: retrying without fixing the config will not help. See the
+ * docstring on {@link LoadQuorumFailedReason} for the full reason set.
  *
  * Defined here (alongside the pure decision logic) so callers can `instanceof`
  * test without importing the heavy `CollabswarmDocument` module.
@@ -291,11 +318,9 @@ export class LoadQuorumFailedError extends Error {
   /** The document path the quorum was being computed for. */
   public readonly documentPath: string;
   /** Why quorum failed -- mirrors `LoadQuorumDecision.reason` on the
-   *  failure case so callers can branch on the specific failure mode. */
-  public readonly reason:
-    | 'insufficient-responses'
-    | 'no-majority'
-    | 'no-peers-queried';
+   *  failure case so callers can branch on the specific failure mode.
+   *  See {@link LoadQuorumFailedReason} for the full set. */
+  public readonly reason: LoadQuorumFailedReason;
   /** Number of peers that actually returned a usable hash. */
   public readonly respondingCount: number;
   /** The effective Q threshold the loader was holding peers to. */
@@ -306,17 +331,25 @@ export class LoadQuorumFailedError extends Error {
 
   constructor(opts: {
     documentPath: string;
-    reason: 'insufficient-responses' | 'no-majority' | 'no-peers-queried';
+    reason: LoadQuorumFailedReason;
     respondingCount: number;
     requiredQ: number;
     agreement: ReadonlyMap<string, number>;
+    /** Free-form detail string used by the `'invalid-config'` reason to
+     *  carry the offending value into the operator-visible error message
+     *  (e.g. `loadQuorumK must be >= 1; got 0`). Ignored for the other
+     *  reasons, which compose the detail string from the structured
+     *  fields. */
+    detail?: string;
   }) {
     const detail =
       opts.reason === 'no-peers-queried'
         ? 'no peers were queried'
         : opts.reason === 'insufficient-responses'
           ? `only ${opts.respondingCount} of the required ${opts.requiredQ} peers responded`
-          : `no tip-set hash reached the required ${opts.requiredQ}-of-${opts.respondingCount} agreement`;
+          : opts.reason === 'invalid-config'
+            ? (opts.detail ?? 'invalid load-quorum configuration')
+            : `no tip-set hash reached the required ${opts.requiredQ}-of-${opts.respondingCount} agreement`;
     super(
       `Initial-load quorum failed for "${opts.documentPath}": ${detail}. ` +
         `Configure CollabswarmConfig.loadQuorumK/Q/loadQuorumTimeoutMs, ` +

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -172,6 +172,81 @@ export function decideLoadQuorum(
 }
 
 /**
+ * Compute the default quorum threshold `Q` for a given `K` using the
+ * strict-majority rule `Math.floor(K / 2) + 1`. This tolerates `floor((K-1)/2)`
+ * faulty peers (one fault at K=3, K=4; two at K=5) — the standard BFT
+ * threshold — and is the formula `CollabswarmConfig.loadQuorumQ` defaults to
+ * when the user does not override it.
+ *
+ * Worked examples:
+ *   - K=1 → Q=1
+ *   - K=2 → Q=2
+ *   - K=3 → Q=2 (one fault tolerated; previously K=3 → Q=3 under
+ *     `Math.ceil(K/2)+1`, which made the gate refuse to pass with even a
+ *     single non-vote and defeated the fault-tolerance intent)
+ *   - K=4 → Q=3
+ *   - K=5 → Q=3
+ *   - K=7 → Q=4
+ *
+ * Pulled out so the loader, the config docstring, and the test matrix all
+ * reference one canonical formula. Callers must still pass the result
+ * through `effectiveQ(q, k)` to handle `K=0` and user overrides.
+ */
+export function defaultQuorumQ(k: number): number {
+  if (k <= 0) return 0;
+  return Math.floor(k / 2) + 1;
+}
+
+/**
+ * Deduplicate a sequence of (peer, peerId) pairs by `peerId`, preserving
+ * first-seen order. Used by the loader to collapse multiple open
+ * connections to the same remote peer into a single quorum entry — without
+ * this, one peer with two connections (e.g. direct + relay-circuit) would
+ * cast two votes in the tip-advertise tally, allowing a single malicious
+ * peer with multiple connections to single-handedly win an agreement.
+ *
+ * Pulled out so the dedup behaviour is unit-testable without standing up
+ * a libp2p stack. The `T` generic lets the caller dedup either raw peer
+ * objects (Multiaddr in `CollabswarmDocument.load()`) or test doubles.
+ */
+export function dedupePeersByPeerId<T>(
+  peers: readonly T[],
+  peerIdOf: (peer: T) => string,
+): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const peer of peers) {
+    const id = peerIdOf(peer);
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(peer);
+  }
+  return out;
+}
+
+/**
+ * Constant-time string equality used by the post-load hash-binding check.
+ * Both inputs are expected to be lowercase hex strings (typically 64 chars
+ * for SHA-256), but the implementation tolerates differing lengths via the
+ * length-XOR + max-loop pattern. Returns `true` if the strings are
+ * byte-identical.
+ *
+ * Pulled out so the comparison logic is reused by `_enforceQuorumHashBinding`
+ * and is unit-testable (timing properties are not asserted in unit tests but
+ * the equality semantics are).
+ */
+export function constantTimeHexEquals(a: string, b: string): boolean {
+  let diff = a.length ^ b.length;
+  const max = Math.max(a.length, b.length);
+  for (let i = 0; i < max; i++) {
+    const av = i < a.length ? a.charCodeAt(i) : 0;
+    const bv = i < b.length ? b.charCodeAt(i) : 0;
+    diff |= av ^ bv;
+  }
+  return diff === 0;
+}
+
+/**
  * Compute the effective `K` (number of peers to query) given a configured
  * upper bound and the number of currently-known peers. Pulled out so the
  * loader and the quorum decision can share a single source of truth and so

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -357,12 +357,34 @@ export function validateLoadQuorumConfig(config: {
         respondingCount: 0,
         requiredQ: 0,
         agreement: new Map(),
-        detail: `${name} must be a positive integer; got ${JSON.stringify(value)}`,
+        detail: `${name} must be a positive integer; got ${formatConfigValue(value)}`,
       });
     }
   };
   checkPositiveInt('loadQuorumK', config.loadQuorumK);
   checkPositiveInt('loadQuorumQ', config.loadQuorumQ);
+}
+
+/**
+ * Format a configuration value for inclusion in operator-visible error
+ * messages. `JSON.stringify` has no representation for `NaN`, `Infinity`,
+ * or `-Infinity` and serializes all three as the literal string `'null'` —
+ * so an operator who passed `loadQuorumK: NaN` would see `got null` in the
+ * error message, indistinguishable from explicitly passing `null` and
+ * actively misleading about the actual misconfiguration. Coerce non-finite
+ * numbers via `String(...)` so they render as their JS literal (`'NaN'`,
+ * `'Infinity'`, `'-Infinity'`) instead. All other values pass through
+ * `JSON.stringify` unchanged so structured values (objects, arrays, the
+ * literal `null`, strings) still get quoted/serialized cleanly.
+ *
+ * Used by `validateLoadQuorumConfig` and `runLoadQuorum`'s post-init guard.
+ * See PR #284 r10 Copilot review.
+ */
+export function formatConfigValue(value: unknown): string {
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return String(value); // 'NaN' | 'Infinity' | '-Infinity'
+  }
+  return JSON.stringify(value);
 }
 
 /**
@@ -448,7 +470,10 @@ export class LoadQuorumFailedError extends Error {
     agreement: ReadonlyMap<string, number>;
     /** Free-form detail string used by the `'invalid-config'` reason to
      *  carry the offending value into the operator-visible error message
-     *  (e.g. `loadQuorumK must be >= 1; got 0`). Ignored for the other
+     *  (e.g. `loadQuorumK must be a positive integer; got NaN`). Non-finite
+     *  numbers render as their JS literal (`'NaN'` / `'Infinity'` /
+     *  `'-Infinity'`) via {@link formatConfigValue}, not the misleading
+     *  `'null'` that `JSON.stringify` produces. Ignored for the other
      *  reasons, which compose the detail string from the structured
      *  fields. */
     detail?: string;

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -549,13 +549,21 @@ export function formatConfigValue(value: unknown): string {
   if (typeof value === 'number' && !Number.isFinite(value)) {
     return String(value); // 'NaN' | 'Infinity' | '-Infinity'
   }
+  // `JSON.stringify` throws on BigInt and circular references; fall back to
+  // `String(value)` so an exotic operator value yields a useful error
+  // message instead of a raw `TypeError` escaping the validator.
+  let json: string | undefined;
+  try {
+    json = JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
   // `JSON.stringify(undefined)` returns `undefined` (not a string), and
   // the function applies a structured replacer to `function` values that
   // also yields `undefined`. Coerce the result so callers that read this
   // in an error message always get a string (avoiding "got undefined")
   // and so strict-mode TypeScript callers see a well-typed `string`
-  // return value. See PR #284 r18 Copilot review.
-  const json = JSON.stringify(value);
+  // return value.
   return json === undefined ? String(value) : json;
 }
 

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -291,12 +291,25 @@ export function effectiveQ(configuredQ: number, k: number): number {
  *     defences. Surfaced as a configuration error rather than a quorum
  *     failure so the misconfiguration is loud at `open()` time. See
  *     PR #284 r5 Copilot review.
+ *   - `'bind-check-failed-all-agreeing-peers'` — quorum agreement was
+ *     reached, but EVERY peer in the agreeing cohort served a full-load
+ *     response whose `tips` array did not hash to `winningHashHex` (or
+ *     omitted `tips` entirely). Distinct from `'no-majority'` so callers
+ *     can tell "no peer was even willing to vote" apart from "the agreeing
+ *     cohort was entirely Byzantine on the load step". Surfaced by
+ *     `CollabswarmDocument.load()` after exhausting every narrowed peer.
+ *     See PR #284 r6 Copilot review for the DoS rationale: without the
+ *     per-peer retry, a single malicious peer in the agreeing cohort could
+ *     vote for the majority hash and then serve a mismatched full load to
+ *     unilaterally abort the whole load, preventing the loader from
+ *     trying any of the OTHER honest agreeing peers.
  */
 export type LoadQuorumFailedReason =
   | 'insufficient-responses'
   | 'no-majority'
   | 'no-peers-queried'
-  | 'invalid-config';
+  | 'invalid-config'
+  | 'bind-check-failed-all-agreeing-peers';
 
 /**
  * Error thrown by `CollabswarmDocument.load()` when the initial-load quorum
@@ -328,6 +341,15 @@ export class LoadQuorumFailedError extends Error {
   /** Snapshot of (hash hex -> vote count) at the moment of failure, used
    *  for observability. Empty when no peer responded. */
   public readonly agreement: ReadonlyMap<string, number>;
+  /** For `reason === 'bind-check-failed-all-agreeing-peers'`: a map from
+   *  peer-id (as `_peerIdOf` extracts it) to the advertised tipsHash hex
+   *  that peer served on its full-load response (or the sentinel
+   *  `'(missing tips)'` when the responder omitted the `tips` array). Lets
+   *  callers and operators see WHICH peers in the agreeing cohort
+   *  equivocated between the probe round and the load round, and what
+   *  they served instead. Empty for all other reasons. See PR #284 r6
+   *  Copilot review. */
+  public readonly agreeingPeerBindFailures: ReadonlyMap<string, string>;
 
   constructor(opts: {
     documentPath: string;
@@ -341,6 +363,10 @@ export class LoadQuorumFailedError extends Error {
      *  reasons, which compose the detail string from the structured
      *  fields. */
     detail?: string;
+    /** Per-peer bind-failure record. Only meaningful when
+     *  `reason === 'bind-check-failed-all-agreeing-peers'`; ignored
+     *  otherwise. */
+    agreeingPeerBindFailures?: ReadonlyMap<string, string>;
   }) {
     const detail =
       opts.reason === 'no-peers-queried'
@@ -349,7 +375,12 @@ export class LoadQuorumFailedError extends Error {
           ? `only ${opts.respondingCount} of the required ${opts.requiredQ} peers responded`
           : opts.reason === 'invalid-config'
             ? (opts.detail ?? 'invalid load-quorum configuration')
-            : `no tip-set hash reached the required ${opts.requiredQ}-of-${opts.respondingCount} agreement`;
+            : opts.reason === 'bind-check-failed-all-agreeing-peers'
+              ? `quorum agreed on a tip-set hash but every peer in the agreeing cohort ` +
+                `(${opts.agreeingPeerBindFailures?.size ?? 0} peer(s)) served a full-load ` +
+                `response whose tips did not hash to the agreed value (or omitted tips entirely); ` +
+                `treating as coordinated Byzantine equivocation on the load step`
+              : `no tip-set hash reached the required ${opts.requiredQ}-of-${opts.respondingCount} agreement`;
     super(
       `Initial-load quorum failed for "${opts.documentPath}": ${detail}. ` +
         `Configure CollabswarmConfig.loadQuorumK/Q/loadQuorumTimeoutMs, ` +
@@ -361,5 +392,7 @@ export class LoadQuorumFailedError extends Error {
     this.respondingCount = opts.respondingCount;
     this.requiredQ = opts.requiredQ;
     this.agreement = opts.agreement;
+    this.agreeingPeerBindFailures =
+      opts.agreeingPeerBindFailures ?? new Map();
   }
 }

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -31,15 +31,28 @@ import { tipsHashToHex } from './tips-hash';
  *     post-validation; see `tips-hash.ts`).
  *   - `'unknown-doc'` -- the peer explicitly disclaimed the document
  *     (received the 1-byte UNKNOWN_DOC sentinel from the wire). Counted
- *     toward an "unknown-doc" tally exactly like a tip-hash vote: when a
- *     Q-of-K majority of probed peers all disclaim the document, the
- *     orchestrator returns `{ newDoc: true }` so `load()` can let a fresh
- *     `open()` create the document on top of the existing swarm rather
- *     than failing with `LoadQuorumFailedError`. Worst-case Byzantine
- *     exposure is identical to the tip-hash case: Q lying peers can
- *     force a wrong outcome, but a single lying peer cannot. See
- *     `Collabswarm.tipAdvertiseHandler` for the wire sentinel and
- *     PR #284 r16 Copilot review for the rationale.
+ *     toward an "unknown-doc" tally that the orchestrator uses to
+ *     surface `{ newDoc: true }` when the responding cohort genuinely
+ *     does not hold the document -- so a fresh `open()` can create the
+ *     document on top of the existing swarm rather than failing with
+ *     `LoadQuorumFailedError`.
+ *
+ *     PRECEDENCE: tip-hash votes take priority over disclaim votes. The
+ *     probe samples from `getConnections()`, which is the WHOLE libp2p
+ *     mesh -- NOT only peers that hold this specific document. Unrelated
+ *     peers in the mesh that have not opened this path legitimately
+ *     return `'unknown-doc'`; if they were allowed to outvote a peer
+ *     that genuinely holds the document, the loader would silently fork
+ *     an existing doc into a new local copy. So when ANY peer returns a
+ *     real tip-hash, the `'unknown-doc'` bucket is EXCLUDED from the
+ *     agreement vote; the new-doc path is only taken when ZERO peers
+ *     reported a real tip-hash. See `Collabswarm.tipAdvertiseHandler`
+ *     for the wire sentinel and PR #284 r16 / r19 Copilot review for
+ *     the precedence rationale.
+ *
+ *     Worst-case Byzantine exposure for new-doc is identical to the
+ *     tip-hash case: Q lying peers can force a wrong outcome, but a
+ *     single lying peer cannot.
  *   - `null` -- the peer did not return a usable hash. This covers BOTH
  *     timeouts AND non-disclaim declines (unauthorized, wrong document
  *     id, deserialization failure, etc.). Non-responding peers are NOT
@@ -170,12 +183,49 @@ export function decideLoadQuorum(
     };
   }
 
-  // Find the largest bucket. Ties are broken arbitrarily by Map iteration
-  // order (insertion order); ties never affect ok/!ok because both buckets
-  // would have the same size and we only accept if size >= q.
+  // Tip-hash votes take PRIORITY over `'unknown-doc'` votes when
+  // selecting the winning bucket. The probe is racing every peer
+  // returned by `getConnections()` -- which is the WHOLE libp2p mesh,
+  // not only peers that have specifically opened this document. So an
+  // honest peer that legitimately holds a document and votes its
+  // `tipsHash` can be outvoted by unrelated peers in the same mesh
+  // that simply have not registered the document path (each of which
+  // legitimately returns the `'unknown-doc'` sentinel). Without this
+  // precedence rule, two such uninvolved peers could outvote the one
+  // peer that actually has the document and force the loader into the
+  // new-doc-creation path -- forking the document silently. See
+  // PR #284 r19 Copilot review.
+  //
+  // Precedence rule: if ANY peer returned a real tip-hash, the
+  // `'unknown-doc'` bucket is excluded from the agreement vote. The
+  // tip-hash buckets then decide quorum among themselves (Q-of-respondingCount
+  // for the winning hash). The new-doc path is only ever taken when
+  // ZERO peers reported a real tip-hash AND the `'unknown-doc'` bucket
+  // meets Q -- i.e. the entire responding cohort genuinely disclaims
+  // the document.
+  //
+  // `respondingCount` is intentionally NOT decremented when we exclude
+  // the `'unknown-doc'` bucket: it still represents the cohort that
+  // responded at all (used for the structured failure reason
+  // 'insufficient-responses' versus 'no-majority'). The
+  // `unknownDocBucketSize` count is still surfaced in the `agreement`
+  // snapshot for operator visibility.
+  const hasTipHashVote = [...agreement.keys()].some(
+    (k) => k !== UNKNOWN_DOC_TALLY_KEY,
+  );
+  const eligibleBuckets = hasTipHashVote
+    ? [...agreement.entries()].filter(
+        ([key]) => key !== UNKNOWN_DOC_TALLY_KEY,
+      )
+    : [...agreement.entries()];
+
+  // Find the largest bucket among ELIGIBLE buckets. Ties are broken
+  // arbitrarily by Map iteration order (insertion order); ties never
+  // affect ok/!ok because both buckets would have the same size and we
+  // only accept if size >= q.
   let bestKey: string | null = null;
   let bestPeers: string[] = [];
-  for (const [key, peers] of agreement.entries()) {
+  for (const [key, peers] of eligibleBuckets) {
     if (peers.length > bestPeers.length) {
       bestKey = key;
       bestPeers = peers;

--- a/packages/collabswarm/src/load-quorum.ts
+++ b/packages/collabswarm/src/load-quorum.ts
@@ -251,6 +251,18 @@ export function constantTimeHexEquals(a: string, b: string): boolean {
  * upper bound and the number of currently-known peers. Pulled out so the
  * loader and the quorum decision can share a single source of truth and so
  * the clamp is unit-testable.
+ *
+ * Defensive against non-finite or fractional inputs as a second line of
+ * defence behind {@link validateLoadQuorumConfig} (which runs at
+ * `Collabswarm.initialize()` time). A misconfigured `loadQuorumK: 1.5`
+ * that bypassed startup validation would otherwise produce
+ * `peers.slice(0, 1.5)` — slicing only one peer and silently degrading
+ * the gate to a single-peer probe even though the `k === 1 && !allowSinglePeer`
+ * guard would not fire (`1.5 !== 1`). `NaN`/`Infinity` similarly would
+ * produce `Math.min(NaN, 3) === NaN` and a `peers.slice(0, NaN) === []`
+ * silent skip. Floor + finiteness guards collapse both classes to 0,
+ * which the orchestrator surfaces as `LoadQuorumFailedError(invalid-config)`.
+ * See PR #284 r9 Copilot review.
  */
 export function effectiveK(
   configuredK: number,
@@ -259,21 +271,98 @@ export function effectiveK(
   // K should be at least 1 (otherwise no probes happen) and at most the
   // number of peers we actually know about (otherwise we'd query the same
   // peer twice or fewer-than-K real peers).
+  if (!Number.isFinite(configuredK)) return 0;
   if (configuredK <= 0) return 0;
   if (knownPeersCount <= 0) return 0;
-  return Math.min(configuredK, knownPeersCount);
+  // Floor so a fractional configuredK (which `validateLoadQuorumConfig`
+  // rejects at startup) cannot escape as a non-integer slice index.
+  return Math.floor(Math.min(configuredK, knownPeersCount));
 }
 
 /**
  * Compute the effective `Q` (quorum threshold) given a configured value and
  * the effective K. Clamped to `[1, K]` so a misconfigured `Q > K` cannot
  * make quorum unreachable, and `Q <= 0` does not silently bypass the gate.
+ *
+ * Defensive against non-finite inputs as a second line of defence behind
+ * {@link validateLoadQuorumConfig}. Without the `Number.isFinite` guard,
+ * `effectiveQ(NaN, 3)` returned `NaN` (all comparisons against `NaN` are
+ * false), and `decideLoadQuorum` then evaluated `bestPeers.length < NaN`
+ * as false — so the gate passed with a single responding peer. We
+ * collapse NaN/Infinity to {@link defaultQuorumQ}(k) here as a fallback
+ * that mirrors the orchestrator's `?? defaultQuorumQ(k)` default. See
+ * PR #284 r9 Copilot review.
  */
 export function effectiveQ(configuredQ: number, k: number): number {
   if (k <= 0) return 0;
+  if (!Number.isFinite(configuredQ)) return defaultQuorumQ(k);
   if (configuredQ < 1) return 1;
   if (configuredQ > k) return k;
-  return configuredQ;
+  // Floor for the same reason as `effectiveK`: a fractional Q would
+  // otherwise produce a non-integer threshold that compares strangely
+  // against integer vote counts.
+  return Math.floor(configuredQ);
+}
+
+/**
+ * Validate the load-quorum tuning knobs from {@link CollabswarmConfig}.
+ *
+ * Runs at {@link Collabswarm.initialize} time so a misconfigured value is
+ * surfaced loudly at startup rather than silently degrading every
+ * subsequent `load()` call. Required behavior under PR #284 r9 Copilot
+ * review (issues #2/#3): `loadQuorumK: 1.5` previously slipped through
+ * `Math.min(configuredK, peersLen)` to produce `peers.slice(0, 1.5)`
+ * which probes only 1 peer (silent single-peer load); `loadQuorumQ: NaN`
+ * propagated through `effectiveQ` to make `bestPeers.length < NaN`
+ * evaluate as false (silent single-peer quorum pass). Both classes of
+ * misconfig are now rejected here with a clear operator-visible error.
+ *
+ * Both knobs MUST be finite positive integers (Number.isInteger(x) && x >= 1).
+ * Rejects:
+ *   - NaN / Infinity / -Infinity
+ *   - non-integers (e.g. 1.5, 2.7)
+ *   - zero and negative values (0, -1)
+ * Accepts:
+ *   - `undefined` (operator did not override; the orchestrator's defaults apply)
+ *   - any positive integer (1, 2, 3, ...)
+ *
+ * Throws {@link LoadQuorumFailedError} with `reason: 'invalid-config'` so
+ * the existing `instanceof`-based error handling in `CollabswarmDocument.load()`
+ * continues to work and operators see a structured failure with the
+ * offending value.
+ *
+ * @param config The {@link CollabswarmConfig} (or its load-quorum subset)
+ *   to validate. Pass-through fields (`enabled`, `timeoutMs`,
+ *   `allowSinglePeer`) are intentionally NOT validated here; only K and Q
+ *   are the load-bearing trust knobs.
+ */
+export function validateLoadQuorumConfig(config: {
+  loadQuorumK?: number;
+  loadQuorumQ?: number;
+}): void {
+  const checkPositiveInt = (name: string, value: number | undefined): void => {
+    if (value === undefined) return;
+    if (
+      typeof value !== 'number' ||
+      !Number.isInteger(value) ||
+      value < 1
+    ) {
+      throw new LoadQuorumFailedError({
+        // No document path is available at initialize() time; use a
+        // placeholder so the error message remains informative. Callers
+        // typically catch this at `initialize()` and surface it to the
+        // operator without needing the path.
+        documentPath: '<config>',
+        reason: 'invalid-config',
+        respondingCount: 0,
+        requiredQ: 0,
+        agreement: new Map(),
+        detail: `${name} must be a positive integer; got ${JSON.stringify(value)}`,
+      });
+    }
+  };
+  checkPositiveInt('loadQuorumK', config.loadQuorumK);
+  checkPositiveInt('loadQuorumQ', config.loadQuorumQ);
 }
 
 /**

--- a/packages/collabswarm/src/merkle-cross-links.test.ts
+++ b/packages/collabswarm/src/merkle-cross-links.test.ts
@@ -1053,4 +1053,206 @@ describe('computeServedFrontier (PR #284 r7 served-payload frontier derivation)'
     const loaderFrontier = [...loaderHashes].filter((h) => !loaderRefs.has(h));
     expect(servedFrontier.sort()).toEqual(loaderFrontier.sort());
   });
+
+  /**
+   * Tests added for the PR #284 r8 multi-head responder fix.
+   *
+   * These tests document the exact bug Copilot flagged: an honest peer
+   * with multiple concurrent heads in `_currentFrontier()` cannot serve
+   * all of them in a single load response (the wire shape carries one
+   * tree rooted at `_lastSyncMessage.changeId`). Advertising
+   * `tipsHash(_currentFrontier())` therefore disagrees with the served
+   * payload's structural frontier and the loader's bind check rejects
+   * an honest peer.
+   *
+   * The fix advertises the served frontier
+   * (`computeServedFrontier(_lastSyncMessage.changes, _latestSnapshot)`)
+   * instead. These tests verify the structural property holds across the
+   * multi-head scenario.
+   */
+  describe('multi-head responder served-vs-current frontier divergence (PR #284 r8)', () => {
+    test('responder with concurrent heads {H1, H2, H3} serves a tree rooted at H1 only: served frontier is {H1}, NOT {H1, H2, H3}', () => {
+      // Scenario from the Copilot review:
+      //   - Peer A made one local change H1 (so `_lastSyncMessage.changeId = H1`).
+      //   - Peer A then received H2 and H3 via GossipSub from concurrent
+      //     writers. Both are in `_hashes` but neither is a child of any
+      //     node in `_lastSyncMessage.changes` (H2 and H3 do not appear
+      //     in H1's children map).
+      //   - `_currentFrontier()` = {H1, H2, H3} (all three are unreferenced).
+      //   - But the load response only ships H1's tree (the responder
+      //     has not yet made a new local change that would cross-link
+      //     H2/H3 into the served tree).
+      //
+      // The served payload's structural frontier is {H1}, which is
+      // exactly what the loader's `computeServedFrontier` derives. The
+      // fix in `_servedFrontier()` advertises tipsHash({H1}) instead of
+      // tipsHash({H1, H2, H3}), so the probe and the load round agree.
+      const servedTree: CRDTChangeNode<unknown> = {
+        kind: docKind,
+        // H1 is a leaf in A's served subtree -- no children, no
+        // cross-links to H2/H3 yet.
+      };
+      const servedFrontier = computeServedFrontier('H1', servedTree, undefined);
+      expect(servedFrontier.sort()).toEqual(['H1']);
+
+      // Sanity: the FULL local DAG frontier as `_currentFrontier()`
+      // would have computed it is {H1, H2, H3}. The two frontiers
+      // differ, which is the entire point of the bug.
+      const localFrontier = ['H1', 'H2', 'H3'].sort();
+      expect(servedFrontier.sort()).not.toEqual(localFrontier);
+    });
+
+    test('honest multi-head responder: loader post-sync `_currentFrontier()` equals the served frontier (NOT the responder local frontier)', () => {
+      // After the loader applies the served payload, its
+      // `_currentFrontier()` will be {H1} (the only head in the
+      // received tree). Two honest peers in the same logical state
+      // would each advertise tipsHash({H1}); the quorum agrees on
+      // {H1}; the structural bind check on the loader hashes the
+      // received payload to {H1}; they match. Quorum succeeds for an
+      // honest responder.
+      const servedTree: CRDTChangeNode<unknown> = { kind: docKind };
+
+      // Simulate two honest peers (P1 and P2) both at the same logical
+      // state -- each with `_lastSyncMessage.changeId = H1` and
+      // `_lastSyncMessage.changes = servedTree`. P1 has remote heads
+      // {H2}, P2 has remote heads {H3}; both un-cross-linked.
+      const p1Served = computeServedFrontier('H1', servedTree, undefined);
+      const p2Served = computeServedFrontier('H1', servedTree, undefined);
+      expect(p1Served.sort()).toEqual(p2Served.sort());
+
+      // The loader (starting from empty) applying P1's load response
+      // ends up with `_currentFrontier() = {H1}`. Same hash as
+      // p1Served, so the bind check accepts.
+      const loaderHashes = new Set<string>();
+      const loaderRefs = new Set<string>();
+      function applyWalk(
+        id: string | undefined,
+        node: CRDTChangeNode<unknown>,
+      ) {
+        if (id) loaderHashes.add(id);
+        if (node.children === undefined) return;
+        if (node.children === false) return;
+        for (const [childId, childNode] of Object.entries(node.children)) {
+          loaderHashes.add(childId);
+          loaderRefs.add(childId);
+          applyWalk(childId, childNode);
+        }
+      }
+      applyWalk('H1', servedTree);
+      const loaderFrontier = [...loaderHashes]
+        .filter((h) => !loaderRefs.has(h))
+        .sort();
+      expect(loaderFrontier).toEqual(p1Served.sort());
+    });
+
+    test('multi-head responder with cross-linked remote head: served frontier includes both heads only when actually present in the served tree', () => {
+      // Variant: the responder DID make a second local change that
+      // cross-linked one remote head (H2) but not the other (H3). The
+      // served tree now contains H1 -> H2 as cross-link, but H3 is
+      // still un-cross-linked. The served frontier is {H1} (with H2
+      // referenced as a deferred-leaf child), NOT {H1, H3}.
+      //
+      // This is consistent: the responder will reconcile H3 via
+      // post-load GossipSub sync (cross-linking on the next local
+      // change), not via the initial-load quorum protocol.
+      const servedTree: CRDTChangeNode<unknown> = {
+        kind: docKind,
+        children: {
+          H2: { kind: docKind }, // deferred leaf -- cross-linked but no inline body
+        },
+      };
+      const servedFrontier = computeServedFrontier('H1', servedTree, undefined);
+      // H1 is the head; H2 is referenced (a child of H1 in the served
+      // tree); H3 is not part of the served payload at all.
+      expect(servedFrontier.sort()).toEqual(['H1']);
+    });
+
+    test('Byzantine responder still caught: claims served frontier {H1} but actually serves a tree where H1 references unknown ancestors', () => {
+      // The structural derivation is independent of whatever the
+      // responder claims in `message.tips`. If the responder's
+      // `_servedFrontier()` honest implementation would yield {H1} but
+      // a tampered serializer ships a tree with H1 -> X -> Y (referencing
+      // ancestors the responder never advertised), the structural
+      // frontier remains {H1} (the only unreferenced node) -- the
+      // ancestors X, Y are referenced by H1's children map and drop
+      // out of the frontier. The bind check still passes against the
+      // honest hash, BUT the served payload now includes data the
+      // responder didn't authorize. That class of equivocation
+      // (extra-data smuggling under a matching frontier hash) is out
+      // of scope for `computeServedFrontier` -- it is detected by the
+      // outer signature check + the loader's defense-in-depth
+      // `message.tips` consistency check, both of which compare the
+      // *served frontier* (not the responder's local frontier).
+      //
+      // This test simply confirms the served frontier of an
+      // ancestor-bearing tree is still {H1}: the structural
+      // derivation does not get fooled by "extra" nodes the responder
+      // shipped that aren't heads.
+      const servedTree: CRDTChangeNode<unknown> = {
+        kind: docKind,
+        children: {
+          X: {
+            kind: docKind,
+            children: {
+              Y: { kind: docKind },
+            },
+          },
+        },
+      };
+      const servedFrontier = computeServedFrontier('H1', servedTree, undefined);
+      expect(servedFrontier.sort()).toEqual(['H1']);
+    });
+
+    test('Byzantine responder lies in advertise vs serves: hash of FULL frontier {H1,H2,H3} but ships only H1 => structural derivation exposes the lie', () => {
+      // A peer that lies about which heads they have -- i.e. computes
+      // its advertise hash over the OLD (buggy) `_currentFrontier()`
+      // semantics on {H1, H2, H3} -- but actually only serves H1's
+      // tree, would lose against the loader's structural derivation.
+      // Two honest peers running the FIX (advertise=served) would
+      // both produce tipsHash({H1}); the liar's hash is
+      // tipsHash({H1,H2,H3}). The liar's hash doesn't even win the
+      // quorum (the honest peers disagree with the liar), but if it
+      // somehow did, the loader's structural derivation would still
+      // hash to {H1} and reject the bind.
+      //
+      // Verifies the structural derivation behaves identically
+      // regardless of what the responder *claims* about their heads.
+      const servedTree: CRDTChangeNode<unknown> = { kind: docKind };
+      const structurallyDerived = computeServedFrontier(
+        'H1',
+        servedTree,
+        undefined,
+      );
+      expect(structurallyDerived.sort()).toEqual(['H1']);
+      // The liar's claim is {H1, H2, H3} -- different from the
+      // structural truth. The loader's defense-in-depth check (compare
+      // `message.tips` to structurally-derived frontier) catches this.
+      expect(structurallyDerived.sort()).not.toEqual(
+        ['H1', 'H2', 'H3'].sort(),
+      );
+    });
+
+    test('multi-head responder with snapshot: served frontier is `_servedFrontier()` inputs (snapshot boundary + served tree)', () => {
+      // When the load response also carries `_latestSnapshot`, the
+      // served frontier is computed over BOTH the snapshot boundary
+      // CID and the served tree. If the served tree references the
+      // boundary (the common case post-snapshot), the boundary drops
+      // out and the head of the post-snapshot chain remains. This is
+      // identical to the single-head case -- the multi-head bug is
+      // about heads NOT in the served tree, not about snapshot
+      // semantics. Sanity that the helper handles the mixed input.
+      const servedTree: CRDTChangeNode<unknown> = {
+        kind: docKind,
+        children: {
+          SNAP_BOUNDARY: { kind: docKind },
+        },
+      };
+      const servedFrontier = computeServedFrontier(
+        'POST_SNAPSHOT_HEAD',
+        servedTree,
+        'SNAP_BOUNDARY',
+      );
+      expect(servedFrontier.sort()).toEqual(['POST_SNAPSHOT_HEAD']);
+    });
+  });
 });

--- a/packages/collabswarm/src/merkle-cross-links.test.ts
+++ b/packages/collabswarm/src/merkle-cross-links.test.ts
@@ -7,6 +7,7 @@ import {
   mergeRemoteSyncTree,
   selectCrossLinks,
   trackTipInList,
+  treeContainsCid,
 } from './merkle-cross-links';
 import {
   CRDTChangeNode,
@@ -1254,5 +1255,337 @@ describe('computeServedFrontier (PR #284 r7 served-payload frontier derivation)'
       );
       expect(servedFrontier.sort()).toEqual(['POST_SNAPSHOT_HEAD']);
     });
+  });
+});
+
+/**
+ * Tests for `treeContainsCid`, the subsumption-check helper used by
+ * `CollabswarmDocument._refreshLastSyncMessageFromSync` to decide
+ * whether an incoming remote sync tree subsumes the locally-cached
+ * `_lastSyncMessage`. The cached message is replaced only when the
+ * incoming tree contains the prior root's CID -- so the served-frontier
+ * coverage can only grow, never shrink.
+ *
+ * Closes the relay-peer empty-served-frontier bug (#284 r14): a peer
+ * that joined via `load()` and never made a local change previously
+ * left `_lastSyncMessage` undefined, advertised `tipsHash([])`, and
+ * served an empty load. Two such relay peers would agree on the empty
+ * hash, satisfy quorum, and let an honest newcomer accept an empty
+ * document while the mesh had data.
+ */
+describe('treeContainsCid (PR #284 r14 _lastSyncMessage subsumption check)', () => {
+  const docKind: CRDTChangeNodeKind = crdtDocumentChangeNode;
+
+  test('returns false when target is undefined / empty', () => {
+    // Defensive: callers pass `_lastSyncMessage?.changeId`, which may be
+    // undefined or empty for a brand-new peer. Treat as "not contained"
+    // so the caller's no-prior-root branch handles the case.
+    const tree: CRDTChangeNode<unknown> = { kind: docKind };
+    expect(treeContainsCid('HEAD', tree, undefined)).toBe(false);
+    expect(treeContainsCid('HEAD', tree, '')).toBe(false);
+  });
+
+  test('returns false when tree is undefined', () => {
+    expect(treeContainsCid(undefined, undefined, 'TARGET')).toBe(false);
+  });
+
+  test('returns true when target equals the root CID', () => {
+    const tree: CRDTChangeNode<unknown> = { kind: docKind };
+    expect(treeContainsCid('HEAD', tree, 'HEAD')).toBe(true);
+  });
+
+  test('returns true when target is a direct child', () => {
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: { CHILD: { kind: docKind } },
+    };
+    expect(treeContainsCid('HEAD', tree, 'CHILD')).toBe(true);
+  });
+
+  test('returns true when target is a deep descendant', () => {
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: {
+        P1: {
+          kind: docKind,
+          children: {
+            P2: {
+              kind: docKind,
+              children: { P3: { kind: docKind } },
+            },
+          },
+        },
+      },
+    };
+    expect(treeContainsCid('HEAD', tree, 'P3')).toBe(true);
+  });
+
+  test('returns false when target is independent of the tree', () => {
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: { P1: { kind: docKind } },
+    };
+    expect(treeContainsCid('HEAD', tree, 'CONCURRENT_HEAD')).toBe(false);
+  });
+
+  test('returns true for cross-linked deferred-leaf children', () => {
+    // Cross-link entries appear as deferred leaves (no `change` payload,
+    // no `children`); the CID still counts as present in the tree.
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: {
+        PRIMARY_PARENT: {
+          kind: docKind,
+          children: { GRANDPARENT: { kind: docKind } },
+        },
+        CROSS_LINK_TIP: { kind: docKind }, // deferred leaf
+      },
+    };
+    expect(treeContainsCid('HEAD', tree, 'CROSS_LINK_TIP')).toBe(true);
+    expect(treeContainsCid('HEAD', tree, 'GRANDPARENT')).toBe(true);
+  });
+
+  test('stops at a deferred children sentinel (conservative)', () => {
+    // A `children === false` sentinel marks an IPLD-deferred subtree we
+    // cannot enumerate. The helper is conservative: targets only
+    // reachable via the deferred subtree are reported as "not contained"
+    // (the caller falls back to the concurrent-roots branch, which
+    // never shrinks served-frontier coverage).
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: false as false,
+    };
+    expect(treeContainsCid('HEAD', tree, 'BURIED_CID')).toBe(false);
+    // Root is still found when targeted directly.
+    expect(treeContainsCid('HEAD', tree, 'HEAD')).toBe(true);
+  });
+
+  test('cycle defense: visited-set prevents infinite recursion', () => {
+    // Same defensive guard as the other walkers in this module.
+    const a: CRDTChangeNode<unknown> = { kind: docKind, children: {} };
+    const b: CRDTChangeNode<unknown> = { kind: docKind, children: { A: a } };
+    a.children = { B: b };
+    // Walk terminates and reports descendants correctly.
+    expect(treeContainsCid('A', a, 'B')).toBe(true);
+    expect(treeContainsCid('A', a, 'A')).toBe(true);
+    expect(treeContainsCid('A', a, 'UNKNOWN')).toBe(false);
+  });
+});
+
+/**
+ * Structural regression tests for the relay-peer empty-served-frontier
+ * bug (PR #284 r14 Copilot review). These tests don't instantiate
+ * `CollabswarmDocument` (the load-quorum test infra has the same ESM
+ * libp2p limitation flagged in `load-quorum-orchestrator.test.ts`);
+ * instead they verify the structural property the fix establishes:
+ * after a peer applies a remote sync tree and refreshes its
+ * `_lastSyncMessage` from it, `computeServedFrontier` over the refreshed
+ * cache yields the SAME frontier the loader would derive from the
+ * served payload -- never the empty set.
+ *
+ * The fix lives in `_refreshLastSyncMessageFromSync` (called by
+ * `_syncDocumentChanges`): the cache is updated when the incoming tree
+ * subsumes the prior root (or when there is no prior root), so a relay
+ * peer that never makes a local change still has a meaningful served
+ * frontier.
+ */
+describe('relay-peer served-frontier (PR #284 r14: _lastSyncMessage refresh from sync)', () => {
+  const docKind: CRDTChangeNodeKind = crdtDocumentChangeNode;
+
+  /**
+   * Mirror the production-side update policy:
+   *   - no prior root => adopt incoming
+   *   - same root => no-op
+   *   - prior root is in incoming tree => replace with incoming
+   *   - independent roots => keep prior (concurrent-heads tradeoff)
+   *
+   * Returns the resulting (changeId, changes) pair.
+   */
+  function refreshLastSync(
+    priorChangeId: string | undefined,
+    priorChanges: CRDTChangeNode<unknown> | undefined,
+    receivedChangeId: string | undefined,
+    receivedChanges: CRDTChangeNode<unknown>,
+  ): {
+    changeId: string | undefined;
+    changes: CRDTChangeNode<unknown> | undefined;
+  } {
+    if (!receivedChangeId) {
+      return { changeId: priorChangeId, changes: priorChanges };
+    }
+    if (!priorChangeId) {
+      return { changeId: receivedChangeId, changes: receivedChanges };
+    }
+    if (priorChangeId === receivedChangeId) {
+      return { changeId: priorChangeId, changes: priorChanges };
+    }
+    if (treeContainsCid(receivedChangeId, receivedChanges, priorChangeId)) {
+      return { changeId: receivedChangeId, changes: receivedChanges };
+    }
+    return { changeId: priorChangeId, changes: priorChanges };
+  }
+
+  test('relay peer (no prior _lastSyncMessage) advertises a non-empty served frontier after one remote sync', () => {
+    // Reproduce the round-14 bug pre-fix:
+    //   - Peer B has _lastSyncMessage = undefined (relay peer, no local
+    //     changes since open()/load()).
+    //   - B receives a sync tree from A rooted at X with a leaf body.
+    //   - With the fix, B's _lastSyncMessage adopts (X, treeX).
+    //   - B's served frontier = {X}, NOT [].
+    //
+    // Pre-fix: B's _lastSyncMessage stays undefined -> served frontier
+    // is []. If C opens, probes B alone (allowSinglePeer K=1), and B
+    // votes tipsHash([]), C accepts an empty document while the mesh
+    // had X. The fix forces B to advertise tipsHash({X}) and ship X's
+    // tree on the load.
+    const incoming: CRDTChangeNode<unknown> = { kind: docKind };
+    const after = refreshLastSync(undefined, undefined, 'X', incoming);
+    expect(after.changeId).toBe('X');
+    expect(after.changes).toBe(incoming);
+
+    const servedFrontier = computeServedFrontier(
+      after.changeId,
+      after.changes,
+      undefined,
+    );
+    expect(servedFrontier).toEqual(['X']);
+    // Counter-check: the pre-fix served frontier would have been [].
+    expect(servedFrontier).not.toEqual([]);
+  });
+
+  test('two relay peers that loaded the same state advertise byte-identical served frontiers (post-fix quorum bootstrap)', () => {
+    // Two peers B and C both `load()`-ed from A. With the fix, both
+    // have _lastSyncMessage = (X, treeX). Their served frontiers and
+    // hashes match, so a newcomer D probing {B, C} sees them agree on
+    // tipsHash({X}). Crucially: they no longer falsely agree on the
+    // EMPTY hash; they agree on the CORRECT non-empty hash.
+    const treeX: CRDTChangeNode<unknown> = { kind: docKind };
+    const bAfter = refreshLastSync(undefined, undefined, 'X', treeX);
+    const cAfter = refreshLastSync(undefined, undefined, 'X', treeX);
+    const bFrontier = computeServedFrontier(
+      bAfter.changeId,
+      bAfter.changes,
+      undefined,
+    );
+    const cFrontier = computeServedFrontier(
+      cAfter.changeId,
+      cAfter.changes,
+      undefined,
+    );
+    expect(bFrontier).toEqual(cFrontier);
+    expect(bFrontier).toEqual(['X']);
+  });
+
+  test('relay peer applies a follow-up gossipsub change Y (child of X): served frontier advances to {Y}', () => {
+    // Continuation of the relay-peer scenario:
+    //   - B already has _lastSyncMessage = (X, treeX) from a prior load.
+    //   - B receives a GossipSub message from A: Y is a new change with
+    //     primary parent X (treeY embeds X as a child).
+    //   - The incoming tree subsumes B's prior root (X appears as a
+    //     child of Y in treeY), so B's _lastSyncMessage advances to
+    //     (Y, treeY). Served frontier = {Y}.
+    const treeX: CRDTChangeNode<unknown> = { kind: docKind };
+    const treeY: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: { X: treeX },
+    };
+    const after = refreshLastSync('X', treeX, 'Y', treeY);
+    expect(after.changeId).toBe('Y');
+    expect(after.changes).toBe(treeY);
+    const frontier = computeServedFrontier(
+      after.changeId,
+      after.changes,
+      undefined,
+    );
+    expect(frontier.sort()).toEqual(['Y']);
+  });
+
+  test('concurrent independent roots: prior _lastSyncMessage is preserved (served-frontier coverage cannot shrink)', () => {
+    // The conservative branch: if the incoming root is INDEPENDENT of
+    // the prior cached root (neither subsumes the other), the cache is
+    // left alone. The next local `_makeChange()` will cross-link both
+    // heads via `_recentTips`; we do not need to widen the served
+    // frontier on the sync path to recover correctness.
+    //
+    // Critically: this branch does NOT shrink served-frontier coverage.
+    // The served frontier remains {priorHead} -- the loader would still
+    // be able to fully load the prior state from this responder.
+    const priorTree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: { PRIOR_PARENT: { kind: docKind } },
+    };
+    const incomingIndependent: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: { INDEPENDENT_PARENT: { kind: docKind } },
+    };
+    const after = refreshLastSync(
+      'PRIOR_HEAD',
+      priorTree,
+      'INDEPENDENT_HEAD',
+      incomingIndependent,
+    );
+    // Prior cache survives.
+    expect(after.changeId).toBe('PRIOR_HEAD');
+    expect(after.changes).toBe(priorTree);
+    const frontier = computeServedFrontier(
+      after.changeId,
+      after.changes,
+      undefined,
+    );
+    expect(frontier.sort()).toEqual(['PRIOR_HEAD']);
+  });
+
+  test('same root re-sent: no-op (idempotency)', () => {
+    const tree: CRDTChangeNode<unknown> = { kind: docKind };
+    const after = refreshLastSync('X', tree, 'X', tree);
+    expect(after.changeId).toBe('X');
+    expect(after.changes).toBe(tree);
+  });
+
+  test('empty sync (no changeId): cache untouched', () => {
+    // Defensive: an incoming sync with no root CID cannot meaningfully
+    // refresh the served frontier; the refresh helper short-circuits
+    // and leaves the cache untouched.
+    const priorTree: CRDTChangeNode<unknown> = { kind: docKind };
+    const emptyIncoming: CRDTChangeNode<unknown> = { kind: docKind };
+    const after = refreshLastSync('X', priorTree, undefined, emptyIncoming);
+    expect(after.changeId).toBe('X');
+    expect(after.changes).toBe(priorTree);
+  });
+
+  test('post-load loader derives the same frontier the refreshed cache advertises (binding symmetry)', () => {
+    // End-to-end structural property the fix establishes:
+    //   1. Relay peer B receives a sync tree (X, treeX). Refresh updates
+    //      _lastSyncMessage so the served frontier is {X}.
+    //   2. C opens, runs `tipAdvertiseV1` against B, gets tipsHash({X}).
+    //   3. C runs `documentLoadV3` against B. B ships (X, treeX) as the
+    //      load response.
+    //   4. C derives `computeServedFrontier(X, treeX)` over the
+    //      received payload, hashes it, compares to the agreed
+    //      tipsHash({X}). The two MATCH because both come from the
+    //      same payload structure.
+    //
+    // Without the fix, step 1 leaves _lastSyncMessage undefined, B
+    // advertises tipsHash([]), and step 3 ships an empty load. C
+    // accepts an empty document while the mesh had X (the bug).
+    const treeX: CRDTChangeNode<unknown> = { kind: docKind };
+    const refreshed = refreshLastSync(undefined, undefined, 'X', treeX);
+
+    // Step 2 + 4: responder advertised frontier == loader-derived
+    // frontier over the served payload.
+    const responderAdvertised = computeServedFrontier(
+      refreshed.changeId,
+      refreshed.changes,
+      undefined,
+    );
+    const loaderDerivedFromPayload = computeServedFrontier(
+      'X',
+      treeX,
+      undefined,
+    );
+    expect(responderAdvertised.sort()).toEqual(
+      loaderDerivedFromPayload.sort(),
+    );
+    expect(responderAdvertised).toEqual(['X']);
   });
 });

--- a/packages/collabswarm/src/merkle-cross-links.test.ts
+++ b/packages/collabswarm/src/merkle-cross-links.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from '@jest/globals';
 import {
   collectReferencedAncestors,
+  computeServedFrontier,
   MAX_CROSS_LINKS,
   MAX_RECENT_TIPS,
   mergeRemoteSyncTree,
@@ -801,5 +802,255 @@ describe('collectReferencedAncestors (frontier helper for initial-load quorum)',
     // entries vs 3 entries), so any tipsHash derived from it would have
     // diverged -- the bug round 3 of the review caught.
     expect(peerAHashes.size).not.toBe(peerBHashes.size);
+  });
+});
+
+/**
+ * Tests for `computeServedFrontier`, the structural-binding helper that
+ * derives a load-response's frontier from the actual served payload
+ * rather than the responder's `tips` attestation. Closes the gap caught
+ * by PR #284 r7 Copilot review: previously the quorum frontier binding
+ * hashed the responder-supplied `tips` array and compared to the
+ * agreed `winningHashHex`, which let a Byzantine peer vote hash X and
+ * then serve a divergent payload while keeping `tips` set to X's CIDs.
+ * The new binding derives the served frontier structurally from
+ * `message.changeId` + `message.changes` (+ optional snapshot
+ * boundary), so the responder cannot lie about what they served.
+ */
+describe('computeServedFrontier (PR #284 r7 served-payload frontier derivation)', () => {
+  const docKind: CRDTChangeNodeKind = crdtDocumentChangeNode;
+
+  test('empty payload (no changes, no snapshot) => empty frontier', () => {
+    // A responder that has no state at all serves nothing. Their
+    // "frontier" is the canonical empty set, which the quorum loader
+    // compares to `tipsHash([])`. Honest brand-new responders bootstrap
+    // cleanly under this case.
+    expect(computeServedFrontier(undefined, undefined, undefined)).toEqual([]);
+    expect(computeServedFrontier(undefined, undefined, '')).toEqual([]);
+  });
+
+  test('snapshot-only payload (no changes) => boundary CID is the sole frontier', () => {
+    // Pure-snapshot load (responder has nothing post-snapshot). The
+    // boundary CID is the only head.
+    const frontier = computeServedFrontier(undefined, undefined, 'SNAP_BOUNDARY');
+    expect(frontier).toEqual(['SNAP_BOUNDARY']);
+  });
+
+  test('single-head linear chain: only the root CID is in the frontier', () => {
+    // Typical case: responder has a linear change history. The served
+    // tree is rooted at HEAD with primary-parent chain HEAD->P1->P2.
+    // The frontier of this payload is {HEAD} -- P1 and P2 are
+    // referenced ancestors.
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: {
+        P1: {
+          kind: docKind,
+          children: {
+            P2: { kind: docKind },
+          },
+        },
+      },
+    };
+    const frontier = computeServedFrontier('HEAD', tree, undefined);
+    expect(frontier.sort()).toEqual(['HEAD']);
+  });
+
+  test('snapshot + post-snapshot chain that references the boundary: boundary drops out, only post-snapshot head remains', () => {
+    // Responder has a snapshot at SNAP_BOUNDARY plus one post-snapshot
+    // change H1 that points back to it. After applying both:
+    //   - SNAP_BOUNDARY is a node in _hashes (snapshot boundary sentinel)
+    //   - SNAP_BOUNDARY is also referenced by H1 as a parent
+    //   - SNAP_BOUNDARY therefore drops out of the frontier
+    //   - H1 is the sole head
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: {
+        SNAP_BOUNDARY: { kind: docKind },
+      },
+    };
+    const frontier = computeServedFrontier('H1', tree, 'SNAP_BOUNDARY');
+    expect(frontier.sort()).toEqual(['H1']);
+  });
+
+  test('snapshot + disjoint post-snapshot change (does NOT reference boundary): two heads', () => {
+    // Edge case: post-snapshot change tree exists but does NOT
+    // reference the snapshot boundary in its children. Both the
+    // snapshot boundary AND the post-snapshot head are tips.
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      // No children -- this is a leaf node in the change tree.
+    };
+    const frontier = computeServedFrontier('H1', tree, 'SNAP_BOUNDARY');
+    expect(frontier.sort()).toEqual(['H1', 'SNAP_BOUNDARY']);
+  });
+
+  test('cross-links: deferred children are referenced AND added to cids; not in frontier', () => {
+    // Cross-link entries in the served tree are deferred leaves -- they
+    // appear as a key in a parent's `children` map (so they are
+    // referenced) and the child node has no `change` payload. They
+    // should be treated as referenced ancestors, not as heads.
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: {
+        PRIMARY_PARENT: {
+          kind: docKind,
+        },
+        CROSS_LINK_TIP: {
+          // Deferred leaf -- no change payload, no children.
+          kind: docKind,
+        },
+      },
+    };
+    const frontier = computeServedFrontier('HEAD', tree, undefined);
+    // HEAD is the only head -- PRIMARY_PARENT and CROSS_LINK_TIP are
+    // both referenced as children.
+    expect(frontier.sort()).toEqual(['HEAD']);
+  });
+
+  test('forged tips attack: responder ships changes for state Y but claims state X tips', () => {
+    // This is the attack the structural-binding closes. Imagine the
+    // quorum agreed on `winningHashHex = tipsHash([X_HEAD])`. A
+    // Byzantine responder votes hash X (truthfully in the probe
+    // round), then on the load serves changes rooted at a completely
+    // different head Y_HEAD. The responder also fakes `message.tips =
+    // [X_HEAD]` -- but the served payload doesn't contain X_HEAD
+    // anywhere.
+    //
+    // The previous (responder-attestation) binding would have
+    // compared `tipsHash([X_HEAD]) === winningHashHex` and PASSED,
+    // allowing the divergent state Y to be applied. The new
+    // structural binding examines the served payload and computes
+    // the frontier as `[Y_HEAD]`. Hashing that gives a value that
+    // differs from `winningHashHex`, so the binding REJECTS the
+    // peer and `load()` retries the next agreeing peer.
+    const forgedTree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: {
+        Y_PARENT: { kind: docKind },
+      },
+    };
+    const servedFrontier = computeServedFrontier(
+      'Y_HEAD',
+      forgedTree,
+      undefined,
+    );
+    expect(servedFrontier.sort()).toEqual(['Y_HEAD']);
+    // The responder's CLAIMED `tips` would say [X_HEAD], but the
+    // structural derivation says [Y_HEAD]. The loader hashes the
+    // structural result and compares to `winningHashHex`; they
+    // differ, the peer is rejected.
+    expect(servedFrontier).not.toContain('X_HEAD');
+  });
+
+  test('forged tips attack with snapshot in payload: structural derivation also exposes the lie', () => {
+    // Same attack but the responder includes a snapshot in the
+    // forged payload. The snapshot boundary they ship is for state Y
+    // (Y_BOUNDARY), not for the agreed state X. The structural
+    // derivation collects {Y_BOUNDARY, Y_HEAD} from the payload --
+    // neither matches the agreed X_HEAD.
+    const forgedTree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: {
+        Y_BOUNDARY: { kind: docKind },
+      },
+    };
+    const servedFrontier = computeServedFrontier(
+      'Y_HEAD',
+      forgedTree,
+      'Y_BOUNDARY',
+    );
+    // Y_BOUNDARY is referenced by Y_HEAD => not in frontier.
+    // Only Y_HEAD remains.
+    expect(servedFrontier.sort()).toEqual(['Y_HEAD']);
+  });
+
+  test('responder-internal equivocation: tips claim multiple heads but payload only embeds one => structural frontier exposes the inconsistency', () => {
+    // Variant: responder advertises `tips = [H1, H2]` in `message.tips`
+    // (and hashes it correctly into the winning hash they voted for),
+    // but the served `changes` tree only embeds H1. The
+    // structurally-derived frontier is {H1}, which hashes
+    // differently from `tipsHash([H1, H2])`. The loader's primary
+    // structural check fires; the responder's `tips` is also
+    // checked against the structural frontier as defense-in-depth.
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      // No children -- a leaf in the change DAG.
+    };
+    const servedFrontier = computeServedFrontier('H1', tree, undefined);
+    expect(servedFrontier.sort()).toEqual(['H1']);
+    // Claimed [H1, H2] != servedFrontier [H1]. Rejected.
+  });
+
+  test('deferred children sentinel: tree walk stops, no descendants recursed into', () => {
+    // A `children === false` sentinel means IPLD-deferred. The
+    // walker should not recurse and the deferred children's keys
+    // are not enumerated. The frontier consists of whatever was
+    // recorded at the level the deferred sentinel was hit.
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: false as false,
+    };
+    const frontier = computeServedFrontier('HEAD', tree, undefined);
+    expect(frontier).toEqual(['HEAD']);
+  });
+
+  test('cycle defense: visited-set prevents infinite recursion', () => {
+    // Content-addressed CIDs can't cycle in practice, but the helper
+    // is defensively guarded. Construct a (synthetic) cycle and
+    // verify the walk terminates.
+    const a: CRDTChangeNode<unknown> = { kind: docKind, children: {} };
+    const b: CRDTChangeNode<unknown> = { kind: docKind, children: { A: a } };
+    a.children = { B: b };
+    // Walk should terminate and the frontier should still be the
+    // (anonymous) root -- with named cycles A and B both being
+    // referenced.
+    const frontier = computeServedFrontier(undefined, a, undefined);
+    // Both A and B are children-keys of each other => both referenced
+    // => empty frontier (no unreferenced CIDs).
+    expect(frontier).toEqual([]);
+  });
+
+  test('honest single-head responder: structural frontier == _currentFrontier() on the loader after sync', () => {
+    // Sanity test: the structural derivation produces the same
+    // frontier the loader would compute via `_hashes \
+    // _referencedAncestors` after applying the served payload
+    // (starting from an empty loader). This is the convergence
+    // property the binding relies on.
+    const tree: CRDTChangeNode<unknown> = {
+      kind: docKind,
+      children: {
+        P1: {
+          kind: docKind,
+          children: {
+            P2: { kind: docKind },
+          },
+        },
+      },
+    };
+    const servedFrontier = computeServedFrontier('HEAD', tree, undefined);
+    // Simulate the loader applying the payload from scratch:
+    //   _hashes after sync = {HEAD, P1, P2}
+    //   _referencedAncestors after sync = {P1, P2}
+    //   _currentFrontier = {HEAD}
+    const loaderHashes = new Set<string>();
+    const loaderRefs = new Set<string>();
+    // Walk the tree the same way `_syncDocumentChanges` would:
+    function applyWalk(
+      id: string | undefined,
+      node: CRDTChangeNode<unknown>,
+    ) {
+      if (id) loaderHashes.add(id);
+      if (node.children === undefined) return;
+      if (node.children === false) return;
+      for (const [childId, childNode] of Object.entries(node.children)) {
+        loaderHashes.add(childId);
+        loaderRefs.add(childId);
+        applyWalk(childId, childNode);
+      }
+    }
+    applyWalk('HEAD', tree);
+    const loaderFrontier = [...loaderHashes].filter((h) => !loaderRefs.has(h));
+    expect(servedFrontier.sort()).toEqual(loaderFrontier.sort());
   });
 });

--- a/packages/collabswarm/src/merkle-cross-links.test.ts
+++ b/packages/collabswarm/src/merkle-cross-links.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 import {
+  collectAllCidsInTree,
   collectReferencedAncestors,
   computeServedFrontier,
   MAX_CROSS_LINKS,
@@ -1712,5 +1713,97 @@ describe('stripInlineChanges (PR #284 r17 content-bind defense)', () => {
     const c1 = (tree.children as any).c1;
     expect(c1.kind).toBe(crdtDocumentChangeNode);
     expect(c1.keyID).toBe('k1');
+  });
+});
+
+describe('collectAllCidsInTree (PR #284 r18 post-sync verification basis)', () => {
+  type Changes = { ops: string[] };
+
+  test('flat root with no children returns just the root CID', () => {
+    const tree: CRDTChangeNode<Changes> = {
+      kind: crdtDocumentChangeNode,
+      change: { ops: ['root'] },
+    };
+    expect(collectAllCidsInTree('root-cid', tree)).toEqual(['root-cid']);
+  });
+
+  test('walks every child level and dedupes via Set', () => {
+    const tree: CRDTChangeNode<Changes> = {
+      kind: crdtDocumentChangeNode,
+      children: {
+        c1: {
+          kind: crdtDocumentChangeNode,
+          children: {
+            gc1: { kind: crdtDocumentChangeNode },
+            gc2: { kind: crdtDocumentChangeNode },
+          },
+        },
+        c2: { kind: crdtDocumentChangeNode },
+      },
+    };
+    const cids = collectAllCidsInTree('root-cid', tree).sort();
+    expect(cids).toEqual(['c1', 'c2', 'gc1', 'gc2', 'root-cid']);
+  });
+
+  test('handles undefined root (defensive guard)', () => {
+    expect(collectAllCidsInTree<Changes>(undefined, undefined)).toEqual([]);
+  });
+
+  test('rootId-only with undefined root: returns just the rootId', () => {
+    expect(collectAllCidsInTree<Changes>('only-root-cid', undefined)).toEqual(
+      ['only-root-cid'],
+    );
+  });
+
+  test('stops at a deferred children sentinel (cannot enumerate descendants)', () => {
+    const tree: CRDTChangeNode<Changes> = {
+      kind: crdtDocumentChangeNode,
+      children: crdtChangeNodeDeferred,
+    };
+    expect(collectAllCidsInTree('root-cid', tree)).toEqual(['root-cid']);
+  });
+
+  test('cycle defense: a child CID that re-appears in a descendant subtree is not walked twice', () => {
+    // Construct an aliasing tree (would not normally happen in practice
+    // because CIDs are content-addressed and unique, but defensive against
+    // a malicious responder that constructs a cyclic-looking tree).
+    const inner: CRDTChangeNode<Changes> = {
+      kind: crdtDocumentChangeNode,
+    };
+    const tree: CRDTChangeNode<Changes> = {
+      kind: crdtDocumentChangeNode,
+      children: {
+        c1: inner,
+        c2: {
+          kind: crdtDocumentChangeNode,
+          children: { c1: inner }, // alias: c1 appears again
+        },
+      },
+    };
+    // c1 should be visited only once.
+    const cids = collectAllCidsInTree('root-cid', tree).sort();
+    expect(cids).toEqual(['c1', 'c2', 'root-cid']);
+  });
+
+  test('preserves all CID keys in a typical Merkle-DAG tree (post-strip shell shape)', () => {
+    // Mimics the post-`stripInlineChanges` shape used in production: no
+    // inline `change` content, only CID-keyed `children` maps. The CID
+    // collector still walks the whole structure.
+    const tree: CRDTChangeNode<Changes> = {
+      kind: crdtDocumentChangeNode,
+      children: {
+        'bafy-a': {
+          kind: crdtWriterChangeNode,
+          children: {
+            'bafy-b': { kind: crdtDocumentChangeNode },
+          },
+        },
+        'bafy-c': { kind: crdtDocumentChangeNode },
+      },
+    };
+    const cids = collectAllCidsInTree('bafy-root', tree);
+    expect(new Set(cids)).toEqual(
+      new Set(['bafy-root', 'bafy-a', 'bafy-b', 'bafy-c']),
+    );
   });
 });

--- a/packages/collabswarm/src/merkle-cross-links.test.ts
+++ b/packages/collabswarm/src/merkle-cross-links.test.ts
@@ -6,12 +6,14 @@ import {
   MAX_RECENT_TIPS,
   mergeRemoteSyncTree,
   selectCrossLinks,
+  stripInlineChanges,
   trackTipInList,
   treeContainsCid,
 } from './merkle-cross-links';
 import {
   CRDTChangeNode,
   CRDTChangeNodeKind,
+  crdtChangeNodeDeferred,
   crdtDocumentChangeNode,
   crdtWriterChangeNode,
 } from './crdt-change-node';
@@ -1587,5 +1589,128 @@ describe('relay-peer served-frontier (PR #284 r14: _lastSyncMessage refresh from
       loaderDerivedFromPayload.sort(),
     );
     expect(responderAdvertised).toEqual(['X']);
+  });
+});
+
+describe('stripInlineChanges (PR #284 r17 content-bind defense)', () => {
+  type Changes = { ops: string[] };
+
+  test('strips top-level inline change', () => {
+    const tree: CRDTChangeNode<Changes> = {
+      kind: crdtDocumentChangeNode,
+      change: { ops: ['a', 'b'] },
+    };
+    const result = stripInlineChanges(tree);
+    expect(result).toBe(tree); // mutated in-place, returned for chaining
+    expect(tree.change).toBeUndefined();
+    expect(tree.kind).toBe(crdtDocumentChangeNode);
+  });
+
+  test('strips recursively through nested children', () => {
+    const tree: CRDTChangeNode<Changes> = {
+      kind: crdtDocumentChangeNode,
+      change: { ops: ['root'] },
+      children: {
+        child1: {
+          kind: crdtDocumentChangeNode,
+          change: { ops: ['c1'] },
+          children: {
+            grandchild1: {
+              kind: crdtWriterChangeNode,
+              change: { ops: ['gc1'] },
+            },
+          },
+        },
+        child2: {
+          kind: crdtDocumentChangeNode,
+          change: { ops: ['c2'] },
+        },
+      },
+    };
+    stripInlineChanges(tree);
+    expect(tree.change).toBeUndefined();
+    const c1 = (tree.children as any).child1;
+    expect(c1.change).toBeUndefined();
+    expect(c1.kind).toBe(crdtDocumentChangeNode); // structure preserved
+    const gc1 = c1.children.grandchild1;
+    expect(gc1.change).toBeUndefined();
+    expect(gc1.kind).toBe(crdtWriterChangeNode);
+    const c2 = (tree.children as any).child2;
+    expect(c2.change).toBeUndefined();
+  });
+
+  test('preserves CID keys (the shape that drives Helia-fetch verification)', () => {
+    const tree: CRDTChangeNode<Changes> = {
+      kind: crdtDocumentChangeNode,
+      change: { ops: ['root'] },
+      children: {
+        'bafy-cid-1': {
+          kind: crdtDocumentChangeNode,
+          change: { ops: ['1'] },
+        },
+        'bafy-cid-2': {
+          kind: crdtDocumentChangeNode,
+          change: { ops: ['2'] },
+        },
+      },
+    };
+    stripInlineChanges(tree);
+    // The CID-keyed structure stays intact so sync()'s _getBlock(cid)
+    // path can fetch each block via Helia (content-validated against
+    // the CID by the blockstore).
+    expect(Object.keys(tree.children as any).sort()).toEqual([
+      'bafy-cid-1',
+      'bafy-cid-2',
+    ]);
+  });
+
+  test('skips a deferred children sentinel (already empty)', () => {
+    const tree: CRDTChangeNode<Changes> = {
+      kind: crdtDocumentChangeNode,
+      change: { ops: ['root'] },
+      children: crdtChangeNodeDeferred,
+    };
+    stripInlineChanges(tree);
+    expect(tree.change).toBeUndefined();
+    expect(tree.children).toBe(crdtChangeNodeDeferred);
+  });
+
+  test('handles undefined node (defensive guard)', () => {
+    expect(stripInlineChanges<Changes>(undefined)).toBeUndefined();
+  });
+
+  test('handles leaf node with no children', () => {
+    const leaf: CRDTChangeNode<Changes> = {
+      kind: crdtDocumentChangeNode,
+      change: { ops: ['leaf'] },
+    };
+    stripInlineChanges(leaf);
+    expect(leaf.change).toBeUndefined();
+    expect(leaf.children).toBeUndefined();
+  });
+
+  test('does not mutate the kind field of any node', () => {
+    // Defense-in-depth: stripInlineChanges must NOT alter the
+    // structural metadata (kind, keyID, children keys). Only `change`
+    // is reset; the rest must survive so the receive-side ACL pre-pass
+    // and CRDT type-routing in `sync()` still work after deferred fetch.
+    const tree: CRDTChangeNode<Changes> = {
+      kind: crdtWriterChangeNode,
+      keyID: 'k1',
+      change: { ops: ['acl-add-writer'] },
+      children: {
+        c1: {
+          kind: crdtDocumentChangeNode,
+          keyID: 'k1',
+          change: { ops: ['doc-change'] },
+        },
+      },
+    };
+    stripInlineChanges(tree);
+    expect(tree.kind).toBe(crdtWriterChangeNode);
+    expect(tree.keyID).toBe('k1');
+    const c1 = (tree.children as any).c1;
+    expect(c1.kind).toBe(crdtDocumentChangeNode);
+    expect(c1.keyID).toBe('k1');
   });
 });

--- a/packages/collabswarm/src/merkle-cross-links.test.ts
+++ b/packages/collabswarm/src/merkle-cross-links.test.ts
@@ -680,8 +680,7 @@ describe('collectReferencedAncestors (frontier helper for initial-load quorum)',
     const tree: Node = {
       kind: docKind,
       change: 'payload-A',
-      // Cast to bypass the type narrowing on `false` literal for tests.
-      children: false as unknown as Record<string, Node>,
+      children: crdtChangeNodeDeferred as unknown as Record<string, Node>,
     };
     const out = new Set<string>();
     expect(() =>

--- a/packages/collabswarm/src/merkle-cross-links.test.ts
+++ b/packages/collabswarm/src/merkle-cross-links.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 import {
+  collectReferencedAncestors,
   MAX_CROSS_LINKS,
   MAX_RECENT_TIPS,
   mergeRemoteSyncTree,
@@ -598,5 +599,207 @@ describe('Merkle CRDT recent-tip tracking from a remote sync tree', () => {
       trackTipInList(naive, { cid, kind });
     }
     expect(naive.map((t) => t.cid)).not.toContain('H');
+  });
+});
+
+describe('collectReferencedAncestors (frontier helper for initial-load quorum)', () => {
+  const docKind: CRDTChangeNodeKind = crdtDocumentChangeNode;
+  type Node = CRDTChangeNode<string>;
+
+  test('empty tree (no children) yields no referenced ancestors', () => {
+    const root: Node = { kind: docKind, change: 'payload-A' };
+    const out = new Set<string>();
+    collectReferencedAncestors('A', root, out);
+    expect(out.size).toBe(0);
+  });
+
+  test('does NOT add the root CID to the referenced set', () => {
+    // The root is the head, not an ancestor. Only `children` keys are
+    // referenced.
+    const root: Node = { kind: docKind, change: 'payload-A' };
+    const out = new Set<string>();
+    collectReferencedAncestors('A', root, out);
+    expect(out.has('A')).toBe(false);
+  });
+
+  test('collects every CID found as a children key (linear chain)', () => {
+    // Local writer chain: C -> B -> A (current head is C; A is the oldest
+    // ancestor). C.children = {B: ...}, B.children = {A: ...}.
+    const tree: Node = {
+      kind: docKind,
+      change: 'payload-C',
+      children: {
+        B: {
+          kind: docKind,
+          change: 'payload-B',
+          children: { A: { kind: docKind, change: 'payload-A' } },
+        },
+      },
+    };
+    const out = new Set<string>();
+    collectReferencedAncestors('C', tree, out);
+    expect(out.has('B')).toBe(true);
+    expect(out.has('A')).toBe(true);
+    expect(out.has('C')).toBe(false); // root is the head, not an ancestor
+    expect(out.size).toBe(2);
+  });
+
+  test('collects cross-link references emitted as deferred leaves', () => {
+    // D's primary parent is C inline, and D cross-links to an older ancestor
+    // X via a deferred leaf (no `change`, no `children`). Both must be
+    // recorded as referenced.
+    const tree: Node = {
+      kind: docKind,
+      change: 'payload-D',
+      children: {
+        C: {
+          kind: docKind,
+          change: 'payload-C',
+          children: { B: { kind: docKind, change: 'payload-B' } },
+        },
+        X: { kind: docKind }, // deferred cross-link
+      },
+    };
+    const out = new Set<string>();
+    collectReferencedAncestors('D', tree, out);
+    expect(out.has('C')).toBe(true);
+    expect(out.has('B')).toBe(true);
+    expect(out.has('X')).toBe(true);
+    expect(out.has('D')).toBe(false);
+  });
+
+  test('skips a `crdtChangeNodeDeferred` children sentinel without throwing', () => {
+    // IPLD-deferred subtree: the inline payload was elided and would need a
+    // blockstore fetch. We don't try to walk it -- the caller already has
+    // whatever parent relationships were inlined elsewhere.
+    const tree: Node = {
+      kind: docKind,
+      change: 'payload-A',
+      // Cast to bypass the type narrowing on `false` literal for tests.
+      children: false as unknown as Record<string, Node>,
+    };
+    const out = new Set<string>();
+    expect(() =>
+      collectReferencedAncestors('A', tree, out),
+    ).not.toThrow();
+    expect(out.size).toBe(0);
+  });
+
+  test('mutates the passed Set in place and returns it', () => {
+    // Tests can compose multiple sync trees into one shared set, mirroring
+    // how `_referencedAncestors` accumulates across calls.
+    const tree: Node = {
+      kind: docKind,
+      change: 'payload-B',
+      children: { A: { kind: docKind, change: 'payload-A' } },
+    };
+    const out = new Set<string>(['X']); // pre-existing entry
+    const returned = collectReferencedAncestors('B', tree, out);
+    expect(returned).toBe(out);
+    expect(out.has('X')).toBe(true); // pre-existing entry preserved
+    expect(out.has('A')).toBe(true); // new entry added
+  });
+
+  test('cycle defence: revisiting a previously-walked CID does not recurse', () => {
+    // Construct a pathological tree where two distinct subtree references
+    // reach the same intermediate CID. The helper should not infinitely
+    // recurse and should still surface the right referenced set.
+    const sharedAncestor: Node = {
+      kind: docKind,
+      change: 'payload-A',
+    };
+    const tree: Node = {
+      kind: docKind,
+      change: 'payload-C',
+      children: {
+        B1: { kind: docKind, change: 'payload-B1', children: { A: sharedAncestor } },
+        B2: { kind: docKind, change: 'payload-B2', children: { A: sharedAncestor } },
+      },
+    };
+    const out = new Set<string>();
+    expect(() =>
+      collectReferencedAncestors('C', tree, out),
+    ).not.toThrow();
+    expect(out.has('A')).toBe(true);
+    expect(out.has('B1')).toBe(true);
+    expect(out.has('B2')).toBe(true);
+  });
+
+  test('frontier semantics: two trees of different cardinality but same head produce the same heads', () => {
+    // PR #284 round-3 acceptance scenario: peer A has merged a long
+    // ancestor chain (`_hashes` includes many CIDs) while peer B loaded
+    // from a snapshot (its `_hashes` includes only the snapshot boundary
+    // + post-snapshot changes). Both peers consider HEAD their current
+    // head. The frontier helper (`_hashes \ referenced`) MUST agree on
+    // {HEAD} across the two views.
+    //
+    // We mimic this by giving each peer different `_hashes` and different
+    // tree shapes, then verifying the computed frontier collapses to the
+    // shared head set.
+    const compute = (
+      hashes: Set<string>,
+      rootId: string | undefined,
+      root: Node,
+    ): Set<string> => {
+      const referenced = new Set<string>();
+      collectReferencedAncestors(rootId, root, referenced);
+      const frontier = new Set<string>();
+      for (const cid of hashes) {
+        if (!referenced.has(cid)) frontier.add(cid);
+      }
+      return frontier;
+    };
+
+    // Peer A: long history, current head HEAD with ancestors P1, P2, P3.
+    const peerATree: Node = {
+      kind: docKind,
+      change: 'HEAD',
+      children: {
+        P1: {
+          kind: docKind,
+          change: 'P1',
+          children: {
+            P2: {
+              kind: docKind,
+              change: 'P2',
+              children: { P3: { kind: docKind, change: 'P3' } },
+            },
+          },
+        },
+      },
+    };
+    const peerAHashes = new Set(['HEAD', 'P1', 'P2', 'P3']);
+
+    // Peer B: loaded from a snapshot at P2, then synced forward to HEAD.
+    // The post-snapshot sync that delivered HEAD had a pruned tree -- it
+    // referenced P2 directly as the parent (the sender knew the loader
+    // would have P2 from the snapshot, so no need to inline anything
+    // deeper). P1 was compacted into the snapshot and never enters the
+    // loader's view at all.
+    const peerBTree: Node = {
+      kind: docKind,
+      change: 'HEAD',
+      children: {
+        P2: { kind: docKind }, // deferred reference to the snapshot boundary
+      },
+    };
+    // After applying the snapshot: P2 is the snapshot boundary (added to
+    // _hashes as a sentinel), HEAD is the new head. P1 is not in B's view.
+    const peerBHashes = new Set(['HEAD', 'P2']);
+
+    const frontierA = compute(peerAHashes, 'HEAD', peerATree);
+    const frontierB = compute(peerBHashes, 'HEAD', peerBTree);
+
+    // Each peer's frontier is exactly {HEAD} despite very different
+    // `_hashes` cardinality (4 vs 3) and tree shapes. This is the
+    // convergence property that round-3 of the Copilot review demanded.
+    expect(Array.from(frontierA).sort()).toEqual(['HEAD']);
+    expect(Array.from(frontierB).sort()).toEqual(['HEAD']);
+
+    // Counter-check: the old buggy implementation (`Array.from(_hashes)`)
+    // would have produced DIFFERENT frontiers for these two peers (4
+    // entries vs 3 entries), so any tipsHash derived from it would have
+    // diverged -- the bug round 3 of the review caught.
+    expect(peerAHashes.size).not.toBe(peerBHashes.size);
   });
 });

--- a/packages/collabswarm/src/merkle-cross-links.ts
+++ b/packages/collabswarm/src/merkle-cross-links.ts
@@ -342,6 +342,56 @@ export function computeServedFrontier<ChangesType>(
 }
 
 /**
+ * Pure helper: walk a sync tree and report whether `targetCid` appears
+ * anywhere in it -- as the root CID, as a `children` map key, or as a
+ * descendant. Used by `CollabswarmDocument._refreshLastSyncMessageFromSync`
+ * to decide whether an incoming sync tree subsumes the locally-cached
+ * `_lastSyncMessage` (i.e. embeds its root), in which case the cache can
+ * be safely replaced without losing served-frontier coverage.
+ *
+ * Walks defensively:
+ *   - Skips a deferred `children` sentinel; we cannot enumerate descendants
+ *     of a deferred node, so we conservatively return `false` if the target
+ *     would only have been found beneath that sentinel.
+ *   - Tracks visited node CIDs so cycles do not recurse forever (content
+ *     addressing rules these out in practice; defensive nonetheless).
+ *
+ * Returns `true` if `targetCid` is found, `false` otherwise. Treats
+ * empty / undefined `targetCid` as "not found" so callers can pass an
+ * optional value without a separate guard.
+ */
+export function treeContainsCid<ChangesType>(
+  rootId: string | undefined,
+  root: CRDTChangeNode<ChangesType> | undefined,
+  targetCid: string | undefined,
+): boolean {
+  if (!targetCid) return false;
+  if (root === undefined) return false;
+  if (rootId === targetCid) return true;
+
+  const visited = new Set<string>();
+
+  function walk(
+    nodeId: string | undefined,
+    node: CRDTChangeNode<ChangesType>,
+  ): boolean {
+    if (nodeId !== undefined) {
+      if (visited.has(nodeId)) return false;
+      visited.add(nodeId);
+    }
+    if (node.children === undefined) return false;
+    if (node.children === crdtChangeNodeDeferred) return false;
+    for (const [childId, childNode] of Object.entries(node.children)) {
+      if (childId === targetCid) return true;
+      if (walk(childId, childNode)) return true;
+    }
+    return false;
+  }
+
+  return walk(rootId, root);
+}
+
+/**
  * Pure helper: append `entry` to `recentTips` with LRU semantics
  * (most-recently-used to the back), evicting the oldest entries when the
  * list exceeds `maxRecentTips`. If `entry.cid` is already present, it is

--- a/packages/collabswarm/src/merkle-cross-links.ts
+++ b/packages/collabswarm/src/merkle-cross-links.ts
@@ -235,6 +235,113 @@ export function collectReferencedAncestors<ChangesType>(
 }
 
 /**
+ * Pure helper: derive the served frontier of a load-response payload
+ * STRUCTURALLY, without applying any of it to local state.
+ *
+ * The initial-load quorum binding (#186 / #189 §5.4.2) needs to verify that
+ * the full-load response a peer serves actually corresponds to the
+ * tip-set hash that peer voted for in the probe round. Previously the
+ * loader hashed the responder-supplied `message.tips` array and compared
+ * to the quorum-agreed hash -- which trusted the responder's own
+ * attestation as the source of truth. A malicious peer could vote hash
+ * X, put X's tip CIDs in `message.tips`, and then serve a `changes`
+ * payload describing a completely different state; the binding would
+ * still pass.
+ *
+ * This helper closes that gap: given the served `changes` tree (rooted
+ * at `changeId`) plus an optional `snapshotBoundaryCid` from
+ * `message.snapshot.lastChangeNodeCID`, it computes the frontier as a
+ * function of the payload's structure -- the set of CIDs that appear in
+ * the served tree but are NOT referenced as a parent (child-key) of any
+ * node in the same tree. Hashing this set with `tipsHash` and comparing
+ * to `winningHashHex` produces a binding decision that does not depend
+ * on the responder's own attestation.
+ *
+ * Algorithm:
+ *   - Initialise `cids = {}` and `referenced = {}`.
+ *   - If `changes` is present, walk the tree:
+ *       - Record `changeId` (if defined) into `cids` (it is a node in
+ *         the served tree, even if it has no children).
+ *       - For every `(childId, childNode)` pair encountered in any
+ *         `children` map, record `childId` into BOTH `cids` (the child
+ *         is a node in the served tree) AND `referenced` (the child is
+ *         a parent of the current node, so it is NOT a head).
+ *       - Recurse into the child's own children (if not deferred).
+ *   - If `snapshotBoundaryCid` is provided and non-empty, record it
+ *     into `cids`. The snapshot boundary is a node the responder
+ *     attests to (post-sync the loader adds it to `_hashes`); whether
+ *     it ends up in the frontier depends on whether any post-snapshot
+ *     change in `changes` references it as a parent.
+ *   - Return `cids \ referenced` -- the heads (CIDs nobody points to).
+ *
+ * Edge cases:
+ *   - Both `changes` undefined AND `snapshotBoundaryCid` empty: the
+ *     responder is brand new / has no state. Returns `[]`. The loader
+ *     can compare against the canonical hash of `[]` to detect a
+ *     responder that voted for a non-empty state but serves nothing.
+ *   - `changeId === undefined` with `changes` defined: the served tree
+ *     is anonymous (no root CID). Pure helpers in this module already
+ *     tolerate `nodeId === undefined`; we record nothing for the
+ *     anonymous root, so an anonymous served tree contributes only its
+ *     children-keys to the analysis.
+ *   - Deferred children sentinel: treated identically to
+ *     `collectReferencedAncestors` -- the children of a deferred node
+ *     are unknown; we do not recurse. Any CIDs that appear as keys
+ *     leading INTO a deferred child are still recorded as referenced
+ *     (we saw them as a child-key before the deferred indicator).
+ *   - Cycles: defensively guarded by a `visited` set on node CIDs.
+ *
+ * This is structurally identical to applying the served payload and
+ * then computing `_hashes \ _referencedAncestors` on an EMPTY pre-sync
+ * loader, except it works in pure form (no I/O, no Helia blockstore
+ * fetch, no document state mutation). The returned array is unsorted;
+ * `tipsHash` performs its own canonical sort. See PR #284 r7 Copilot
+ * review for the design discussion.
+ */
+export function computeServedFrontier<ChangesType>(
+  changeId: string | undefined,
+  changes: CRDTChangeNode<ChangesType> | undefined,
+  snapshotBoundaryCid: string | undefined,
+): string[] {
+  const cids = new Set<string>();
+  const referenced = new Set<string>();
+  const visited = new Set<string>();
+
+  function walk(
+    nodeId: string | undefined,
+    node: CRDTChangeNode<ChangesType>,
+  ): void {
+    if (nodeId !== undefined) {
+      if (visited.has(nodeId)) return;
+      visited.add(nodeId);
+      cids.add(nodeId);
+    }
+    if (node.children === undefined) return;
+    if (node.children === crdtChangeNodeDeferred) return;
+    for (const [childId, childNode] of Object.entries(node.children)) {
+      cids.add(childId);
+      referenced.add(childId);
+      walk(childId, childNode);
+    }
+  }
+
+  if (changes !== undefined) {
+    walk(changeId, changes);
+  }
+  if (snapshotBoundaryCid) {
+    cids.add(snapshotBoundaryCid);
+  }
+
+  const frontier: string[] = [];
+  for (const cid of cids) {
+    if (!referenced.has(cid)) {
+      frontier.push(cid);
+    }
+  }
+  return frontier;
+}
+
+/**
  * Pure helper: append `entry` to `recentTips` with LRU semantics
  * (most-recently-used to the back), evicting the oldest entries when the
  * list exceeds `maxRecentTips`. If `entry.cid` is already present, it is

--- a/packages/collabswarm/src/merkle-cross-links.ts
+++ b/packages/collabswarm/src/merkle-cross-links.ts
@@ -174,6 +174,67 @@ export function mergeRemoteSyncTree<ChangesType>(
 }
 
 /**
+ * Pure helper: walk a sync tree and record every CID that appears as a
+ * `children` key -- i.e. every CID that some node in the tree points to
+ * as a parent (or as a cross-link target, which is also a parent in the
+ * Merkle-CRDT DAG; cross-links reference *predecessor* CIDs).
+ *
+ * Used by `CollabswarmDocument._currentFrontier()` to compute the set of
+ * heads as `(all known CIDs) \ (referenced ancestors)`. A CID is a "head"
+ * iff no node we've ever seen references it as a parent. This gives the
+ * leaves of the merged DAG (the CIDs the responder would attest to as the
+ * current frontier), which is the correct semantic for the initial-load
+ * quorum binding -- two honest peers with the same logical state but
+ * different sync histories converge on the same head set even though
+ * their full `_hashes` cardinality differs.
+ *
+ * The root CID (`rootId`, if provided) is intentionally NOT added to the
+ * referenced set -- the root of a tree is the head, not a child of anything
+ * in this traversal. Descendants reached via `node.children` keys ARE
+ * referenced.
+ *
+ * Walks defensively:
+ *   - Skips a deferred `children` sentinel (`crdtChangeNodeDeferred`); IPLD
+ *     dereferencing happens elsewhere and isn't required to enumerate the
+ *     in-memory parent relationships we already have.
+ *   - Tracks visited node CIDs so cycles (shouldn't happen with content
+ *     addressing, but defensively) don't recurse forever.
+ *
+ * Mutates `out` in place and returns it for convenience.
+ */
+export function collectReferencedAncestors<ChangesType>(
+  rootId: string | undefined,
+  root: CRDTChangeNode<ChangesType>,
+  out: Set<string>,
+): Set<string> {
+  const visited = new Set<string>();
+
+  function walk(
+    nodeId: string | undefined,
+    node: CRDTChangeNode<ChangesType>,
+  ): void {
+    if (nodeId !== undefined) {
+      if (visited.has(nodeId)) return;
+      visited.add(nodeId);
+    }
+
+    if (node.children === undefined) return;
+    if (node.children === crdtChangeNodeDeferred) return;
+
+    for (const [childId, childNode] of Object.entries(node.children)) {
+      // The `children` map keys are CIDs the current node references as
+      // parents (primary parent + cross-links). They are ancestors by
+      // definition -- record them as referenced.
+      out.add(childId);
+      walk(childId, childNode);
+    }
+  }
+
+  walk(rootId, root);
+  return out;
+}
+
+/**
  * Pure helper: append `entry` to `recentTips` with LRU semantics
  * (most-recently-used to the back), evicting the oldest entries when the
  * list exceeds `maxRecentTips`. If `entry.cid` is already present, it is

--- a/packages/collabswarm/src/merkle-cross-links.ts
+++ b/packages/collabswarm/src/merkle-cross-links.ts
@@ -467,3 +467,53 @@ export function stripInlineChanges<ChangesType>(
   }
   return node;
 }
+
+/**
+ * Recursively collect every CID that appears in a `CRDTChangeNode` tree
+ * (the optional root CID, every node-id appearing in any `children` map
+ * key). Returns the CIDs in insertion order, deduplicated via the
+ * underlying `Set`. Used by `CollabswarmDocument._sendLoadRequestAndSync`
+ * on quorum-bound loads as the basis for the post-`sync()` "did every
+ * stripped block actually arrive?" check (PR #284 r18 Copilot review):
+ *
+ *   1. Collect all CIDs from the served tree BEFORE `stripInlineChanges`
+ *      reduces it to a CID-keyed shell.
+ *   2. Strip inline content; call `sync()`.
+ *   3. Verify every collected CID is now in `_hashes`. If any is missing,
+ *      the load is reported as a per-peer bind failure so the loader can
+ *      retry the next peer in the agreeing cohort. Without this check, a
+ *      transient bitswap/blockstore miss would let `sync()` return `true`
+ *      with only a partially-applied document and `load()` report success.
+ *
+ * Skips a deferred `children` sentinel (we cannot enumerate descendants
+ * beneath a deferred node; defensively bounded by a `visited` set on
+ * node CIDs).
+ *
+ * Pure (no I/O); the recursion is bounded by the tree size.
+ */
+export function collectAllCidsInTree<ChangesType>(
+  rootId: string | undefined,
+  root: CRDTChangeNode<ChangesType> | undefined,
+): string[] {
+  if (!root) return rootId ? [rootId] : [];
+  const cids = new Set<string>();
+  const visited = new Set<string>();
+  function walk(
+    nodeId: string | undefined,
+    node: CRDTChangeNode<ChangesType>,
+  ): void {
+    if (nodeId !== undefined) {
+      if (visited.has(nodeId)) return;
+      visited.add(nodeId);
+      cids.add(nodeId);
+    }
+    if (node.children === undefined) return;
+    if (node.children === crdtChangeNodeDeferred) return;
+    for (const [childId, childNode] of Object.entries(node.children)) {
+      cids.add(childId);
+      walk(childId, childNode);
+    }
+  }
+  walk(rootId, root);
+  return [...cids];
+}

--- a/packages/collabswarm/src/merkle-cross-links.ts
+++ b/packages/collabswarm/src/merkle-cross-links.ts
@@ -426,3 +426,44 @@ export function trackTipInList<Tip extends { cid: string }>(
   }
   return recentTips;
 }
+
+/**
+ * Recursively strip inline `change` content from a `CRDTChangeNode` tree
+ * by setting `change: undefined` on every node, leaving the CID-keyed
+ * `children` structure intact. Mutates the passed tree in-place; returns
+ * the same root for chaining convenience.
+ *
+ * Used by `CollabswarmDocument._sendLoadRequestAndSync` on quorum-bound
+ * loads as a defense-in-depth against inline-content forgery (PR #284
+ * r17 Copilot review). The structural quorum bind proves Q peers agree
+ * on the FRONTIER CIDs, but a Byzantine peer that voted for the agreed
+ * frontier can still serve a tree whose `children` map uses those CIDs
+ * as keys but whose inline `change` values are forged. Stripping inline
+ * content forces each change to flow through Helia's CID-addressed
+ * blockstore (`_getBlock(cid) -> heliaNode.blockstore.get(cid)`), which
+ * content-validates the fetched bytes against the CID intrinsically.
+ * Bitswap retrieves from any peer in the swarm that holds the legitimate
+ * block, including honest peers in the agreeing cohort.
+ *
+ * Skips a deferred `children` sentinel (already empty by definition).
+ * Walks every other node so a partially-deferred tree is fully stripped.
+ *
+ * Pure (no I/O, no clock); the recursion is bounded by the tree size.
+ * Returned as a free function so the unit tests can exercise the helper
+ * without standing up a full `CollabswarmDocument` instance.
+ */
+export function stripInlineChanges<ChangesType>(
+  node: CRDTChangeNode<ChangesType> | undefined,
+): CRDTChangeNode<ChangesType> | undefined {
+  if (!node) return node;
+  node.change = undefined;
+  if (
+    node.children !== undefined &&
+    node.children !== crdtChangeNodeDeferred
+  ) {
+    for (const child of Object.values(node.children)) {
+      stripInlineChanges(child);
+    }
+  }
+  return node;
+}

--- a/packages/collabswarm/src/tips-hash.test.ts
+++ b/packages/collabswarm/src/tips-hash.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from '@jest/globals';
+import { tipsHash, tipsHashToHex, TIPS_HASH_LENGTH } from './tips-hash';
+
+describe('tipsHash (initial-load quorum, #189 §5.4.2)', () => {
+  test('returns a 32-byte SHA-256 digest', async () => {
+    const hash = await tipsHash(['bafy1', 'bafy2']);
+    expect(hash).toBeInstanceOf(Uint8Array);
+    expect(hash.length).toBe(TIPS_HASH_LENGTH);
+  });
+
+  test('is deterministic regardless of input order', async () => {
+    const a = await tipsHash(['bafy1', 'bafy2', 'bafy3']);
+    const b = await tipsHash(['bafy3', 'bafy1', 'bafy2']);
+    expect(tipsHashToHex(a)).toBe(tipsHashToHex(b));
+  });
+
+  test('accepts a Set<string> and matches the array form', async () => {
+    const fromSet = await tipsHash(new Set(['bafy1', 'bafy2']));
+    const fromArr = await tipsHash(['bafy2', 'bafy1']);
+    expect(tipsHashToHex(fromSet)).toBe(tipsHashToHex(fromArr));
+  });
+
+  test('different tip sets produce different hashes', async () => {
+    const a = await tipsHash(['bafy1', 'bafy2']);
+    const b = await tipsHash(['bafy1', 'bafy3']);
+    expect(tipsHashToHex(a)).not.toBe(tipsHashToHex(b));
+  });
+
+  test('empty tip set has a stable hash (founding-member case)', async () => {
+    const a = await tipsHash([]);
+    const b = await tipsHash(new Set<string>());
+    expect(tipsHashToHex(a)).toBe(tipsHashToHex(b));
+    expect(a.length).toBe(TIPS_HASH_LENGTH);
+  });
+
+  test('boundary-ambiguous inputs do not collide (separator works)', async () => {
+    // If the canonicalizer concatenated CIDs without a separator,
+    // ["ab", "c"] and ["a", "bc"] would hash identically.
+    const a = await tipsHash(['ab', 'c']);
+    const b = await tipsHash(['a', 'bc']);
+    expect(tipsHashToHex(a)).not.toBe(tipsHashToHex(b));
+  });
+
+  test('does not mutate the caller-provided collection', async () => {
+    const input = ['z', 'a', 'm'];
+    await tipsHash(input);
+    expect(input).toEqual(['z', 'a', 'm']);
+  });
+});
+
+describe('tipsHashToHex', () => {
+  test('produces lowercase hex of correct length', () => {
+    const bytes = new Uint8Array([0x00, 0x0f, 0xff, 0xab]);
+    expect(tipsHashToHex(bytes)).toBe('000fffab');
+  });
+});

--- a/packages/collabswarm/src/tips-hash.test.ts
+++ b/packages/collabswarm/src/tips-hash.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 import { tipsHash, tipsHashToHex, TIPS_HASH_LENGTH } from './tips-hash';
+import { constantTimeHexEquals } from './load-quorum';
 
 describe('tipsHash (initial-load quorum, #189 §5.4.2)', () => {
   test('returns a 32-byte SHA-256 digest', async () => {
@@ -52,5 +53,53 @@ describe('tipsHashToHex', () => {
   test('produces lowercase hex of correct length', () => {
     const bytes = new Uint8Array([0x00, 0x0f, 0xff, 0xab]);
     expect(tipsHashToHex(bytes)).toBe('000fffab');
+  });
+});
+
+describe('hash binding: equivocating peer rejection (#186, suppressed comment fix)', () => {
+  // Models `CollabswarmDocument._enforceQuorumHashBinding`. The quorum-agreed
+  // hash (the "vote") must match the recomputed `tipsHash` of the
+  // locally-applied state (the "serve"). A peer that votes for tip set X
+  // but serves a load whose tips hash to Y is treated as Byzantine
+  // equivocation and rejected — without this binding, a malicious peer
+  // in the agreeing cohort could vote with the majority and then serve
+  // arbitrary state, completely defeating the gate.
+  test('matching vote and serve passes the binding check', async () => {
+    const advertisedTips = ['cidA', 'cidB', 'cidC'];
+    const servedTips = ['cidC', 'cidA', 'cidB']; // same set, different order
+    const advertisedHex = tipsHashToHex(await tipsHash(advertisedTips));
+    const servedHex = tipsHashToHex(await tipsHash(servedTips));
+    expect(constantTimeHexEquals(advertisedHex, servedHex)).toBe(true);
+  });
+
+  test('mismatched vote vs serve fails the binding check', async () => {
+    const advertisedTips = ['cidA', 'cidB'];
+    // Malicious peer voted for {A,B} but then served only {A} — the
+    // served state has a different tipsHash and the binding catches it.
+    const servedTips = ['cidA'];
+    const advertisedHex = tipsHashToHex(await tipsHash(advertisedTips));
+    const servedHex = tipsHashToHex(await tipsHash(servedTips));
+    expect(constantTimeHexEquals(advertisedHex, servedHex)).toBe(false);
+  });
+
+  test('extra-CID injection (vote {A,B}, serve {A,B,evil}) fails the binding check', async () => {
+    // The most security-critical case: the agreeing cohort attested to
+    // {A,B} but a member sneaks in an extra "evil" CID in the load
+    // response. Post-sync `tipsHash(_hashes)` reflects {A,B,evil}, which
+    // does NOT match the voted `winningHashHex`.
+    const advertisedHex = tipsHashToHex(await tipsHash(['cidA', 'cidB']));
+    const servedHex = tipsHashToHex(
+      await tipsHash(['cidA', 'cidB', 'cidEvil']),
+    );
+    expect(constantTimeHexEquals(advertisedHex, servedHex)).toBe(false);
+  });
+
+  test('empty-set vote vs non-empty serve fails (founding-case spoof)', async () => {
+    // A peer that voted "I have nothing" (empty tip-set hash) but then
+    // serves a non-empty document must be rejected — the founding-case
+    // bypass that this fix removes would otherwise let this through.
+    const advertisedHex = tipsHashToHex(await tipsHash([]));
+    const servedHex = tipsHashToHex(await tipsHash(['cidA']));
+    expect(constantTimeHexEquals(advertisedHex, servedHex)).toBe(false);
   });
 });

--- a/packages/collabswarm/src/tips-hash.test.ts
+++ b/packages/collabswarm/src/tips-hash.test.ts
@@ -56,14 +56,20 @@ describe('tipsHashToHex', () => {
   });
 });
 
-describe('hash binding: equivocating peer rejection (#186, suppressed comment fix)', () => {
-  // Models `CollabswarmDocument._enforceQuorumHashBinding`. The quorum-agreed
-  // hash (the "vote") must match the recomputed `tipsHash` of the
-  // locally-applied state (the "serve"). A peer that votes for tip set X
-  // but serves a load whose tips hash to Y is treated as Byzantine
-  // equivocation and rejected — without this binding, a malicious peer
-  // in the agreeing cohort could vote with the majority and then serve
-  // arbitrary state, completely defeating the gate.
+describe('hash binding: equivocating peer rejection (#186 / #189 §5.4.2)', () => {
+  // Models the in-line binding check in
+  // `CollabswarmDocument._sendLoadRequestAndSync`. The responder includes
+  // its own current frontier as `message.tips` on the load response; the
+  // loader hashes that and compares to the quorum-agreed `winningHashHex`.
+  // A peer that votes for tip set X but serves a load whose `tips` hash
+  // to Y is treated as Byzantine equivocation and rejected — without this
+  // binding, a malicious peer in the agreeing cohort could vote with the
+  // majority and then serve arbitrary state.
+  //
+  // Hashing the responder's signed `tips` attestation (rather than
+  // recomputing `tipsHash(loader._hashes)` post-sync) keeps the binding
+  // correct under snapshot-loads (which don't restore ancestor CIDs to
+  // `_hashes`) and history compaction.
   test('matching vote and serve passes the binding check', async () => {
     const advertisedTips = ['cidA', 'cidB', 'cidC'];
     const servedTips = ['cidC', 'cidA', 'cidB']; // same set, different order
@@ -72,34 +78,36 @@ describe('hash binding: equivocating peer rejection (#186, suppressed comment fi
     expect(constantTimeHexEquals(advertisedHex, servedHex)).toBe(true);
   });
 
-  test('mismatched vote vs serve fails the binding check', async () => {
-    const advertisedTips = ['cidA', 'cidB'];
-    // Malicious peer voted for {A,B} but then served only {A} — the
-    // served state has a different tipsHash and the binding catches it.
-    const servedTips = ['cidA'];
-    const advertisedHex = tipsHashToHex(await tipsHash(advertisedTips));
-    const servedHex = tipsHashToHex(await tipsHash(servedTips));
-    expect(constantTimeHexEquals(advertisedHex, servedHex)).toBe(false);
-  });
-
-  test('extra-CID injection (vote {A,B}, serve {A,B,evil}) fails the binding check', async () => {
-    // The most security-critical case: the agreeing cohort attested to
-    // {A,B} but a member sneaks in an extra "evil" CID in the load
-    // response. Post-sync `tipsHash(_hashes)` reflects {A,B,evil}, which
-    // does NOT match the voted `winningHashHex`.
-    const advertisedHex = tipsHashToHex(await tipsHash(['cidA', 'cidB']));
-    const servedHex = tipsHashToHex(
-      await tipsHash(['cidA', 'cidB', 'cidEvil']),
-    );
-    expect(constantTimeHexEquals(advertisedHex, servedHex)).toBe(false);
-  });
-
-  test('empty-set vote vs non-empty serve fails (founding-case spoof)', async () => {
-    // A peer that voted "I have nothing" (empty tip-set hash) but then
-    // serves a non-empty document must be rejected — the founding-case
-    // bypass that this fix removes would otherwise let this through.
-    const advertisedHex = tipsHashToHex(await tipsHash([]));
-    const servedHex = tipsHashToHex(await tipsHash(['cidA']));
-    expect(constantTimeHexEquals(advertisedHex, servedHex)).toBe(false);
-  });
+  // The same logical case (vote X, serve Y → reject) under a range of
+  // adversarial shapes. Table-driven so adding a new attack pattern only
+  // needs one row.
+  test.each([
+    {
+      label: 'subset-serve (vote {A,B}, serve {A})',
+      advertisedTips: ['cidA', 'cidB'] as string[],
+      servedTips: ['cidA'] as string[],
+    },
+    {
+      label: 'extra-cid-injection (vote {A,B}, serve {A,B,evil})',
+      advertisedTips: ['cidA', 'cidB'] as string[],
+      servedTips: ['cidA', 'cidB', 'cidEvil'] as string[],
+    },
+    {
+      label: 'founding-case-spoof (vote {}, serve {A})',
+      advertisedTips: [] as string[],
+      servedTips: ['cidA'] as string[],
+    },
+    {
+      label: 'disjoint-set (vote {A}, serve {B})',
+      advertisedTips: ['cidA'] as string[],
+      servedTips: ['cidB'] as string[],
+    },
+  ])(
+    'mismatched vote vs serve fails the binding check: $label',
+    async ({ advertisedTips, servedTips }) => {
+      const advertisedHex = tipsHashToHex(await tipsHash(advertisedTips));
+      const servedHex = tipsHashToHex(await tipsHash(servedTips));
+      expect(constantTimeHexEquals(advertisedHex, servedHex)).toBe(false);
+    },
+  );
 });

--- a/packages/collabswarm/src/tips-hash.ts
+++ b/packages/collabswarm/src/tips-hash.ts
@@ -1,0 +1,78 @@
+/**
+ * Deterministic tip-set hash used by the initial-load quorum protocol.
+ *
+ * When a new node opens a document, it asks K peers in parallel for a
+ * lightweight "tip advertisement" -- the responder's current view of the
+ * document's tip set, summarized as a single 32-byte SHA-256 digest. The
+ * loader counts how many peers returned the *same* hash and only proceeds
+ * with a full document-load against a peer that participated in the
+ * agreeing majority. See `load-quorum.ts` for the decision logic and
+ * `CollabswarmDocument.load()` for how the gate is wired in.
+ *
+ * Closes the "no quorum protocol for verifying initial document state" gap
+ * tracked under issue #189 §5.4 item 2 (and listed as a bullet under #186).
+ *
+ * The hash is deterministic across peers that share the same tip set
+ * because:
+ *   - the input CIDs are sorted lexicographically (the input order from
+ *     `Set` iteration or array-passed order is irrelevant);
+ *   - each CID is UTF-8 encoded with an explicit `\n` separator to avoid
+ *     prefix-ambiguity between adjacent CIDs (`["ab", "c"]` vs
+ *     `["a", "bc"]`).
+ *
+ * An empty tip set hashes to the SHA-256 of the empty string. This is
+ * intentional: peers that have never seen any changes (founding member,
+ * brand-new document) all agree on the empty-set hash, so a quorum can be
+ * met cleanly in the bootstrapping case.
+ */
+
+/**
+ * 32-byte SHA-256 length, used by the hash function and by callers that
+ * need to validate wire-encoded tip-hash bytes.
+ */
+export const TIPS_HASH_LENGTH = 32;
+
+/**
+ * Compute the canonical tip-set hash for a document's set of known change
+ * CIDs (typically a peer's `_hashes` field).
+ *
+ * @param hashes The collection of tip CIDs. Accepts either a `Set<string>`
+ *   (the in-memory representation in `CollabswarmDocument._hashes`) or a
+ *   plain `string[]` (more convenient for tests).
+ * @returns A 32-byte `Uint8Array` containing the SHA-256 digest of the
+ *   canonicalized tip set.
+ */
+export async function tipsHash(
+  hashes: Set<string> | readonly string[],
+): Promise<Uint8Array> {
+  const sorted = Array.from(hashes).slice().sort();
+  // Use `\n` (0x0A) as a CID separator. Real CIDs are base32/base58/base64
+  // text and never contain raw `\n`, so this is unambiguous. Encoding the
+  // separator (rather than concatenating bytes directly) prevents two
+  // different tip sets from colliding via a shared boundary, e.g.
+  // `["ab", "c"]` vs `["a", "bc"]`.
+  const canonical = sorted.join('\n');
+  const encoded = new TextEncoder().encode(canonical);
+  // Cast required: `Uint8Array<ArrayBufferLike>` does not strictly satisfy
+  // WebCrypto's `BufferSource` (excludes `SharedArrayBuffer`-backed views).
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    encoded as Uint8Array<ArrayBuffer>,
+  );
+  return new Uint8Array(digest);
+}
+
+/**
+ * Encode a tips-hash byte array as a lowercase hex string. Used to key the
+ * agreement map in `decideLoadQuorum` and to log/diagnose hash mismatches.
+ *
+ * Mirrors the canonical encoding so two callers comparing serialized hashes
+ * over the wire always produce identical strings for identical inputs.
+ */
+export function tipsHashToHex(hash: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < hash.length; i++) {
+    out += hash[i].toString(16).padStart(2, '0');
+  }
+  return out;
+}

--- a/packages/collabswarm/src/tips-hash.ts
+++ b/packages/collabswarm/src/tips-hash.ts
@@ -36,34 +36,51 @@ export const TIPS_HASH_LENGTH = 32;
  * Compute the canonical tip-set hash for a document's set of known change
  * CIDs.
  *
- * # Input contract: pass the FRONTIER, NOT the full observed-CID set
+ * # Input contract: pass the SERVED FRONTIER, NOT `_hashes` or the local DAG frontier
  *
- * The caller **MUST** pass the canonical frontier (heads) of the local
- * change DAG -- the change-block CIDs that no other change in the local
- * DAG references as a parent or cross-link target. The reference
- * implementation is `CollabswarmDocument._currentFrontier()` in
- * `collabswarm-document.ts`, which computes this as `_hashes \
- * _referencedAncestors`.
+ * The caller **MUST** pass the **served frontier** -- the heads of the
+ * change tree the responder would actually ship in a `documentLoadV3`
+ * / `snapshotLoadV3` round. The reference implementation is
+ * `CollabswarmDocument._servedFrontier()` in `collabswarm-document.ts`,
+ * which computes this via `computeServedFrontier` over
+ * `_lastSyncMessage.changes` (the served tree) plus
+ * `_latestSnapshot?.lastChangeNodeCID` (the snapshot boundary, if any).
  *
- * Implementers **MUST NOT** pass the full set of observed/merged CIDs
- * (e.g. a peer's `_hashes` field directly). Two honest peers with the same
+ * # Why "served frontier" and not "current local frontier"?
+ *
+ * A peer's `_currentFrontier()` (`_hashes \ _referencedAncestors`) is the
+ * heads of EVERYTHING this peer has seen. That set is correct for "the
+ * logical state of my local document" but it is the WRONG input for
+ * `tipsHash` when used by the initial-load quorum protocol. The load
+ * response only carries ONE change tree (rooted at
+ * `_lastSyncMessage.changeId`); remote heads received via GossipSub but
+ * not yet cross-linked into a local change are in `_currentFrontier()`
+ * but NOT in the served payload. Hashing `_currentFrontier()` therefore
+ * advertises a frontier the responder cannot actually serve, and the
+ * loader's structural bind check
+ * (`computeServedFrontier(message.changes, ...)` over the received
+ * payload) hashes to a different value -- rejecting the honest peer.
+ * Round 8 of the PR #284 Copilot review caught this exact bug.
+ *
+ * # Implementer warning: do NOT hash `_hashes` directly
+ *
+ * Implementers **MUST NOT** hash the full set of observed/merged CIDs
+ * (e.g. the peer's entire `_hashes` set). Two honest peers with the same
  * logical document state can have different observed-CID sets when their
  * history depths differ (history compaction, snapshot-loads that don't
  * restore ancestor CIDs, different join times). Hashing the full set
- * causes those honest peers to produce different hashes and the
- * initial-load quorum gate (see `load-quorum.ts`) would never agree --
- * the load would fail for a state both peers actually share. Round 3 of
- * the PR #284 Copilot review caught this exact bug; the previous wording
- * of this docstring ("typically a peer's `_hashes`") was misleading and
- * has been corrected.
+ * would cause those honest peers to produce different hashes and the
+ * quorum gate (see `load-quorum.ts`) would never agree. Round 3 of the
+ * PR #284 Copilot review caught this earlier variant of the bug; the
+ * previous wording of this docstring ("typically a peer's `_hashes`")
+ * was misleading and has been corrected.
  *
- * Passing the frontier instead makes the hash deterministic across honest
- * peers with the same logical state regardless of differing pruning /
- * sync histories: two peers that have converged on the same CRDT state
- * always have the same frontier even if their internal merged-CID sets
- * differ.
+ * Passing the served frontier makes the hash deterministic across honest
+ * peers whose `_lastSyncMessage` / `_latestSnapshot` describe the same
+ * logical state -- regardless of differing pruning / sync histories or
+ * unrelated concurrent heads held only in their local DAG.
  *
- * @param hashes The canonical frontier (heads) of the local change DAG.
+ * @param hashes The served frontier (heads of the served change tree).
  *   Accepts either a `Set<string>` or a plain `string[]` (more convenient
  *   for tests). Order within the collection is irrelevant -- the
  *   implementation sorts lexicographically before hashing.

--- a/packages/collabswarm/src/tips-hash.ts
+++ b/packages/collabswarm/src/tips-hash.ts
@@ -34,13 +34,41 @@ export const TIPS_HASH_LENGTH = 32;
 
 /**
  * Compute the canonical tip-set hash for a document's set of known change
- * CIDs (typically a peer's `_hashes` field).
+ * CIDs.
  *
- * @param hashes The collection of tip CIDs. Accepts either a `Set<string>`
- *   (the in-memory representation in `CollabswarmDocument._hashes`) or a
- *   plain `string[]` (more convenient for tests).
+ * # Input contract: pass the FRONTIER, NOT the full observed-CID set
+ *
+ * The caller **MUST** pass the canonical frontier (heads) of the local
+ * change DAG -- the change-block CIDs that no other change in the local
+ * DAG references as a parent or cross-link target. The reference
+ * implementation is `CollabswarmDocument._currentFrontier()` in
+ * `collabswarm-document.ts`, which computes this as `_hashes \
+ * _referencedAncestors`.
+ *
+ * Implementers **MUST NOT** pass the full set of observed/merged CIDs
+ * (e.g. a peer's `_hashes` field directly). Two honest peers with the same
+ * logical document state can have different observed-CID sets when their
+ * history depths differ (history compaction, snapshot-loads that don't
+ * restore ancestor CIDs, different join times). Hashing the full set
+ * causes those honest peers to produce different hashes and the
+ * initial-load quorum gate (see `load-quorum.ts`) would never agree --
+ * the load would fail for a state both peers actually share. Round 3 of
+ * the PR #284 Copilot review caught this exact bug; the previous wording
+ * of this docstring ("typically a peer's `_hashes`") was misleading and
+ * has been corrected.
+ *
+ * Passing the frontier instead makes the hash deterministic across honest
+ * peers with the same logical state regardless of differing pruning /
+ * sync histories: two peers that have converged on the same CRDT state
+ * always have the same frontier even if their internal merged-CID sets
+ * differ.
+ *
+ * @param hashes The canonical frontier (heads) of the local change DAG.
+ *   Accepts either a `Set<string>` or a plain `string[]` (more convenient
+ *   for tests). Order within the collection is irrelevant -- the
+ *   implementation sorts lexicographically before hashing.
  * @returns A 32-byte `Uint8Array` containing the SHA-256 digest of the
- *   canonicalized tip set.
+ *   canonicalized frontier.
  */
 export async function tipsHash(
   hashes: Set<string> | readonly string[],

--- a/packages/collabswarm/src/wire-protocols.ts
+++ b/packages/collabswarm/src/wire-protocols.ts
@@ -40,13 +40,38 @@ export const snapshotLoadV3 = '/collabswarm/snapshot-load/3.0.0';
 //             sign just the document id and the responder can authorize
 //             via the standard ACL/signature check).
 //
-//   Response: empty payload (peer declines: unknown document, unauthorized,
-//             signing disabled-on-one-side mismatch, etc.) OR a serialized
-//             `CRDTSyncMessage` whose only populated payload field is
-//             `tipsHash` (plus `documentId` and optionally `signature`).
-//             The responder does NOT include `changes`, `snapshot`, or
-//             `keychainChanges` -- the heavy state transfer happens later
-//             via documentLoadV3/snapshotLoadV3 against an agreeing peer.
+//   Response: ONE of three wire shapes -- the loader's probe distinguishes
+//             them by the first-byte and length of the response:
+//
+//               (a) Empty payload (zero bytes) -- the responder declines
+//                   without disclosing whether the document exists: the
+//                   request was unauthorized, the request's documentId
+//                   did not match (signing-on-one-side mismatch), the
+//                   responder threw on serialization, etc. The loader
+//                   records this as a generic non-vote (`null` from the
+//                   probe). NOT used for the "I genuinely don't have
+//                   this document" case -- see (b).
+//
+//               (b) Single-byte `0xff` sentinel (UNKNOWN_DOC) -- the
+//                   responder has NO document registered for this path.
+//                   Distinguished from (a) so the loader can tally
+//                   disclaim votes alongside tip-hash votes via
+//                   `decideLoadQuorum` (see `load-quorum.ts`). The
+//                   sentinel is intentionally unauthenticated (no
+//                   per-doc keychain to sign/encrypt with); the quorum
+//                   gate's Q-Byzantine threshold defends against
+//                   lying-disclaim attacks AND tip-hash votes are
+//                   given precedence over disclaim votes so peers WITH
+//                   the document outvote unrelated peers in the same
+//                   mesh that don't. See PR #284 r16 / r19.
+//
+//               (c) Serialized + encrypted `CRDTSyncMessage` whose
+//                   only populated payload field is `tipsHash` (plus
+//                   `documentId` and optionally `signature`). The
+//                   responder does NOT include `changes`, `snapshot`,
+//                   or `keychainChanges` -- the heavy state transfer
+//                   happens later via documentLoadV3/snapshotLoadV3
+//                   against an agreeing peer.
 //
 // Layered on documentLoadV3's transport semantics, but on a separate
 // protocol id so a slow/malicious peer that serves bogus full loads cannot

--- a/packages/collabswarm/src/wire-protocols.ts
+++ b/packages/collabswarm/src/wire-protocols.ts
@@ -8,6 +8,36 @@ export const documentLoadV2 = '/collabswarm/doc-load/2.0.0';
 export const documentKeyUpdateV2 = '/collabswarm/key-update/2.0.0';
 export const snapshotLoadV2 = '/collabswarm/snapshot-load/2.0.0';
 
+// Tip-advertise v1: lightweight initial-load quorum probe.
+//
+// Closes the "no quorum protocol for verifying initial document state" gap
+// tracked under issue #189 §5.4 item 2 (also a bullet under #186). When a
+// node opens a document, it asks up to `loadQuorumK` peers in parallel for
+// a 32-byte SHA-256 digest of their current tip set (see `tips-hash.ts`)
+// and proceeds with a full document-load only if at least `loadQuorumQ`
+// peers agree on the same hash. This defends against a single malicious or
+// partitioned peer serving a stale/maliciously-crafted initial state.
+//
+// Wire format (request and response are length-delimited single frames):
+//
+//   Request:  serialized `CRDTLoadRequest` (same shape as documentLoadV2 --
+//             reuses the existing load-request serializer so a writer can
+//             sign just the document id and the responder can authorize
+//             via the standard ACL/signature check).
+//
+//   Response: empty payload (peer declines: unknown document, unauthorized,
+//             signing disabled-on-one-side mismatch, etc.) OR a serialized
+//             `CRDTSyncMessage` whose only populated payload field is
+//             `tipsHash` (plus `documentId` and optionally `signature`).
+//             The responder does NOT include `changes`, `snapshot`, or
+//             `keychainChanges` -- the heavy state transfer happens later
+//             via documentLoadV2/snapshotLoadV2 against an agreeing peer.
+//
+// Layered on documentLoadV2's transport semantics, but on a separate
+// protocol id so a slow/malicious peer that serves bogus full loads cannot
+// also cheaply poison every quorum vote at the same time.
+export const tipAdvertiseV1 = '/collabswarm/tip-advertise/1.0.0';
+
 // BeeKEM Welcome v1: onboards a new reader into a document. The inviting
 // writer sends a Welcome containing (a) the invitation epoch ID the
 // recipient should record so subsequent `since_invited` history filtering

--- a/packages/collabswarm/src/wire-protocols.ts
+++ b/packages/collabswarm/src/wire-protocols.ts
@@ -1,12 +1,27 @@
 export const bloomFilterUpdateV1 = '/collabswarm/bloom-index/1.0.0';
 
-// V2 doc-load, key-update, and snapshot-load handlers use a shared handler
-// model where a single handler serves all documents. The key-update wire
-// format prepends a length-prefixed document-path header so the shared
-// handler can route requests to the correct document.
-export const documentLoadV2 = '/collabswarm/doc-load/2.0.0';
+// V3 doc-load and snapshot-load handlers use a shared handler model where
+// a single handler serves all documents. They include an explicit `tips`
+// field in the SIGNED `CRDTSyncMessage` payload so the loader can bind the
+// served state to the responder's current frontier and complete the
+// initial-load quorum check (see `tipAdvertiseV1` and #189 §5.4.2).
+//
+// Why v3 (not "v2 with an extra optional field")? Including `tips` inside
+// the signed payload changes the bytes the signer authenticated. A
+// receiver whose serializer doesn't recognise `tips` would: (1) deserialize
+// the message dropping `tips`, (2) re-serialize for signature verification,
+// (3) get bytes that differ from what the sender signed -> signature check
+// fails. Versioning the protocol id forces incompatible peers to dial a
+// protocol they don't have a handler for and fail loudly instead of
+// silently dropping the binding. There are no live users of this project,
+// so we did NOT retain a v2 alias -- removing legacy handlers keeps the
+// codebase clean.
+//
+// `documentKeyUpdateV2` is intentionally NOT bumped: its wire shape is
+// unaffected by the load-quorum work (no `tips` field, no `tipsHash`).
+export const documentLoadV3 = '/collabswarm/doc-load/3.0.0';
 export const documentKeyUpdateV2 = '/collabswarm/key-update/2.0.0';
-export const snapshotLoadV2 = '/collabswarm/snapshot-load/2.0.0';
+export const snapshotLoadV3 = '/collabswarm/snapshot-load/3.0.0';
 
 // Tip-advertise v1: lightweight initial-load quorum probe.
 //
@@ -20,7 +35,7 @@ export const snapshotLoadV2 = '/collabswarm/snapshot-load/2.0.0';
 //
 // Wire format (request and response are length-delimited single frames):
 //
-//   Request:  serialized `CRDTLoadRequest` (same shape as documentLoadV2 --
+//   Request:  serialized `CRDTLoadRequest` (same shape as documentLoadV3 --
 //             reuses the existing load-request serializer so a writer can
 //             sign just the document id and the responder can authorize
 //             via the standard ACL/signature check).
@@ -31,9 +46,9 @@ export const snapshotLoadV2 = '/collabswarm/snapshot-load/2.0.0';
 //             `tipsHash` (plus `documentId` and optionally `signature`).
 //             The responder does NOT include `changes`, `snapshot`, or
 //             `keychainChanges` -- the heavy state transfer happens later
-//             via documentLoadV2/snapshotLoadV2 against an agreeing peer.
+//             via documentLoadV3/snapshotLoadV3 against an agreeing peer.
 //
-// Layered on documentLoadV2's transport semantics, but on a separate
+// Layered on documentLoadV3's transport semantics, but on a separate
 // protocol id so a slow/malicious peer that serves bogus full loads cannot
 // also cheaply poison every quorum vote at the same time.
 export const tipAdvertiseV1 = '/collabswarm/tip-advertise/1.0.0';


### PR DESCRIPTION
## Summary

Closes the "no quorum protocol for verifying initial document state" gap tracked under issue #189 §5.4 item 2 (also bulleted in #186). Today, when a node opens a document, `CollabswarmDocument._sendLoadRequestAndSync` asks **one** peer for the document state and trusts the response. A single malicious or partitioned peer can serve a stale or maliciously-crafted state and the loader has no way to detect it.

This PR adds a K-of-Q quorum gate on top of the existing load flow:

1. Loader queries up to **K** peers in parallel via a new lightweight `tipAdvertiseV1` protocol for a 32-byte SHA-256 hash of their tip set.
2. Loader runs a pure quorum decision (`load-quorum.ts`) requiring **Q** peers to agree on the same tip hash.
3. If quorum passes, the loader narrows the candidate set to agreeing peers and proceeds with the existing snapshot-/doc-load flow.
4. If quorum fails, `load()` throws `LoadQuorumFailedError` so the application can catch the failure and recover.

The Welcome flow is untouched (writer signature + recipient binding already cover its integrity); the gate applies only to documentLoadV3/snapshotLoadV3 initial state transfer (v2 was dropped to keep the wire format clean — see "Wire format" below).

## Design

- **`tips-hash.ts`** — Deterministic `SHA-256(sorted CID list joined by '\n')`. Same view → byte-identical hash across peers.
- **`load-quorum.ts`** — Pure decision logic. Timeouts/declines (`null`) are **non-votes, NOT disagreements** so stale peer caches do not flip a partition into a Byzantine-failure verdict. `effectiveK`/`effectiveQ` clamp to safe ranges.
- **`tipAdvertiseV1`** (`/collabswarm/tip-advertise/1.0.0`) — Separate protocol from documentLoadV3 so a malicious peer can't cheaply poison both votes on one dial. Reuses existing `CRDTLoadRequest` / `CRDTSyncMessage` serializers; response carries only `tipsHash` + `documentId` + `signature`.
- **`CRDTSyncMessage.tipsHash?: Uint8Array`** — base64-encoded on the JSON wire by the yjs and automerge serializers, same pattern as the recently-added `welcomeEpochId` field.
- **Edge cases:**
  - Solo / founding-member flow — the empty-`_hashes` bypass has been REMOVED; the gate now runs uniformly on every load. New-document creation in an EXISTING swarm is surfaced via the new `unknown-doc` probe sentinel: each peer that does not hold the document responds with a 1-byte UNKNOWN_DOC marker, `decideLoadQuorum` tallies these alongside tip-hash votes, and a Q-of-K majority of disclaims surfaces as `{ newDoc: true }` so `load()` returns `false` and `open()` creates the document fresh. True founders (no peers in the mesh) are handled by the `peers.length === 0` short-circuit at the top of `load()`. Solo / dev-only flows can opt out via `loadQuorumEnabled: false` or set `loadQuorumAllowSinglePeer: true`. See PR #284 r16 / r21 reviews.
  - K=1 with `loadQuorumAllowSinglePeer: true` — single-peer pass-through with a loud warning that trust is degraded.
  - K=1 with `loadQuorumAllowSinglePeer: false` (default) — throw `LoadQuorumFailedError`.
  - Unknown encryption key / failed signature / doc-id mismatch / short hash — recorded as non-vote.

## Config knobs (`CollabswarmConfig`)

| Field | Default | Notes |
|---|---|---|
| `loadQuorumEnabled` | `true` | Master toggle. `false` reverts to legacy single-peer load. |
| `loadQuorumK` | `3` | Max peers queried in parallel. Clamped to `min(K, knownPeers)`. |
| `loadQuorumQ` | `floor(effectiveK / 2) + 1` | Strict-majority BFT threshold (e.g. effectiveK=3 -> Q=2, tolerating one fault). Default derives from EFFECTIVE K (clamped against reachable peer count), not configured K. Clamped to `[1, effectiveK]`. |
| `loadQuorumTimeoutMs` | `5000` | Per-peer probe timeout. |
| `loadQuorumAllowSinglePeer` | `false` | Required to pass the gate in a 1-peer mesh. |

Defaults give defence against a single dishonest peer (Q=2 majority of K=3) without fanning out enough requests to noticeably impact open latency.

## Wire format

- **Aggressive break**: `documentLoadV2` / `snapshotLoadV2` removed entirely; replaced by `documentLoadV3` / `snapshotLoadV3` so the new mandatory `tips`-bound signed payload is unambiguous on the wire. `documentKeyUpdateV2` is unchanged. No live users, so no migration shim is provided.
- Added optional `tipsHash` field to `CRDTSyncMessage`. Existing peers ignore it; new peers tolerate its absence on regular sync traffic.

## Files

New:
- `packages/collabswarm/src/tips-hash.ts` (+ tests)
- `packages/collabswarm/src/load-quorum.ts` (+ tests, exports `LoadQuorumFailedError`)

Modified:
- `packages/collabswarm/src/collabswarm-document.ts` — wire the gate into `load()`, add `handleTipAdvertiseRequestData`, `_probeTipAdvertise`, `_raceTipAdvertiseProbe`, `_peerIdOf` helpers
- `packages/collabswarm/src/collabswarm.ts` — register the shared `tipAdvertiseV1` handler
- `packages/collabswarm/src/crdt-sync-message.ts` — add `tipsHash?: Uint8Array`
- `packages/collabswarm/src/collabswarm-config.ts` — five new config knobs
- `packages/collabswarm/src/wire-protocols.ts` — `tipAdvertiseV1`
- `packages/collabswarm/src/index.ts` — barrel exports
- `packages/collabswarm-yjs/src/collabswarm-yjs.ts` + test — base64 wire encoding for `tipsHash`
- `packages/collabswarm-automerge/src/collabswarm-automerge.ts` + test — base64 wire encoding for `tipsHash`

## Test plan

- [x] `yarn workspace @collabswarm/collabswarm test` — 508 / 508 passing (35 new tests: 20 in tips-hash, 15 in load-quorum)
- [x] `yarn workspace @collabswarm/collabswarm-yjs test` — 72 / 72 passing (3 new tipsHash round-trip tests)
- [x] `yarn workspace @collabswarm/collabswarm-automerge test` — 57 / 57 passing (3 new tipsHash round-trip tests)
- [x] `yarn tsc` clean in all three workspaces
- [ ] e2e/integration suite — relay-mediated browser tests not exercised in this PR; the test-app does not directly call `swarm.doc(path).open()`, so the gate does not affect the existing peer-discovery/sync flows. If the e2e test-app is later wired to open documents through `Collabswarm`, it should either run with `loadQuorumK: 2` against a 2-browser + 1-relay topology, or set `loadQuorumEnabled: false` for dev-only scenarios.

## Conflict-awareness with PR #281 (BeeKEM Welcome payload encryption)

This PR is branched off current `main`. PR #281's Welcome-flow edits live in a different region of `collabswarm-document.ts` (~lines 2900-3500, vs. the load-flow region around ~2100-2400 touched here). Same approach for `crdt-sync-message.ts`, `collabswarm-config.ts`, `wire-protocols.ts`, and the yjs/automerge serializers: new fields added **alongside** existing ones, no renames or restructures. The rebase should be straightforward when #281 lands.

Closes #189 (item 2: initial-load quorum protocol). Partial credit on #186 (one of the listed security gaps).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Initial-load quorum gating with configurable K/Q/timeouts, a lightweight tip-advertise probe, quorum orchestration APIs, and verifiable tip-set hashing/hex utilities.

* **Bug Fixes / Reliability**
  * Stronger validation and defensive handling of optional quorum fields in sync messages, enforced load-response bind checks, and upgraded v3 load protocol semantics.

* **Tests**
  * Broad new coverage for quorum math, orchestration, hash binding, serialization, and frontier collection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/swarmbase/swarmbase/pull/284)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

