### PR TITLE
Add cookbook recipes

### DIFF
--- a/site/src/content/docs/cookbook/collaborative-wiki.md
+++ b/site/src/content/docs/cookbook/collaborative-wiki.md
@@ -1,6 +1,213 @@
 ---
 title: Build a collaborative wiki
-description: A real-time wiki with shared editable articles.
+description: Model, open, render, and edit shared wiki articles with Swarmbase and Yjs.
 ---
 
-This page is being written. Until it lands, the [GitHub repository](https://github.com/swarmbase/swarmbase) is the best source.
+You want a wiki where every article is editable by multiple people at once, keeps working offline, and syncs peer-to-peer without a central database. Each article should merge concurrent edits at the character level instead of losing them. This recipe builds that on Swarmbase's golden-path stack: Yjs documents plus the React hooks.
+
+:::note
+The in-repo example this recipe is based on (`examples/wiki-swarm`) uses the Redux integration and the Automerge CRDT backend. This recipe shows the same application shape on the Yjs + React hooks stack, which is the recommended path. If you prefer Redux, see [Redux integration](../redux/).
+:::
+
+## Install
+
+```sh
+npm install @swarmbase/collabswarm @swarmbase/collabswarm-yjs @swarmbase/collabswarm-react yjs quill-delta
+```
+
+## Model the documents
+
+Each article is its own Swarmbase document (its own `Y.Doc`), opened lazily by path. Article metadata goes in a `Y.Map` (last-writer-wins per key), body text in a `Y.Text` (character-level merge), and tags in a `Y.Map<boolean>` used as an add-wins set:
+
+```typescript
+import * as Y from 'yjs';
+
+// Shape of the Y.Doc at /articles/<id> — enforced by convention, not schema.
+// title:   Y.Text  — short, but still merged character-by-character
+// content: Y.Text  — article body (character-level merge)
+// meta:    Y.Map   — updatedBy, updatedAt (LWW per key)
+// tags:    Y.Map<boolean> — add-wins set
+function readArticle(doc: Y.Doc) {
+  return {
+    title: doc.getText('title'),
+    content: doc.getText('content'),
+    meta: doc.getMap('meta'),
+    tags: doc.getMap<boolean>('tags'),
+  };
+}
+```
+
+See [Yjs schema design](../yjs-schema-design/) for why each field uses the type it does.
+
+## Set up the swarm
+
+Providers are created once at module level. The `useCollabswarm` hook constructs and initializes the swarm when a keypair is available, and `CollabswarmContext.Provider` supplies the shared document caches the document hooks need:
+
+```tsx
+// App.tsx
+import React from 'react';
+import {
+  CollabswarmDocument,
+  SubtleCrypto,
+  defaultConfig,
+  defaultBootstrapConfig,
+} from '@swarmbase/collabswarm';
+import {
+  YjsProvider,
+  YjsJSONSerializer,
+  YjsACLProvider,
+  YjsKeychainProvider,
+} from '@swarmbase/collabswarm-yjs';
+import {
+  CollabswarmContext,
+  useCollabswarm,
+} from '@swarmbase/collabswarm-react';
+import { WikiArticle } from './WikiArticle';
+
+const crdt = new YjsProvider();
+const serializer = new YjsJSONSerializer();
+const auth = new SubtleCrypto();
+const acl = new YjsACLProvider();
+const keychain = new YjsKeychainProvider();
+
+export default function App() {
+  const [privateKey, setPrivateKey] = React.useState<CryptoKey | undefined>();
+  const [publicKey, setPublicKey] = React.useState<CryptoKey | undefined>();
+
+  // Shared caches used by useCollabswarmDocumentState.
+  const [docCache, setDocCache] = React.useState<{
+    [docPath: string]: CollabswarmDocument<any, any, any, any, any, any>;
+  }>({});
+  const [docDataCache, setDocDataCache] = React.useState<{ [docPath: string]: any }>({});
+  const [docReadersCache, setDocReadersCache] = React.useState<{ [docPath: string]: any[] }>({});
+  const [docWritersCache, setDocWritersCache] = React.useState<{ [docPath: string]: any[] }>({});
+
+  // Your identity is a WebCrypto keypair. Generate one on first run.
+  React.useEffect(() => {
+    (async () => {
+      const keypair = await crypto.subtle.generateKey(
+        { name: 'ECDSA', namedCurve: 'P-384' },
+        true,
+        ['sign', 'verify'],
+      );
+      setPrivateKey(keypair.privateKey);
+      setPublicKey(keypair.publicKey);
+    })();
+  }, []);
+
+  // Bootstrap through your relay (see the relay recipe).
+  const relayAddr = process.env.REACT_APP_RELAY_MULTIADDR;
+  const config = defaultConfig(defaultBootstrapConfig(relayAddr ? [relayAddr] : []));
+
+  const collabswarm = useCollabswarm(
+    privateKey,
+    publicKey,
+    crdt,
+    serializer,
+    serializer,
+    serializer,
+    auth,
+    acl,
+    keychain,
+    config,
+  );
+
+  return (
+    <CollabswarmContext.Provider
+      value={{
+        docCache, docDataCache, docReadersCache, docWritersCache,
+        setDocCache, setDocDataCache, setDocReadersCache, setDocWritersCache,
+      }}
+    >
+      {collabswarm
+        ? <WikiArticle collabswarm={collabswarm} articleId="getting-started" />
+        : <p>Connecting…</p>}
+    </CollabswarmContext.Provider>
+  );
+}
+```
+
+## Open, render, and edit an article
+
+`useCollabswarmDocumentState` opens the document at a path, subscribes to changes, and returns the current `Y.Doc` plus a change function. Text edits are applied as Quill deltas so concurrent edits merge instead of overwriting each other:
+
+```tsx
+// WikiArticle.tsx
+import React from 'react';
+import * as Y from 'yjs';
+import Delta from 'quill-delta';
+import { Collabswarm } from '@swarmbase/collabswarm';
+import { useCollabswarmDocumentState } from '@swarmbase/collabswarm-react';
+
+export type YjsCollabswarm = Collabswarm<
+  Y.Doc,
+  Uint8Array,
+  (doc: Y.Doc) => void,
+  CryptoKey,
+  CryptoKey,
+  CryptoKey
+>;
+
+export function WikiArticle({
+  collabswarm,
+  articleId,
+}: {
+  collabswarm: YjsCollabswarm;
+  articleId: string;
+}) {
+  const [article, changeArticle] = useCollabswarmDocumentState(
+    collabswarm,
+    `/articles/${articleId}`,
+  );
+
+  if (!article) {
+    // Document is still opening (or being fetched from peers).
+    return <p>Loading article…</p>;
+  }
+
+  const title = article.getText('title').toString();
+  const content = article.getText('content').toString();
+
+  // Convert a full-string edit into character-level operations so
+  // concurrent edits from other peers are preserved.
+  const editText = (field: string, previous: string, next: string) => {
+    const diff = new Delta().insert(previous).diff(new Delta().insert(next));
+    changeArticle((doc: Y.Doc) => {
+      doc.getText(field).applyDelta(diff.ops);
+      doc.getMap('meta').set('updatedAt', Date.now());
+    });
+  };
+
+  return (
+    <div>
+      <input
+        value={title}
+        placeholder="Article title"
+        onChange={(e) => editText('title', title, e.target.value)}
+      />
+      <textarea
+        value={content}
+        placeholder="Write something…"
+        onChange={(e) => editText('content', content, e.target.value)}
+      />
+    </div>
+  );
+}
+```
+
+## How it works
+
+- `useCollabswarm` constructs a `Collabswarm` node and calls `initialize(config)` once you have a keypair. The node joins the libp2p swarm through your bootstrap relay.
+- `useCollabswarmDocumentState` calls `collabswarm.doc(path)` and `open()` on first use, then `subscribe()`s. When any peer changes the document, the hook updates the shared cache and your component re-renders.
+- `changeArticle(fn)` runs your function against the live `Y.Doc`; Swarmbase encodes the resulting Yjs update, signs it, encrypts it with the document key, and broadcasts it to peers.
+- If `open()` finds no existing document on the network, the path is treated as a brand-new document — creating an article is just opening a path nobody has used yet.
+
+For a multi-article wiki, keep one *index document* (for example `/articles-index`) holding a `Y.Map` of `articleId → title`, and update it whenever an article's title changes — the same pattern the password manager recipe uses for its secrets list.
+
+## Pitfalls
+
+- **Don't assign whole strings to text fields.** Replacing a title with a fresh value (rather than applying a delta diff) is last-writer-wins on the whole field and silently drops concurrent edits. The delta-diff pattern above is the production-safe approach.
+- **The document is `undefined` while opening.** Opening involves a network round-trip to peers. Always render a loading state; don't assume the doc exists on first render.
+- **One document per article, not one document for the wiki.** A single `Y.Doc` holding every article grows without bound (Yjs tombstones are permanent), loads eagerly, and shares a single ACL and encryption key. Split at entity and access-control boundaries.
+- **Two tabs are two peers.** Each browser tab runs its own node with its own storage. That's a feature for testing merge behavior — open the same article path in two windows and type in both.
+- **Alpha software.** Data exists only while some peer holds it. If every browser that opened an article clears its storage, the article is gone — run a pinning node for anything you care about (see [Keeping data alive](../pinning/)).

--- a/site/src/content/docs/cookbook/collaborative-wiki.md
+++ b/site/src/content/docs/cookbook/collaborative-wiki.md
@@ -1,213 +1,66 @@
 ---
 title: Build a collaborative wiki
-description: Model, open, render, and edit shared wiki articles with Swarmbase and Yjs.
+description: Run and assess the repository's Vite, Redux, and Automerge wiki example.
 ---
 
-You want a wiki where every article is editable by multiple people at once, keeps working offline, and syncs peer-to-peer without a central database. Each article should merge concurrent edits at the character level instead of losing them. This recipe builds that on Swarmbase's golden-path stack: Yjs documents plus the React hooks.
+**Status: Runnable from source (single-browser startup smoke only).**
 
-:::note
-The in-repo example this recipe is based on (`examples/wiki-swarm`) uses the Redux integration and the Automerge CRDT backend. This recipe shows the same application shape on the Yjs + React hooks stack, which is the recommended path. If you prefer Redux, see [Redux integration](../redux/).
-:::
+The current wiki is [`examples/wiki-swarm`](https://github.com/swarmbase/swarmbase/tree/main/examples/wiki-swarm): a Vite application using Redux and Automerge. Its production build and strict Chromium startup smoke test pass. This evidence does **not** prove article mutation, two-browser synchronization, convergence, restart recovery, or a multi-user Yjs application. See [Limitations](../../concepts/limitations/).
 
-## Install
+The workspace packages are unpublished. Work from a repository checkout with Node.js 22.19.0 and the locked dependencies installed as described in the [quick start](../../getting-started/quick-start/).
+
+## Run and verify the source example
+
+From the repository root:
 
 ```sh
-npm install @swarmbase/collabswarm @swarmbase/collabswarm-yjs @swarmbase/collabswarm-react yjs quill-delta
+yarn build
+yarn workspace @swarmbase/wiki-swarm start
 ```
 
-## Model the documents
+Vite prints the local URL. To build without starting a server:
 
-Each article is its own Swarmbase document (its own `Y.Doc`), opened lazily by path. Article metadata goes in a `Y.Map` (last-writer-wins per key), body text in a `Y.Text` (character-level merge), and tags in a `Y.Map<boolean>` used as an add-wins set:
-
-```typescript
-import * as Y from 'yjs';
-
-// Shape of the Y.Doc at /articles/<id> — enforced by convention, not schema.
-// title:   Y.Text  — short, but still merged character-by-character
-// content: Y.Text  — article body (character-level merge)
-// meta:    Y.Map   — updatedBy, updatedAt (LWW per key)
-// tags:    Y.Map<boolean> — add-wins set
-function readArticle(doc: Y.Doc) {
-  return {
-    title: doc.getText('title'),
-    content: doc.getText('content'),
-    meta: doc.getMap('meta'),
-    tags: doc.getMap<boolean>('tags'),
-  };
-}
+```sh
+yarn workspace @swarmbase/wiki-swarm build
 ```
 
-See [Yjs schema design](../yjs-schema-design/) for why each field uses the type it does.
+To run the exact application smoke path:
 
-## Set up the swarm
-
-Providers are created once at module level. The `useCollabswarm` hook constructs and initializes the swarm when a keypair is available, and `CollabswarmContext.Provider` supplies the shared document caches the document hooks need:
-
-```tsx
-// App.tsx
-import React from 'react';
-import {
-  CollabswarmDocument,
-  SubtleCrypto,
-  defaultConfig,
-  defaultBootstrapConfig,
-} from '@swarmbase/collabswarm';
-import {
-  YjsProvider,
-  YjsJSONSerializer,
-  YjsACLProvider,
-  YjsKeychainProvider,
-} from '@swarmbase/collabswarm-yjs';
-import {
-  CollabswarmContext,
-  useCollabswarm,
-} from '@swarmbase/collabswarm-react';
-import { WikiArticle } from './WikiArticle';
-
-const crdt = new YjsProvider();
-const serializer = new YjsJSONSerializer();
-const auth = new SubtleCrypto();
-const acl = new YjsACLProvider();
-const keychain = new YjsKeychainProvider();
-
-export default function App() {
-  const [privateKey, setPrivateKey] = React.useState<CryptoKey | undefined>();
-  const [publicKey, setPublicKey] = React.useState<CryptoKey | undefined>();
-
-  // Shared caches used by useCollabswarmDocumentState.
-  const [docCache, setDocCache] = React.useState<{
-    [docPath: string]: CollabswarmDocument<any, any, any, any, any, any>;
-  }>({});
-  const [docDataCache, setDocDataCache] = React.useState<{ [docPath: string]: any }>({});
-  const [docReadersCache, setDocReadersCache] = React.useState<{ [docPath: string]: any[] }>({});
-  const [docWritersCache, setDocWritersCache] = React.useState<{ [docPath: string]: any[] }>({});
-
-  // Your identity is a WebCrypto keypair. Generate one on first run.
-  React.useEffect(() => {
-    (async () => {
-      const keypair = await crypto.subtle.generateKey(
-        { name: 'ECDSA', namedCurve: 'P-384' },
-        true,
-        ['sign', 'verify'],
-      );
-      setPrivateKey(keypair.privateKey);
-      setPublicKey(keypair.publicKey);
-    })();
-  }, []);
-
-  // Bootstrap through your relay (see the relay recipe).
-  const relayAddr = process.env.REACT_APP_RELAY_MULTIADDR;
-  const config = defaultConfig(defaultBootstrapConfig(relayAddr ? [relayAddr] : []));
-
-  const collabswarm = useCollabswarm(
-    privateKey,
-    publicKey,
-    crdt,
-    serializer,
-    serializer,
-    serializer,
-    auth,
-    acl,
-    keychain,
-    config,
-  );
-
-  return (
-    <CollabswarmContext.Provider
-      value={{
-        docCache, docDataCache, docReadersCache, docWritersCache,
-        setDocCache, setDocDataCache, setDocReadersCache, setDocWritersCache,
-      }}
-    >
-      {collabswarm
-        ? <WikiArticle collabswarm={collabswarm} articleId="getting-started" />
-        : <p>Connecting…</p>}
-    </CollabswarmContext.Provider>
-  );
-}
+```sh
+yarn exec playwright install chromium
+yarn test:e2e:wiki-swarm
 ```
 
-## Open, render, and edit an article
+The last command builds the wiki and checks that it starts in Chromium without browser runtime errors. It is not a collaboration test.
 
-`useCollabswarmDocumentState` opens the document at a path, subscribes to changes, and returns the current `Y.Doc` plus a change function. Text edits are applied as Quill deltas so concurrent edits merge instead of overwriting each other:
+## Relay configuration
 
-```tsx
-// WikiArticle.tsx
-import React from 'react';
-import * as Y from 'yjs';
-import Delta from 'quill-delta';
-import { Collabswarm } from '@swarmbase/collabswarm';
-import { useCollabswarmDocumentState } from '@swarmbase/collabswarm-react';
+The example reads a browser-safe Vite variable:
 
-export type YjsCollabswarm = Collabswarm<
-  Y.Doc,
-  Uint8Array,
-  (doc: Y.Doc) => void,
-  CryptoKey,
-  CryptoKey,
-  CryptoKey
->;
-
-export function WikiArticle({
-  collabswarm,
-  articleId,
-}: {
-  collabswarm: YjsCollabswarm;
-  articleId: string;
-}) {
-  const [article, changeArticle] = useCollabswarmDocumentState(
-    collabswarm,
-    `/articles/${articleId}`,
-  );
-
-  if (!article) {
-    // Document is still opening (or being fetched from peers).
-    return <p>Loading article…</p>;
-  }
-
-  const title = article.getText('title').toString();
-  const content = article.getText('content').toString();
-
-  // Convert a full-string edit into character-level operations so
-  // concurrent edits from other peers are preserved.
-  const editText = (field: string, previous: string, next: string) => {
-    const diff = new Delta().insert(previous).diff(new Delta().insert(next));
-    changeArticle((doc: Y.Doc) => {
-      doc.getText(field).applyDelta(diff.ops);
-      doc.getMap('meta').set('updatedAt', Date.now());
-    });
-  };
-
-  return (
-    <div>
-      <input
-        value={title}
-        placeholder="Article title"
-        onChange={(e) => editText('title', title, e.target.value)}
-      />
-      <textarea
-        value={content}
-        placeholder="Write something…"
-        onChange={(e) => editText('content', content, e.target.value)}
-      />
-    </div>
-  );
-}
+```sh
+VITE_RELAY_MULTIADDR='/dns4/relay.example.com/tcp/443/wss/p2p/12D3KooW...' \
+  yarn workspace @swarmbase/wiki-swarm start
 ```
 
-## How it works
+Use the public, dialable multiaddr from [Run your own relay](../running-a-relay/), not a `0.0.0.0` listen address. A relay helps browser peers discover and reach one another; it does not store wiki data durably.
 
-- `useCollabswarm` constructs a `Collabswarm` node and calls `initialize(config)` once you have a keypair. The node joins the libp2p swarm through your bootstrap relay.
-- `useCollabswarmDocumentState` calls `collabswarm.doc(path)` and `open()` on first use, then `subscribe()`s. When any peer changes the document, the hook updates the shared cache and your component re-renders.
-- `changeArticle(fn)` runs your function against the live `Y.Doc`; Swarmbase encodes the resulting Yjs update, signs it, encrypts it with the document key, and broadcasts it to peers.
-- If `open()` finds no existing document on the network, the path is treated as a brand-new document — creating an article is just opening a path nobody has used yet.
+## What the example demonstrates
 
-For a multi-article wiki, keep one *index document* (for example `/articles-index`) holding a `Y.Map` of `articleId → title`, and update it whenever an article's title changes — the same pattern the password manager recipe uses for its secrets list.
+- Vite can bundle the Automerge WASM application.
+- The current Redux reducer/provider stack initializes far enough to render the wiki shell.
+- The source maps a route document ID to one Automerge document, but the smoke test does not open or mutate an article.
+- Title, Slate content, metadata, and ACL display are application-level patterns.
 
-## Pitfalls
+The example must use one **stable, application-persisted ECDSA P-384 signing identity** across reloads. Generating a new key pair on each mount creates a new ACL identity and is not an account or recovery flow. Signing identity, KEM identity, document keys, and libp2p peer identity are distinct; see [Security](../../concepts/security/).
 
-- **Don't assign whole strings to text fields.** Replacing a title with a fresh value (rather than applying a delta diff) is last-writer-wins on the whole field and silently drops concurrent edits. The delta-diff pattern above is the production-safe approach.
-- **The document is `undefined` while opening.** Opening involves a network round-trip to peers. Always render a loading state; don't assume the doc exists on first render.
-- **One document per article, not one document for the wiki.** A single `Y.Doc` holding every article grows without bound (Yjs tombstones are permanent), loads eagerly, and shares a single ACL and encryption key. Split at entity and access-control boundaries.
-- **Two tabs are two peers.** Each browser tab runs its own node with its own storage. That's a feature for testing merge behavior — open the same article path in two windows and type in both.
-- **Alpha software.** Data exists only while some peer holds it. If every browser that opened an article clears its storage, the article is gone — run a pinning node for anything you care about (see [Keeping data alive](../pinning/)).
+## Multi-user work still required
+
+**Status: Deferred/incomplete integration.** The wiki has no automatic invitation, identity directory, key exchange, or account recovery. Sharing an article path or signing public key does not transfer its document key. A real invitation flow must authenticate the recipient out of band, exchange the recipient's signing and P-256 ECDH KEM public keys, persist both parties' key material, and exercise the core onboarding APIs described in the [password-manager recipe](../password-manager/).
+
+Do not describe full-string or editor-state replacement as a production-safe collaborative delta strategy. The current smoke test does not assert concurrent editor behavior. If adapting the design to Yjs, choose shared types and operations deliberately; see [Designing Yjs schemas](../yjs-schema-design/).
+
+## Application design cautions
+
+A wiki commonly uses one article document plus a separate article-index document. Updating both is a dual write: Swarmbase does not provide a transaction spanning documents, so one update can succeed while the other rejects. Make index repair and reconciliation explicit.
+
+Do not infer durability from content-addressed blocks or recommend pinning as an available fix. The current pinning path is incomplete; retained blocks alone also omit identity, keys, graph state, and recovery metadata. See [Storage](../../concepts/storage/) and [Keeping data alive](../pinning/).

--- a/site/src/content/docs/cookbook/password-manager.md
+++ b/site/src/content/docs/cookbook/password-manager.md
@@ -1,6 +1,168 @@
 ---
-title: Build a shared password manager
-description: End-to-end encrypted secrets shared between devices and people.
+title: Encrypted shared secrets store
+description: Build a password manager where secrets are end-to-end encrypted and shared per-document via ACLs.
 ---
 
-This page is being written. Until it lands, the [GitHub repository](https://github.com/swarmbase/swarmbase) is the best source.
+You want to store passwords and share individual ones with specific people — without any server ever being able to read them. With Swarmbase every document is end-to-end encrypted with its own key, and access is controlled by a per-document ACL of public keys, so "share this one password with Bob" is a first-class operation rather than a server-side permission check you have to trust. This recipe follows the `examples/password-manager` app in the repository.
+
+## Why E2E encryption matters here
+
+Secrets travel through relay servers and other peers you don't control. In Swarmbase, change payloads are AES-GCM-encrypted with a per-document symmetric key managed by the document keychain, and signed with the author's key. Relays and non-member peers forward and store ciphertext only. Removing a reader rotates the document key, so *future* changes are unreadable to them (see Pitfalls for what rotation cannot do).
+
+## Identity is a keypair
+
+There are no accounts. A user *is* an ECDSA P-384 WebCrypto keypair. Generate one on first login and let the user save it — losing the private key means losing access:
+
+```typescript
+// login.ts — from examples/password-manager/src/Login.tsx and utils.ts
+export async function generateIdentity() {
+  const keypair = await crypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-384' },
+    true,
+    ['sign', 'verify'],
+  );
+  return keypair;
+}
+
+// Persist / restore keys as JWK strings so the user can keep them.
+export async function exportKey(key: CryptoKey): Promise<string> {
+  const jwk = await crypto.subtle.exportKey('jwk', key);
+  return JSON.stringify(jwk);
+}
+
+export async function importKey(
+  keyData: string,
+  keyUsage: KeyUsage[], // ['sign'] for private, ['verify'] for public
+): Promise<CryptoKey> {
+  const jwk = JSON.parse(keyData) as JsonWebKey;
+  return await crypto.subtle.importKey(
+    'jwk',
+    jwk,
+    { name: 'ECDSA', namedCurve: 'P-384' },
+    true,
+    keyUsage,
+  );
+}
+```
+
+The swarm setup (providers, `useCollabswarm`, `CollabswarmContext.Provider`) is identical to the [collaborative wiki recipe](../collaborative-wiki/) — the password manager example passes `YjsProvider`, `YjsJSONSerializer` (three times: changes, sync, and load serializer), `SubtleCrypto`, `YjsACLProvider`, and `YjsKeychainProvider` to `useCollabswarm`.
+
+## A private index plus one document per secret
+
+Each secret lives in its own document at `/passwords/<uuid>` so it can be shared individually. A per-user index document lists the secrets you know about:
+
+```tsx
+// PasswordList.tsx (condensed from examples/password-manager/src/PasswordList.tsx)
+import React from 'react';
+import * as Y from 'yjs';
+import * as uuid from 'uuid';
+import { useCollabswarmDocumentState } from '@swarmbase/collabswarm-react';
+import { YjsCollabswarm } from './utils';
+
+export function PasswordList({
+  userId,
+  collabswarm,
+}: {
+  userId: string;
+  collabswarm: YjsCollabswarm;
+}) {
+  const [passwords, changePasswords] = useCollabswarmDocumentState(
+    collabswarm,
+    `/${userId}/passwords-index`,
+  );
+
+  const addSecret = () => {
+    changePasswords((current: Y.Doc) => {
+      current.getArray<Y.Map<Y.Text>>('passwords').push([
+        new Y.Map<Y.Text>(
+          Object.entries({
+            id: new Y.Text(uuid.v4()),
+          }),
+        ),
+      ]);
+    });
+  };
+
+  return (
+    <ul>
+      {passwords &&
+        passwords.getArray<Y.Map<Y.Text>>('passwords').map((password) => {
+          const id = password.get('id')?.toString();
+          const name = password.get('name')?.toString();
+          return <li key={id}>{name || `Unnamed Secret (id: ${id})`}</li>;
+        })}
+      <li>
+        <button onClick={addSecret}>New Secret</button>
+      </li>
+    </ul>
+  );
+}
+```
+
+Editing a secret's value applies a character-level delta so concurrent edits merge (see the wiki recipe for the same pattern):
+
+```tsx
+// PasswordEditor.tsx (condensed)
+import Delta from 'quill-delta';
+import * as Y from 'yjs';
+
+const [doc, changeDoc] = useCollabswarmDocumentState(
+  collabswarm,
+  `/passwords/${passwordId}`,
+);
+const value = doc && doc.getText('value').toString();
+
+// In the input's onChange:
+const a = new Delta().insert(value || '');
+const b = new Delta().insert(e.target.value);
+const diff = a.diff(b);
+changeDoc((current: Y.Doc) => {
+  current.getText('value').applyDelta(diff.ops);
+});
+```
+
+## Share a secret with the ACL
+
+The third element of the `useCollabswarmDocumentState` tuple exposes the document's ACL. To share, a teammate copies their serialized public key to you (out of band); you deserialize it and add them as a reader (decrypt) or writer (decrypt + edit):
+
+```tsx
+// PermissionsTable.tsx (condensed from examples/password-manager/src/PermissionsTable.tsx)
+import { useCollabswarmDocumentState } from '@swarmbase/collabswarm-react';
+import { deserializeKey, serializeKey } from '@swarmbase/collabswarm-yjs';
+
+const [, , { readers, addReader, removeReader, writers, addWriter, removeWriter }] =
+  useCollabswarmDocumentState(collabswarm, `/passwords/${passwordId}`);
+
+// Add a collaborator from their pasted public key:
+const key = await deserializeKey(
+  { name: 'ECDSA', namedCurve: 'P-384' },
+  ['verify'],
+)(pastedPublicKey);
+
+await addReader(key);   // read-only: can decrypt
+// or
+await addWriter(key);   // read/write: can decrypt and author changes
+
+// Revoke:
+await removeReader(key); // rotates the document key for future changes
+
+// Display keys in the UI:
+const shortId = await serializeKey(someReaderKey); // base64 of the raw public key
+```
+
+Users find their own shareable public key the same way: `serializeKey(publicKey)` (the example shows it on a Settings page, alongside the node's multiaddrs from `collabswarm.libp2p.getMultiaddrs()`).
+
+## How it works
+
+- Each document keychain generates an AES-GCM-256 key; every change block is encrypted with the current key and tagged with a key ID before broadcast.
+- `addReader`/`addWriter` update the document's CRDT-backed ACL and distribute key material to the new member; `removeReader` triggers key rotation so subsequent changes use a key the removed member never receives.
+- `getReaders()` returns readers *and* writers — the example de-duplicates by serialized key when rendering a permissions table.
+- The index document at `/${userId}/passwords-index` is just another encrypted document, private to you by default. Importing a secret someone shared is: add its ID to your index, then open `/passwords/<id>` — which only decrypts if you're on the ACL.
+
+## Pitfalls
+
+- **Revocation is forward-only.** A removed reader keeps everything they already decrypted, and can still decrypt history encrypted under keys they held. Key rotation protects *future* changes only. This is fundamental to CRDTs, not a bug to be patched later.
+- **Key loss is unrecoverable.** There's no password reset. If the user loses the private key JWK, their index and any unshared secrets are gone. Make export/backup a prominent flow.
+- **The document path is not a secret capability.** Anyone can subscribe to `/passwords/<uuid>` topics and collect ciphertext; only ACL members can decrypt. Don't put sensitive data in the path itself.
+- **Index and secret can drift.** The secret's name is stored both in the secret document and in your index entry; the example updates both in the same UI handler. If you change the schema, keep that dual-write in mind.
+- **Alpha software; unaudited crypto.** The encryption design has not had an external security audit. Don't protect production credentials with it yet — and run a [pinning node](../pinning/) so an all-tabs-closed weekend doesn't delete your vault.

--- a/site/src/content/docs/cookbook/password-manager.md
+++ b/site/src/content/docs/cookbook/password-manager.md
@@ -1,168 +1,78 @@
 ---
 title: Encrypted shared secrets store
-description: Build a password manager where secrets are end-to-end encrypted and shared per-document via ACLs.
+description: Assess the password-manager source example and the incomplete distinct-identity onboarding flow.
 ---
 
-You want to store passwords and share individual ones with specific people — without any server ever being able to read them. With Swarmbase every document is end-to-end encrypted with its own key, and access is controlled by a per-document ACL of public keys, so "share this one password with Bob" is a first-class operation rather than a server-side permission check you have to trust. This recipe follows the `examples/password-manager` app in the repository.
+**Status: Runnable from source for startup smoke; Deferred/incomplete integration for sharing and revocation.**
 
-## Why E2E encryption matters here
+[`examples/password-manager`](https://github.com/swarmbase/swarmbase/tree/main/examples/password-manager) is a Vite, React, and Yjs reference application. Its typechecked production build and strict Chromium startup smoke test pass. It has no acceptance test proving two-user sharing, invitation delivery, restart recovery, or revocation.
 
-Secrets travel through relay servers and other peers you don't control. In Swarmbase, change payloads are AES-GCM-encrypted with a per-document symmetric key managed by the document keychain, and signed with the author's key. Relays and non-member peers forward and store ciphertext only. Removing a reader rotates the document key, so *future* changes are unreadable to them (see Pitfalls for what rotation cannot do).
+:::caution
+Do not store real passwords, recovery codes, API tokens, or other credentials in this example. Swarmbase is alpha software, is not independently audited, and has no assured durability or recovery path.
+:::
 
-## Identity is a keypair
+Packages are unpublished. From a repository checkout prepared with the [quick start](../../getting-started/quick-start/), run:
 
-There are no accounts. A user *is* an ECDSA P-384 WebCrypto keypair. Generate one on first login and let the user save it — losing the private key means losing access:
+Build and smoke-test the application:
 
-```typescript
-// login.ts — from examples/password-manager/src/Login.tsx and utils.ts
-export async function generateIdentity() {
-  const keypair = await crypto.subtle.generateKey(
-    { name: 'ECDSA', namedCurve: 'P-384' },
-    true,
-    ['sign', 'verify'],
-  );
-  return keypair;
-}
-
-// Persist / restore keys as JWK strings so the user can keep them.
-export async function exportKey(key: CryptoKey): Promise<string> {
-  const jwk = await crypto.subtle.exportKey('jwk', key);
-  return JSON.stringify(jwk);
-}
-
-export async function importKey(
-  keyData: string,
-  keyUsage: KeyUsage[], // ['sign'] for private, ['verify'] for public
-): Promise<CryptoKey> {
-  const jwk = JSON.parse(keyData) as JsonWebKey;
-  return await crypto.subtle.importKey(
-    'jwk',
-    jwk,
-    { name: 'ECDSA', namedCurve: 'P-384' },
-    true,
-    keyUsage,
-  );
-}
+```sh
+yarn build
+yarn workspace @swarmbase/password-manager build
+yarn test:e2e:password-manager
 ```
 
-The swarm setup (providers, `useCollabswarm`, `CollabswarmContext.Provider`) is identical to the [collaborative wiki recipe](../collaborative-wiki/) — the password manager example passes `YjsProvider`, `YjsJSONSerializer` (three times: changes, sync, and load serializer), `SubtleCrypto`, `YjsACLProvider`, and `YjsKeychainProvider` to `useCollabswarm`.
+To run the Vite development server separately:
 
-## A private index plus one document per secret
-
-Each secret lives in its own document at `/passwords/<uuid>` so it can be shared individually. A per-user index document lists the secrets you know about:
-
-```tsx
-// PasswordList.tsx (condensed from examples/password-manager/src/PasswordList.tsx)
-import React from 'react';
-import * as Y from 'yjs';
-import * as uuid from 'uuid';
-import { useCollabswarmDocumentState } from '@swarmbase/collabswarm-react';
-import { YjsCollabswarm } from './utils';
-
-export function PasswordList({
-  userId,
-  collabswarm,
-}: {
-  userId: string;
-  collabswarm: YjsCollabswarm;
-}) {
-  const [passwords, changePasswords] = useCollabswarmDocumentState(
-    collabswarm,
-    `/${userId}/passwords-index`,
-  );
-
-  const addSecret = () => {
-    changePasswords((current: Y.Doc) => {
-      current.getArray<Y.Map<Y.Text>>('passwords').push([
-        new Y.Map<Y.Text>(
-          Object.entries({
-            id: new Y.Text(uuid.v4()),
-          }),
-        ),
-      ]);
-    });
-  };
-
-  return (
-    <ul>
-      {passwords &&
-        passwords.getArray<Y.Map<Y.Text>>('passwords').map((password) => {
-          const id = password.get('id')?.toString();
-          const name = password.get('name')?.toString();
-          return <li key={id}>{name || `Unnamed Secret (id: ${id})`}</li>;
-        })}
-      <li>
-        <button onClick={addSecret}>New Secret</button>
-      </li>
-    </ul>
-  );
-}
+```sh
+yarn workspace @swarmbase/password-manager start
 ```
 
-Editing a secret's value applies a character-level delta so concurrent edits merge (see the wiki recipe for the same pattern):
+The smoke test proves startup only, not operational sharing.
 
-```tsx
-// PasswordEditor.tsx (condensed)
-import Delta from 'quill-delta';
-import * as Y from 'yjs';
+## Required key material
 
-const [doc, changeDoc] = useCollabswarmDocumentState(
-  collabswarm,
-  `/passwords/${passwordId}`,
+A deployable application must generate, authenticate, persist, restore, and back up separate keys:
+
+- a stable **ECDSA P-384** key pair for identity signing and ACL membership;
+- a stable **ECDH P-256** KEM key pair whose private key permits `deriveBits`, for encrypted BeeKEM Welcomes;
+- document epoch keys and membership state needed for recovery.
+
+The application, not Swarmbase, owns identity binding and recovery. Exchange the recipient's signing public key and raw 65-byte SEC1-uncompressed KEM public key over an authenticated out-of-band channel. A pasted, unauthenticated key is vulnerable to substitution.
+
+## Correct onboarding sequence
+
+**Status: Illustrative core sequence; not an end-to-end application recipe.** The direct document API has the necessary shape:
+
+```ts
+const kemKeyPair = await crypto.subtle.generateKey(
+  { name: 'ECDH', namedCurve: 'P-256' },
+  true,
+  ['deriveBits'],
 );
-const value = doc && doc.getText('value').toString();
 
-// In the input's onChange:
-const a = new Delta().insert(value || '');
-const b = new Delta().insert(e.target.value);
-const diff = a.diff(b);
-changeDoc((current: Y.Doc) => {
-  current.getText('value').applyDelta(diff.ops);
-});
+await documentRef.setKemKeyPair(kemKeyPair);
+const kemRaw = documentRef.getKemPublicKeyRaw();
+
+await ownerDocumentRef.addReader(recipientIdentityPublicKey, recipientKemRaw);
+await ownerDocumentRef.addWriter(recipientIdentityPublicKey);
 ```
 
-## Share a secret with the ACL
+Each participant must call `setKemKeyPair` on the relevant document ref before receiving Welcomes or administering BeeKEM membership. Add the recipient as a reader with `addReader(identity, kemRaw)` before granting writer status. Calling `addReader(identity)` without KEM bytes changes the reader ACL but sends no encrypted Welcome.
 
-The third element of the `useCollabswarmDocumentState` tuple exposes the document's ACL. To share, a teammate copies their serialized public key to you (out of band); you deserialize it and add them as a reader (decrypt) or writer (decrypt + edit):
+The current React wrapper exposes only `addReader(user)` and `addWriter(user)`. It cannot pass `kemRaw`, cannot call `setKemKeyPair`, and therefore cannot implement this onboarding sequence by itself. The password-manager UI currently pastes only an ECDSA public key, so its sharing controls are not evidence that a second identity can decrypt the document.
 
-```tsx
-// PermissionsTable.tsx (condensed from examples/password-manager/src/PermissionsTable.tsx)
-import { useCollabswarmDocumentState } from '@swarmbase/collabswarm-react';
-import { deserializeKey, serializeKey } from '@swarmbase/collabswarm-yjs';
+## Safer implementation checklist
 
-const [, , { readers, addReader, removeReader, writers, addWriter, removeWriter }] =
-  useCollabswarmDocumentState(collabswarm, `/passwords/${passwordId}`);
+**Status: Deferred/incomplete integration.** Prefer completing and testing these items over copying a runnable vault snippet:
 
-// Add a collaborator from their pasted public key:
-const key = await deserializeKey(
-  { name: 'ECDSA', namedCurve: 'P-384' },
-  ['verify'],
-)(pastedPublicKey);
+- Persist and restore signing keys and P-256 KEM keys without logging or exposing private material.
+- Bind both public keys to the intended human through an authenticated channel.
+- Install KEM state on every opened document before invitation handling.
+- Add a reader with signing identity plus raw KEM key; only then add writer rights if needed.
+- Confirm the recipient decrypts and edits in a two-browser, two-identity test.
+- Test dropped, replayed, delayed, and out-of-order Welcome and PathUpdate messages.
+- Test restart before and after invitation, removal, and key rotation.
+- Provide explicit backup, export, recovery, and destructive-loss UX.
+- Reconcile the per-user index and secret document after partial dual-write failure.
 
-await addReader(key);   // read-only: can decrypt
-// or
-await addWriter(key);   // read/write: can decrypt and author changes
-
-// Revoke:
-await removeReader(key); // rotates the document key for future changes
-
-// Display keys in the UI:
-const shortId = await serializeKey(someReaderKey); // base64 of the raw public key
-```
-
-Users find their own shareable public key the same way: `serializeKey(publicKey)` (the example shows it on a Settings page, alongside the node's multiaddrs from `collabswarm.libp2p.getMultiaddrs()`).
-
-## How it works
-
-- Each document keychain generates an AES-GCM-256 key; every change block is encrypted with the current key and tagged with a key ID before broadcast.
-- `addReader`/`addWriter` update the document's CRDT-backed ACL and distribute key material to the new member; `removeReader` triggers key rotation so subsequent changes use a key the removed member never receives.
-- `getReaders()` returns readers *and* writers — the example de-duplicates by serialized key when rendering a permissions table.
-- The index document at `/${userId}/passwords-index` is just another encrypted document, private to you by default. Importing a secret someone shared is: add its ID to your index, then open `/passwords/<id>` — which only decrypts if you're on the ACL.
-
-## Pitfalls
-
-- **Revocation is forward-only.** A removed reader keeps everything they already decrypted, and can still decrypt history encrypted under keys they held. Key rotation protects *future* changes only. This is fundamental to CRDTs, not a bug to be patched later.
-- **Key loss is unrecoverable.** There's no password reset. If the user loses the private key JWK, their index and any unshared secrets are gone. Make export/backup a prominent flow.
-- **The document path is not a secret capability.** Anyone can subscribe to `/passwords/<uuid>` topics and collect ciphertext; only ACL members can decrypt. Don't put sensitive data in the path itself.
-- **Index and secret can drift.** The secret's name is stored both in the secret document and in your index entry; the example updates both in the same UI handler. If you change the schema, keep that dual-write in mind.
-- **Alpha software; unaudited crypto.** The encryption design has not had an external security audit. Don't protect production credentials with it yet — and run a [pinning node](../pinning/) so an all-tabs-closed weekend doesn't delete your vault.
+BeeKEM reader mappings, tree state, and cached Welcomes have important memory-only paths. PathUpdate delivery is best effort, and restart, missed-update, multiwriter, and complete revocation behavior remain unresolved. Removing a member cannot erase plaintext or old keys they already copied. See [Security](../../concepts/security/) and [Limitations](../../concepts/limitations/).

--- a/site/src/content/docs/cookbook/pinning.md
+++ b/site/src/content/docs/cookbook/pinning.md
@@ -1,6 +1,92 @@
 ---
-title: Keep data alive with pinning
-description: Preventing data loss when all peers go offline.
+title: Keeping data alive (pinning)
+description: Understand the data-loss risk in a peer-to-peer database and run a pinning node so documents survive when every browser closes.
 ---
 
-This page is being written. Until it lands, the [GitHub repository](https://github.com/swarmbase/swarmbase) is the best source.
+Swarmbase has no central database: a document exists only as long as some peer holds a copy. Browsers are terrible archivists — tabs close, storage gets evicted, laptops sleep — so without help, a document that only ever lived in two browsers can simply vanish. Pinning is the answer: an always-on node that stores document data durably and serves it back to peers.
+
+:::caution[Read this before storing anything you care about]
+This is an alpha project, and the repository README says it plainly: **data loss can occur if all clients lose local storage and no remote pinning is set up.** Treat data in Swarmbase today "like venture investing — only put in what you can afford to lose." Pinning tooling is one of the thinnest areas of the project and a great place to contribute.
+:::
+
+## What pinning means here
+
+Swarmbase stores encrypted CRDT change blocks as content-addressed IPFS blocks (via Helia). Under normal operation, peers cache and serve the blocks for documents they've viewed — data spreads with popularity and disappears with disinterest. A *pinning node* opts specific blocks out of that lifecycle: it marks them as pinned in its blockstore so they're always available, even when every other peer is offline. One durable copy is enough for the network to recover a document, and because addresses are content hashes, a restored block is automatically the *right* block.
+
+Pinned blocks are ciphertext. A pinning node stores and serves your data without holding document keys — availability infrastructure doesn't need to be trusted with plaintext.
+
+## What exists today: `CollabswarmNode`
+
+The core package ships a Node.js-side node with automatic pinning logic. It subscribes to the document-publish pubsub topic (`/documents` by default); whenever any peer publishes a document, it opens that document, subscribes to its changes, and pins every CID it sees (`helia.pins.add`, with de-duplication and a concurrency cap). Adapted from the daemon in the repository (`packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts`) to the Yjs backend:
+
+```typescript
+// pinning-node.ts — run with Node.js
+import { SubtleCrypto, defaultBootstrapConfig } from '@swarmbase/collabswarm';
+import { CollabswarmNode, defaultNodeConfig } from '@swarmbase/collabswarm/node';
+import {
+  YjsProvider,
+  YjsJSONSerializer,
+  YjsACLProvider,
+  YjsKeychainProvider,
+} from '@swarmbase/collabswarm-yjs';
+
+const crdt = new YjsProvider();
+const serializer = new YjsJSONSerializer();
+const auth = new SubtleCrypto();
+const acl = new YjsACLProvider();
+const keychain = new YjsKeychainProvider();
+
+const keypair = await crypto.subtle.generateKey(
+  { name: 'ECDSA', namedCurve: 'P-384' },
+  true,
+  ['sign', 'verify'],
+);
+
+const swarmNode = new CollabswarmNode(
+  keypair.privateKey,
+  keypair.publicKey,
+  crdt,
+  serializer,   // ChangesSerializer
+  serializer,   // SyncMessageSerializer
+  serializer,   // LoadMessageSerializer
+  auth,
+  acl,
+  keychain,
+  defaultNodeConfig(
+    defaultBootstrapConfig([
+      // Your relay, so browsers and this node find each other:
+      // '/dns4/relay.example.com/tcp/9001/ws/p2p/<relay-peer-id>',
+    ]),
+  ),
+);
+
+console.log('Starting pinning node...');
+await swarmNode.start();
+// Logs: "Listening for pinning requests on: /documents"
+```
+
+`swarmNode.stop()` unsubscribes the publish handler and document subscriptions.
+
+## How it works
+
+- On `start()`, the node initializes a full Swarmbase peer (Helia + libp2p, same stack as the browser) and subscribes to `config.pubsubDocumentPublishPath` (`/documents`).
+- Each publish message names a document; the node calls `swarm.doc(documentId)`, subscribes a `pinning-handler`, opens the document, and pins the CIDs from the announcement and from every subsequent change it observes.
+- Pinning is deduplicated (seen-CID set) and throttled (at most 10 concurrent pin operations), so a busy swarm doesn't overwhelm the blockstore.
+- Because it's a normal peer, browsers fetch blocks from it over Bitswap like from any other peer — no special client configuration is needed beyond sharing a relay/bootstrap path.
+
+## Honest limitations — help wanted
+
+This is the least-finished part of Swarmbase. Know what you're getting:
+
+- **No packaged pinning service.** There is no Docker image, CLI, or hosted offering for a pinning node today — the `CollabswarmNode` class and the daemon script above are the state of the art. (The relay server image is *not* a pinning node; it forwards messages and stores nothing durably.)
+- **No client-side "pin this document" API.** A `documentRef.pin()` call is sketched in the codebase but not currently exposed; pinning is driven by the node observing publish messages, not by explicit client requests.
+- **No selective or quota'd pinning.** The node pins everything it hears about on the publish topic, forever. There's no per-document policy, TTL, or storage accounting yet.
+- **Generic IPFS pinning services are only a partial substitute.** Services like Pinata or web3.storage can pin the raw blocks, but they can't subscribe to Swarmbase's pubsub or follow new changes — they aren't CRDT-aware. Running a `CollabswarmNode` is what gives you automatic pin-on-publish behavior.
+- **Contributions welcome.** Pinning policy, a packaged pinning server, client pin APIs, and storage GC are explicitly on the "make this easier" wishlist — if you need this for production, the maintainers want to hear from you.
+
+## Pitfalls
+
+- **A relay is not a backup.** It's easy to deploy the [relay](../running-a-relay/) and assume durability — the relay only moves messages. If the pinning node is down while all browsers clear storage, the data is gone.
+- **The pinning node must be online to observe publishes.** It pins what it *hears*. Documents that were only ever synced while your pinning node was offline are not pinned; bring the node up before you rely on it, and keep it running.
+- **Storage grows monotonically.** CRDT history plus pin-everything policy means disk usage only increases. Budget for it and monitor it.
+- **Back up the node's blockstore.** Unlike relays (stateless), a pinning node is stateful: its blockstore/datastore *is* your durability story. Snapshot it, and persist its private key if you want a stable peer identity.

--- a/site/src/content/docs/cookbook/pinning.md
+++ b/site/src/content/docs/cookbook/pinning.md
@@ -1,92 +1,46 @@
 ---
 title: Keeping data alive (pinning)
-description: Understand the data-loss risk in a peer-to-peer database and run a pinning node so documents survive when every browser closes.
+description: Design and validate a pinning integration without treating the current listener as a durability service.
 ---
 
-Swarmbase has no central database: a document exists only as long as some peer holds a copy. Browsers are terrible archivists — tabs close, storage gets evicted, laptops sleep — so without help, a document that only ever lived in two browsers can simply vanish. Pinning is the answer: an always-on node that stores document data durably and serves it back to peers.
+**Status: Deferred/incomplete integration.**
 
-:::caution[Read this before storing anything you care about]
-This is an alpha project, and the repository README says it plainly: **data loss can occur if all clients lose local storage and no remote pinning is set up.** Treat data in Swarmbase today "like venture investing — only put in what you can afford to lose." Pinning tooling is one of the thinnest areas of the project and a great place to contribute.
-:::
+Swarmbase does not currently provide a runnable, end-to-end pinning daemon or durability guarantee. Do not rely on this recipe to preserve important data. See [Storage](../../concepts/storage/) and [Limitations](../../concepts/limitations/).
 
-## What pinning means here
+## What exists
 
-Swarmbase stores encrypted CRDT change blocks as content-addressed IPFS blocks (via Helia). Under normal operation, peers cache and serve the blocks for documents they've viewed — data spreads with popularity and disappears with disinterest. A *pinning node* opts specific blocks out of that lifecycle: it marks them as pinned in its blockstore so they're always available, even when every other peer is offline. One durable copy is enough for the network to recover a document, and because addresses are content hashes, a restored block is automatically the *right* block.
+The Node-only `CollabswarmNode` contains a listener for `pubsubDocumentPublishPath` (default `/documents`). Given an announcement, it can open that document, observe its change graph, and call Helia's pin API for announced CIDs with de-duplication and bounded concurrency.
 
-Pinned blocks are ciphertext. A pinning node stores and serves your data without holding document keys — availability infrastructure doesn't need to be trusted with plaintext.
+That listener is only one side of a protocol. The normal core document commit path does **not** publish document announcements to it, so ordinary application changes do not activate automatic pinning. There is also no integrated generic IPFS pinning-service client, packaged pinning service, supported CLI, or hosted service.
 
-## What exists today: `CollabswarmNode`
+The default Node configuration uses the repository's IndexedDB-backed stores. Durable restart/recovery for a Node pinning process has not been validated, including stable storage paths, process identity, graph restoration, subscriptions, keys, and serving retained data after restart.
 
-The core package ships a Node.js-side node with automatic pinning logic. It subscribes to the document-publish pubsub topic (`/documents` by default); whenever any peer publishes a document, it opens that document, subscribes to its changes, and pins every CID it sees (`helia.pins.add`, with de-duplication and a concurrency cap). Adapted from the daemon in the repository (`packages/collabswarm-automerge/bin/collabswarm-automerge-d.ts`) to the Yjs backend:
+## Why blocks alone are insufficient
 
-```typescript
-// pinning-node.ts — run with Node.js
-import { SubtleCrypto, defaultBootstrapConfig } from '@swarmbase/collabswarm';
-import { CollabswarmNode, defaultNodeConfig } from '@swarmbase/collabswarm/node';
-import {
-  YjsProvider,
-  YjsJSONSerializer,
-  YjsACLProvider,
-  YjsKeychainProvider,
-} from '@swarmbase/collabswarm-yjs';
+Pinning ciphertext CIDs preserves bytes, not a recoverable application. Recovery may also require:
 
-const crdt = new YjsProvider();
-const serializer = new YjsJSONSerializer();
-const auth = new SubtleCrypto();
-const acl = new YjsACLProvider();
-const keychain = new YjsKeychainProvider();
+- discoverable root, frontier, snapshot, and change CIDs;
+- enough shadow-graph or index state to traverse retained history;
+- document epoch keys and keychain state;
+- persisted signing identity and KEM membership state;
+- compatible CRDT, ACL, serializer, quorum, and network configuration;
+- reachable providers able to serve the retained blocks.
 
-const keypair = await crypto.subtle.generateKey(
-  { name: 'ECDSA', namedCurve: 'P-384' },
-  true,
-  ['sign', 'verify'],
-);
+A generic pinning service can retain CIDs explicitly sent to it, but Swarmbase has no generic client that discovers and exports every required block or restores the associated metadata.
 
-const swarmNode = new CollabswarmNode(
-  keypair.privateKey,
-  keypair.publicKey,
-  crdt,
-  serializer,   // ChangesSerializer
-  serializer,   // SyncMessageSerializer
-  serializer,   // LoadMessageSerializer
-  auth,
-  acl,
-  keychain,
-  defaultNodeConfig(
-    defaultBootstrapConfig([
-      // Your relay, so browsers and this node find each other:
-      // '/dns4/relay.example.com/tcp/9001/ws/p2p/<relay-peer-id>',
-    ]),
-  ),
-);
+## Integration checklist
 
-console.log('Starting pinning node...');
-await swarmNode.start();
-// Logs: "Listening for pinning requests on: /documents"
-```
+Before calling a custom service “pinning,” implement and test all of the following:
 
-`swarmNode.stop()` unsubscribes the publish handler and document subscriptions.
+1. Define an authenticated, authorized publication/request protocol.
+2. Publish every relevant document frontier and subsequent update from the core/application path.
+3. Traverse and retain all required blocks, including snapshots and retained tails.
+4. Persist the service's blockstore, datastore, identity, subscriptions, and recovery index.
+5. Bound storage with explicit quota, retention, compaction, and deletion policies.
+6. Monitor publication failures, missing blocks, provider reachability, disk use, and restore readiness.
+7. Reconcile changes missed while the service was offline.
+8. Restore into a clean client with the same key, ACL, quorum, and history settings.
+9. Repeat restore after service restart and after compaction or block garbage collection.
+10. Test loss of every browser replica; retained blocks must still be discoverable and decryptable.
 
-## How it works
-
-- On `start()`, the node initializes a full Swarmbase peer (Helia + libp2p, same stack as the browser) and subscribes to `config.pubsubDocumentPublishPath` (`/documents`).
-- Each publish message names a document; the node calls `swarm.doc(documentId)`, subscribes a `pinning-handler`, opens the document, and pins the CIDs from the announcement and from every subsequent change it observes.
-- Pinning is deduplicated (seen-CID set) and throttled (at most 10 concurrent pin operations), so a busy swarm doesn't overwhelm the blockstore.
-- Because it's a normal peer, browsers fetch blocks from it over Bitswap like from any other peer — no special client configuration is needed beyond sharing a relay/bootstrap path.
-
-## Honest limitations — help wanted
-
-This is the least-finished part of Swarmbase. Know what you're getting:
-
-- **No packaged pinning service.** There is no Docker image, CLI, or hosted offering for a pinning node today — the `CollabswarmNode` class and the daemon script above are the state of the art. (The relay server image is *not* a pinning node; it forwards messages and stores nothing durably.)
-- **No client-side "pin this document" API.** A `documentRef.pin()` call is sketched in the codebase but not currently exposed; pinning is driven by the node observing publish messages, not by explicit client requests.
-- **No selective or quota'd pinning.** The node pins everything it hears about on the publish topic, forever. There's no per-document policy, TTL, or storage accounting yet.
-- **Generic IPFS pinning services are only a partial substitute.** Services like Pinata or web3.storage can pin the raw blocks, but they can't subscribe to Swarmbase's pubsub or follow new changes — they aren't CRDT-aware. Running a `CollabswarmNode` is what gives you automatic pin-on-publish behavior.
-- **Contributions welcome.** Pinning policy, a packaged pinning server, client pin APIs, and storage GC are explicitly on the "make this easier" wishlist — if you need this for production, the maintainers want to hear from you.
-
-## Pitfalls
-
-- **A relay is not a backup.** It's easy to deploy the [relay](../running-a-relay/) and assume durability — the relay only moves messages. If the pinning node is down while all browsers clear storage, the data is gone.
-- **The pinning node must be online to observe publishes.** It pins what it *hears*. Documents that were only ever synced while your pinning node was offline are not pinned; bring the node up before you rely on it, and keep it running.
-- **Storage grows monotonically.** CRDT history plus pin-everything policy means disk usage only increases. Budget for it and monitor it.
-- **Back up the node's blockstore.** Unlike relays (stateless), a pinning node is stateful: its blockstore/datastore *is* your durability story. Snapshot it, and persist its private key if you want a stable peer identity.
+Until this acceptance path exists, keep independent conventional backups of data and key material. A [relay](../running-a-relay/) forwards traffic but is not storage, backup, or pinning.

--- a/site/src/content/docs/cookbook/react.md
+++ b/site/src/content/docs/cookbook/react.md
@@ -1,6 +1,170 @@
 ---
-title: Use Swarmbase with React
-description: Hooks for loading, subscribing to, and changing documents.
+title: React integration
+description: Use the @swarmbase/collabswarm-react hooks to open, subscribe to, and edit documents from React components.
 ---
 
-This page is being written. Until it lands, the [GitHub repository](https://github.com/swarmbase/swarmbase) is the best source.
+You're building a React app and want Swarmbase documents to behave like React state: open on mount, re-render on remote changes, clean up on unmount, and share one connection across many components. `@swarmbase/collabswarm-react` provides two hooks and a context that do exactly that.
+
+## Install
+
+```sh
+npm install @swarmbase/collabswarm @swarmbase/collabswarm-yjs @swarmbase/collabswarm-react yjs
+```
+
+## Complete example
+
+```tsx
+import React from 'react';
+import * as Y from 'yjs';
+import {
+  Collabswarm,
+  CollabswarmDocument,
+  SubtleCrypto,
+  defaultConfig,
+  defaultBootstrapConfig,
+} from '@swarmbase/collabswarm';
+import {
+  YjsProvider,
+  YjsJSONSerializer,
+  YjsACLProvider,
+  YjsKeychainProvider,
+} from '@swarmbase/collabswarm-yjs';
+import {
+  CollabswarmContext,
+  useCollabswarm,
+  useCollabswarmDocumentState,
+} from '@swarmbase/collabswarm-react';
+
+// Providers are stateless factories — create them once, outside components.
+const crdt = new YjsProvider();
+const serializer = new YjsJSONSerializer();
+const auth = new SubtleCrypto();
+const acl = new YjsACLProvider();
+const keychain = new YjsKeychainProvider();
+
+type YjsCollabswarm = Collabswarm<
+  Y.Doc, Uint8Array, (doc: Y.Doc) => void, CryptoKey, CryptoKey, CryptoKey
+>;
+
+// 1. Provide the shared document caches at the top of your tree.
+function SwarmProvider({ children }: { children: React.ReactNode }) {
+  const [docCache, setDocCache] = React.useState<{
+    [docPath: string]: CollabswarmDocument<any, any, any, any, any, any>;
+  }>({});
+  const [docDataCache, setDocDataCache] = React.useState<{ [docPath: string]: any }>({});
+  const [docReadersCache, setDocReadersCache] = React.useState<{ [docPath: string]: any[] }>({});
+  const [docWritersCache, setDocWritersCache] = React.useState<{ [docPath: string]: any[] }>({});
+
+  return (
+    <CollabswarmContext.Provider
+      value={{
+        docCache, docDataCache, docReadersCache, docWritersCache,
+        setDocCache, setDocDataCache, setDocReadersCache, setDocWritersCache,
+      }}
+    >
+      {children}
+    </CollabswarmContext.Provider>
+  );
+}
+
+// 2. Create the swarm once you have an identity keypair.
+function App({ privateKey, publicKey }: { privateKey?: CryptoKey; publicKey?: CryptoKey }) {
+  const config = defaultConfig(defaultBootstrapConfig([
+    // '/dns4/relay.example.com/tcp/443/wss/p2p/<relay-peer-id>',
+  ]));
+
+  const collabswarm = useCollabswarm(
+    privateKey,
+    publicKey,
+    crdt,
+    serializer,   // ChangesSerializer
+    serializer,   // SyncMessageSerializer
+    serializer,   // LoadMessageSerializer
+    auth,
+    acl,
+    keychain,
+    config,
+  );
+
+  if (!collabswarm) return <p>Starting swarm…</p>;
+
+  return (
+    <SwarmProvider>
+      <Note collabswarm={collabswarm} path="/notes/hello" />
+    </SwarmProvider>
+  );
+}
+
+// 3. Open a document and edit it.
+function Note({ collabswarm, path }: { collabswarm: YjsCollabswarm; path: string }) {
+  const [doc, changeDoc, aclControls] = useCollabswarmDocumentState(
+    collabswarm,
+    path,
+  );
+
+  if (!doc) return <p>Opening {path}…</p>; // still loading from peers
+
+  return (
+    <div>
+      <pre>{doc.getText('content').toString()}</pre>
+      <button
+        onClick={() =>
+          changeDoc((current: Y.Doc) => {
+            current.getText('content').insert(0, 'Hello! ');
+          })
+        }
+      >
+        Prepend greeting
+      </button>
+      <p>{aclControls.writers?.length ?? 0} writer(s)</p>
+    </div>
+  );
+}
+```
+
+## The hooks
+
+### `useCollabswarm(privateKey, publicKey, provider, changesSerializer, syncMessageSerializer, loadMessageSerializer, authProvider, aclProvider, keychainProvider, config?)`
+
+Constructs a `Collabswarm` node and calls `initialize(config)` in an effect. Returns `undefined` until both keys are set and initialization completes — so you can start rendering before the user "logs in" and pass the keys in later. The effect re-runs if `privateKey`/`publicKey` change.
+
+### `useCollabswarmDocumentState(collabswarm, documentPath, originFilter?)`
+
+Returns a tuple:
+
+```typescript
+const [doc, changeDoc, aclControls] = useCollabswarmDocumentState(swarm, '/notes/hello');
+// doc:        DocType | undefined       — undefined until open() resolves
+// changeDoc:  (fn, message?) => void    — apply a local change
+// aclControls: {
+//   readers, addReader, removeReader,
+//   writers, addWriter, removeWriter,
+// }
+```
+
+`originFilter` (`'all' | 'remote' | 'local'`, default `'all'`) controls which change origins trigger re-renders.
+
+## Lifecycle: what the hook actually does
+
+- **First subscriber opens the document.** The hook calls `collabswarm.doc(path)` then `docRef.open()`, and records the in-flight promise in a module-level task map. A second component mounting with the same path *awaits the same open* instead of opening twice.
+- **Every hook instance gets its own subscription.** Each instance subscribes with a unique random ID, so multiple components watching one document don't clobber each other's handlers.
+- **Reference counting on unmount.** Each path keeps a subscriber count. Unmounting unsubscribes that instance; when the *last* subscriber for a path unmounts, the caches are evicted and the document is `close()`d to free pubsub/network resources.
+- **Strict-mode safe.** The open-task entry is only deleted after the open promise settles, so React 18 strict-mode's rapid unmount/remount doesn't call `open()` twice on the same document.
+- **ACL data comes along for free.** On open, the hook fetches `getReaders()`/`getWriters()` and keeps them updated from change notifications, exposing them via the third tuple element.
+
+## Loading states
+
+There is no Suspense integration — the pattern that exists is the `undefined` check:
+
+- `useCollabswarm(...)` returns `undefined` → swarm still initializing (or no keys yet).
+- `useCollabswarmDocumentState(...)[0]` is `undefined` → document still opening.
+
+Render spinners/placeholders on those, exactly as the wiki and password-manager examples do.
+
+## Pitfalls
+
+- **You must provide `CollabswarmContext` with real React state.** The context's default value has no-op setters — hooks will open documents but nothing will ever re-render. Wire all eight values (four caches + four setters) to `useState` as shown above.
+- **`changeDoc` is a no-op before the document opens.** It looks up the doc ref in the cache and does nothing if it isn't there yet. Disable edit controls until `doc` is defined.
+- **Don't rely on object identity for `Y.Doc`.** `YjsProvider` mutates the `Y.Doc` in place; the `doc` value's reference may not change between renders even though content did. Read values out (`doc.getText(...).toString()`) during render rather than memoizing on `doc`.
+- **Unstable keys re-create the swarm.** `useCollabswarm` re-initializes when `privateKey`/`publicKey` change identity. Keep them in state set once, not derived per-render.
+- **Alpha API.** The context-plus-module-cache design is explicitly acknowledged in the source as interim ("ew, global state"); expect this surface to change before 1.0.

--- a/site/src/content/docs/cookbook/react.md
+++ b/site/src/content/docs/cookbook/react.md
@@ -1,170 +1,122 @@
 ---
 title: React integration
-description: Use the @swarmbase/collabswarm-react hooks to open, subscribe to, and edit documents from React components.
+description: Use the current React hooks for a basic, single-identity Yjs document from repository workspaces.
 ---
 
-You're building a React app and want Swarmbase documents to behave like React state: open on mount, re-render on remote changes, clean up on unmount, and share one connection across many components. `@swarmbase/collabswarm-react` provides two hooks and a context that do exactly that.
+**Status: Runnable from source for basic single-identity hooks; sharing is incomplete.**
 
-## Install
+The packages are unpublished. Build and consume the repository workspaces as shown in the [quick start](../../getting-started/quick-start/). The current password-manager source typechecks, builds, and passes a Chromium startup smoke test:
 
 ```sh
-npm install @swarmbase/collabswarm @swarmbase/collabswarm-yjs @swarmbase/collabswarm-react yjs
+yarn build
+yarn workspace @swarmbase/password-manager build
+yarn test:e2e:password-manager
 ```
 
-## Complete example
+This evidence covers startup, not sharing or cross-browser convergence.
+
+## Provide the current context shape
+
+`useCollabswarmDocumentState` requires four caches and four setters backed by React state:
 
 ```tsx
-import React from 'react';
-import * as Y from 'yjs';
-import {
-  Collabswarm,
-  CollabswarmDocument,
-  SubtleCrypto,
-  defaultConfig,
-  defaultBootstrapConfig,
-} from '@swarmbase/collabswarm';
-import {
-  YjsProvider,
-  YjsJSONSerializer,
-  YjsACLProvider,
-  YjsKeychainProvider,
-} from '@swarmbase/collabswarm-yjs';
-import {
-  CollabswarmContext,
-  useCollabswarm,
-  useCollabswarmDocumentState,
-} from '@swarmbase/collabswarm-react';
+function SwarmDocumentProvider({ children }: { children: React.ReactNode }) {
+  const [docCache, setDocCache] = React.useState<Record<string, any>>({});
+  const [docDataCache, setDocDataCache] = React.useState<Record<string, any>>({});
+  const [docReadersCache, setDocReadersCache] = React.useState<Record<string, any[]>>({});
+  const [docWritersCache, setDocWritersCache] = React.useState<Record<string, any[]>>({});
 
-// Providers are stateless factories — create them once, outside components.
+  return (
+    <CollabswarmContext.Provider value={{
+      docCache,
+      docDataCache,
+      docReadersCache,
+      docWritersCache,
+      setDocCache,
+      setDocDataCache,
+      setDocReadersCache,
+      setDocWritersCache,
+    }}>
+      {children}
+    </CollabswarmContext.Provider>
+  );
+}
+```
+
+The default context setters are no-ops; omitting this provider prevents cache updates from driving renders.
+
+## Initialize one identity
+
+Create provider instances outside render, then pass stable ECDSA P-384 signing keys to the current hook signature:
+
+```tsx
 const crdt = new YjsProvider();
 const serializer = new YjsJSONSerializer();
 const auth = new SubtleCrypto();
 const acl = new YjsACLProvider();
 const keychain = new YjsKeychainProvider();
 
-type YjsCollabswarm = Collabswarm<
-  Y.Doc, Uint8Array, (doc: Y.Doc) => void, CryptoKey, CryptoKey, CryptoKey
+const swarm = useCollabswarm(
+  privateKey,
+  publicKey,
+  crdt,
+  serializer,
+  serializer,
+  serializer,
+  auth,
+  acl,
+  keychain,
+  defaultConfig(defaultBootstrapConfig(
+    import.meta.env.VITE_RELAY_MULTIADDR
+      ? [import.meta.env.VITE_RELAY_MULTIADDR]
+      : [],
+  )),
+);
+```
+
+The application must persist and restore the signing keys. New keys mean a new ACL identity. `useCollabswarm` re-runs when key object identity changes, but it has no effect cleanup that stops the previous swarm; do not rotate or reconstruct keys during normal rendering.
+
+## Open and change one document
+
+```tsx
+import type { Collabswarm } from '@swarmbase/collabswarm';
+import type * as Y from 'yjs';
+
+type YjsSwarm = Collabswarm<
+  Y.Doc,
+  Uint8Array,
+  (doc: Y.Doc) => void,
+  CryptoKey,
+  CryptoKey,
+  CryptoKey
 >;
 
-// 1. Provide the shared document caches at the top of your tree.
-function SwarmProvider({ children }: { children: React.ReactNode }) {
-  const [docCache, setDocCache] = React.useState<{
-    [docPath: string]: CollabswarmDocument<any, any, any, any, any, any>;
-  }>({});
-  const [docDataCache, setDocDataCache] = React.useState<{ [docPath: string]: any }>({});
-  const [docReadersCache, setDocReadersCache] = React.useState<{ [docPath: string]: any[] }>({});
-  const [docWritersCache, setDocWritersCache] = React.useState<{ [docPath: string]: any[] }>({});
+function Note({ swarm }: { swarm: YjsSwarm }) {
+  const [doc, changeDoc, acl] = useCollabswarmDocumentState(
+    swarm,
+    '/notes/hello',
+  );
+
+  if (!doc) return <p>Opening…</p>;
 
   return (
-    <CollabswarmContext.Provider
-      value={{
-        docCache, docDataCache, docReadersCache, docWritersCache,
-        setDocCache, setDocDataCache, setDocReadersCache, setDocWritersCache,
-      }}
-    >
-      {children}
-    </CollabswarmContext.Provider>
-  );
-}
-
-// 2. Create the swarm once you have an identity keypair.
-function App({ privateKey, publicKey }: { privateKey?: CryptoKey; publicKey?: CryptoKey }) {
-  const config = defaultConfig(defaultBootstrapConfig([
-    // '/dns4/relay.example.com/tcp/443/wss/p2p/<relay-peer-id>',
-  ]));
-
-  const collabswarm = useCollabswarm(
-    privateKey,
-    publicKey,
-    crdt,
-    serializer,   // ChangesSerializer
-    serializer,   // SyncMessageSerializer
-    serializer,   // LoadMessageSerializer
-    auth,
-    acl,
-    keychain,
-    config,
-  );
-
-  if (!collabswarm) return <p>Starting swarm…</p>;
-
-  return (
-    <SwarmProvider>
-      <Note collabswarm={collabswarm} path="/notes/hello" />
-    </SwarmProvider>
-  );
-}
-
-// 3. Open a document and edit it.
-function Note({ collabswarm, path }: { collabswarm: YjsCollabswarm; path: string }) {
-  const [doc, changeDoc, aclControls] = useCollabswarmDocumentState(
-    collabswarm,
-    path,
-  );
-
-  if (!doc) return <p>Opening {path}…</p>; // still loading from peers
-
-  return (
-    <div>
-      <pre>{doc.getText('content').toString()}</pre>
-      <button
-        onClick={() =>
-          changeDoc((current: Y.Doc) => {
-            current.getText('content').insert(0, 'Hello! ');
-          })
-        }
-      >
-        Prepend greeting
-      </button>
-      <p>{aclControls.writers?.length ?? 0} writer(s)</p>
-    </div>
+    <button onClick={() => {
+      changeDoc((current: Y.Doc) => {
+        current.getText('content').insert(0, 'Hello ');
+      });
+    }}>
+      {doc.getText('content').toString()} ({acl.writers?.length ?? 0} writers)
+    </button>
   );
 }
 ```
 
-## The hooks
+The tuple is `[document | undefined, changeDoc, aclControls]`; `originFilter` is optionally `'all'`, `'remote'`, or `'local'`.
 
-### `useCollabswarm(privateKey, publicKey, provider, changesSerializer, syncMessageSerializer, loadMessageSerializer, authProvider, aclProvider, keychainProvider, config?)`
+`changeDoc` returns `void`. It fire-and-forgets `documentRef.change()` and does not return or catch its promise, so authorization, storage, encryption, or publication rejection is dropped by the wrapper. It is also a no-op before the document ref reaches the cache. Use the direct document API when the UI must await and report failures.
 
-Constructs a `Collabswarm` node and calls `initialize(config)` in an effect. Returns `undefined` until both keys are set and initialization completes — so you can start rendering before the user "logs in" and pass the keys in later. The effect re-runs if `privateKey`/`publicKey` change.
+## Lifecycle boundaries
 
-### `useCollabswarmDocumentState(collabswarm, documentPath, originFilter?)`
+Each document-hook instance unsubscribes on cleanup, and the last subscriber closes and evicts that document. The open-task map deduplicates an in-flight open, including a rapid StrictMode remount. That is the only StrictMode guarantee: it is not a guarantee for swarm initialization, networking, mutations, or every side effect.
 
-Returns a tuple:
-
-```typescript
-const [doc, changeDoc, aclControls] = useCollabswarmDocumentState(swarm, '/notes/hello');
-// doc:        DocType | undefined       — undefined until open() resolves
-// changeDoc:  (fn, message?) => void    — apply a local change
-// aclControls: {
-//   readers, addReader, removeReader,
-//   writers, addWriter, removeWriter,
-// }
-```
-
-`originFilter` (`'all' | 'remote' | 'local'`, default `'all'`) controls which change origins trigger re-renders.
-
-## Lifecycle: what the hook actually does
-
-- **First subscriber opens the document.** The hook calls `collabswarm.doc(path)` then `docRef.open()`, and records the in-flight promise in a module-level task map. A second component mounting with the same path *awaits the same open* instead of opening twice.
-- **Every hook instance gets its own subscription.** Each instance subscribes with a unique random ID, so multiple components watching one document don't clobber each other's handlers.
-- **Reference counting on unmount.** Each path keeps a subscriber count. Unmounting unsubscribes that instance; when the *last* subscriber for a path unmounts, the caches are evicted and the document is `close()`d to free pubsub/network resources.
-- **Strict-mode safe.** The open-task entry is only deleted after the open promise settles, so React 18 strict-mode's rapid unmount/remount doesn't call `open()` twice on the same document.
-- **ACL data comes along for free.** On open, the hook fetches `getReaders()`/`getWriters()` and keeps them updated from change notifications, exposing them via the third tuple element.
-
-## Loading states
-
-There is no Suspense integration — the pattern that exists is the `undefined` check:
-
-- `useCollabswarm(...)` returns `undefined` → swarm still initializing (or no keys yet).
-- `useCollabswarmDocumentState(...)[0]` is `undefined` → document still opening.
-
-Render spinners/placeholders on those, exactly as the wiki and password-manager examples do.
-
-## Pitfalls
-
-- **You must provide `CollabswarmContext` with real React state.** The context's default value has no-op setters — hooks will open documents but nothing will ever re-render. Wire all eight values (four caches + four setters) to `useState` as shown above.
-- **`changeDoc` is a no-op before the document opens.** It looks up the doc ref in the cache and does nothing if it isn't there yet. Disable edit controls until `doc` is defined.
-- **Don't rely on object identity for `Y.Doc`.** `YjsProvider` mutates the `Y.Doc` in place; the `doc` value's reference may not change between renders even though content did. Read values out (`doc.getText(...).toString()`) during render rather than memoizing on `doc`.
-- **Unstable keys re-create the swarm.** `useCollabswarm` re-initializes when `privateKey`/`publicKey` change identity. Keep them in state set once, not derived per-render.
-- **Alpha API.** The context-plus-module-cache design is explicitly acknowledged in the source as interim ("ew, global state"); expect this surface to change before 1.0.
+The ACL controls expose `addReader(user)` and cannot pass the recipient's raw P-256 ECDH KEM key or install a KEM key pair. They therefore cannot perform complete distinct-identity onboarding. Use the direct API and the sequence in [Encrypted shared secrets store](../password-manager/). See [Security](../../concepts/security/) for persistence and revocation limits.

--- a/site/src/content/docs/cookbook/redux.md
+++ b/site/src/content/docs/cookbook/redux.md
@@ -1,6 +1,181 @@
 ---
-title: Use Swarmbase with Redux
-description: Wiring documents into a Redux store.
+title: Redux integration
+description: Wire Swarmbase into a Redux store with @swarmbase/collabswarm-redux reducers and thunk actions.
 ---
 
-This page is being written. Until it lands, the [GitHub repository](https://github.com/swarmbase/swarmbase) is the best source.
+Your app already keeps state in Redux and you want Swarmbase documents to flow through the same store: dispatch an action to open a document, read it from state with selectors, and have remote changes arrive as ordinary actions. `@swarmbase/collabswarm-redux` provides a reducer factory and a set of thunk action creators that do this.
+
+:::note
+The package targets classic Redux with `redux-thunk`. The in-repo examples (`examples/wiki-swarm`, `examples/browser-test`) demonstrate it with the Automerge CRDT backend; this recipe shows the same wiring with the golden-path Yjs backend and the reducer signature as currently implemented in `@swarmbase/collabswarm-redux`.
+:::
+
+## Install
+
+```sh
+npm install @swarmbase/collabswarm @swarmbase/collabswarm-yjs @swarmbase/collabswarm-redux redux redux-thunk react-redux yjs
+```
+
+## Store setup
+
+`collabswarmReducer(...)` is a factory: it takes your identity keypair and the full provider stack, and returns a reducer whose initial state already contains a constructed (but uninitialized) `Collabswarm` node. That means you need the keypair *before* creating the store:
+
+```typescript
+// store.ts
+import { combineReducers, createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import * as Y from 'yjs';
+import { SubtleCrypto } from '@swarmbase/collabswarm';
+import {
+  YjsProvider,
+  YjsJSONSerializer,
+  YjsACLProvider,
+  YjsKeychainProvider,
+} from '@swarmbase/collabswarm-yjs';
+import { collabswarmReducer, CollabswarmState } from '@swarmbase/collabswarm-redux';
+
+export type SwarmState = CollabswarmState<
+  Y.Doc,                 // DocType
+  Uint8Array,            // ChangesType
+  (doc: Y.Doc) => void,  // ChangeFnType
+  CryptoKey,             // PrivateKey
+  CryptoKey,             // PublicKey
+  CryptoKey              // DocumentKey
+>;
+
+export interface RootState {
+  swarm: SwarmState;
+  // ...your other slices
+}
+
+// The swarm slice can live anywhere in your store; the *Async thunks find it
+// through a selector you pass in.
+export const selectSwarmState = (root: RootState): SwarmState => root.swarm;
+
+export async function makeStore() {
+  const keypair = await crypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-384' },
+    true,
+    ['sign', 'verify'],
+  );
+
+  const serializer = new YjsJSONSerializer();
+  const rootReducer = combineReducers({
+    swarm: collabswarmReducer(
+      keypair.privateKey,
+      keypair.publicKey,
+      new YjsProvider(),
+      serializer,              // ChangesSerializer
+      serializer,              // SyncMessageSerializer
+      serializer,              // LoadMessageSerializer
+      new SubtleCrypto(),      // AuthProvider
+      new YjsACLProvider(),
+      new YjsKeychainProvider(),
+    ),
+  });
+
+  return createStore(rootReducer, applyMiddleware(thunk));
+}
+```
+
+## Dispatching document operations
+
+Five thunk action creators cover the whole lifecycle. Each accepts your state selector as its final argument (omit it only if the collabswarm state *is* the store root):
+
+```tsx
+// NoteEditor.tsx
+import React from 'react';
+import * as Y from 'yjs';
+import { useDispatch, useSelector } from 'react-redux';
+import { defaultConfig, defaultBootstrapConfig } from '@swarmbase/collabswarm';
+import {
+  initializeAsync,
+  connectAsync,
+  openDocumentAsync,
+  closeDocumentAsync,
+  changeDocumentAsync,
+} from '@swarmbase/collabswarm-redux';
+import { RootState, selectSwarmState } from './store';
+
+export function NoteEditor({ documentId }: { documentId: string }) {
+  const dispatch = useDispatch<any>();
+  const docState = useSelector(
+    (root: RootState) => root.swarm.documents[documentId],
+  );
+  const peers = useSelector((root: RootState) => root.swarm.peers);
+
+  React.useEffect(() => {
+    const config = defaultConfig(
+      defaultBootstrapConfig([
+        // '/dns4/relay.example.com/tcp/443/wss/p2p/<relay-peer-id>',
+      ]),
+    );
+    dispatch(initializeAsync(config, selectSwarmState))
+      .then(() => dispatch(openDocumentAsync(documentId, selectSwarmState)));
+
+    return () => {
+      dispatch(closeDocumentAsync(documentId, selectSwarmState));
+    };
+  }, [documentId]);
+
+  if (!docState) return <p>Opening… ({peers.length} peers)</p>;
+
+  const doc: Y.Doc = docState.document;
+  return (
+    <div>
+      <pre>{doc.getText('content').toString()}</pre>
+      <button
+        onClick={() =>
+          dispatch(
+            changeDocumentAsync(
+              documentId,
+              (current: Y.Doc) => {
+                current.getText('content').insert(0, 'Hello from Redux! ');
+              },
+              undefined,          // optional change message
+              selectSwarmState,
+            ),
+          )
+        }
+      >
+        Edit
+      </button>
+    </div>
+  );
+}
+```
+
+`connectAsync(addresses, selector)` is available for dialing extra peers after initialization.
+
+## How it works
+
+The state shape is:
+
+```typescript
+interface CollabswarmState<...> {
+  node: Collabswarm<...>;                 // the swarm node itself
+  documents: {
+    [documentPath: string]: {
+      documentRef: CollabswarmDocument<...>;
+      document: DocType;                  // current CRDT value
+      peers?: string[];
+    };
+  };
+  peers: string[];                        // connected peer addresses
+}
+```
+
+- `initializeAsync` subscribes `peer-connect`/`peer-disconnect` handlers (dispatching `PEER_CONNECT`/`PEER_DISCONNECT`), calls `node.initialize(config)`, then dispatches `INITIALIZE`.
+- `openDocumentAsync` gets a document ref via `node.doc(id)`, subscribes with the `'remote'` origin filter so each incoming remote change dispatches `SYNC_DOCUMENT`, then awaits `open()` and dispatches `OPEN_DOCUMENT`. If `open()` returns `false` (nothing found on the network) the path is treated as a new document.
+- `changeDocumentAsync` calls `documentRef.change(fn, message)` and dispatches `CHANGE_DOCUMENT` with the updated document, so local edits update the store without a network round-trip.
+- `closeDocumentAsync` unsubscribes, closes the ref, and dispatches `CLOSE_DOCUMENT`, which removes the entry from `state.documents`.
+- The reducer handles `INITIALIZE`/`CONNECT` by shallow-copying state (the mutation happened inside the node — the copy forces subscribers to re-read), and `SYNC_DOCUMENT`/`CHANGE_DOCUMENT` by replacing the `document` value for that path.
+
+All action type constants (`INITIALIZE`, `CONNECT`, `OPEN_DOCUMENT`, `CLOSE_DOCUMENT`, `SYNC_DOCUMENT`, `CHANGE_DOCUMENT`, `PEER_CONNECT`, `PEER_DISCONNECT`) and the plain action creators are exported if you need to reduce over them in your own slices.
+
+## Pitfalls
+
+- **The store holds non-serializable values by design.** `state.swarm.node` and each `documentRef` are live class instances, and Yjs mutates `document` in place. If you use Redux Toolkit, disable `serializableCheck` (and `immutableCheck`) for this slice; time-travel debugging will not faithfully replay swarm state.
+- **Keys before store.** Because the reducer factory takes the keypair, you must generate or load the user's keys before `createStore`. If your login flow produces keys later, create the store after login (or re-create it) — there is no built-in "set identity later" action.
+- **Always pass your selector.** The default selector assumes the collabswarm state is the *root* of the store. With `combineReducers` nesting, forgetting the selector argument on any `*Async` call reads `undefined` and logs "Node not initialized yet".
+- **Yjs identity vs. re-render.** `SYNC_DOCUMENT` replaces the `document` reference in the store, but for Yjs it's the same mutated `Y.Doc` object. Select derived values (e.g. `doc.getText('content').toString()`) in components rather than memoizing on the doc reference.
+- **Repo examples lag the package.** `examples/wiki-swarm` calls an older `collabswarmReducer` signature (no keypair, no load serializer). Follow the signature in this recipe, which matches the current package source.

--- a/site/src/content/docs/cookbook/redux.md
+++ b/site/src/content/docs/cookbook/redux.md
@@ -1,181 +1,108 @@
 ---
 title: Redux integration
-description: Wire Swarmbase into a Redux store with @swarmbase/collabswarm-redux reducers and thunk actions.
+description: Initialize and read Swarmbase state through Redux while accounting for the current local-change ordering bug.
 ---
 
-Your app already keeps state in Redux and you want Swarmbase documents to flow through the same store: dispatch an action to open a document, read it from state with selectors, and have remote changes arrive as ordinary actions. `@swarmbase/collabswarm-redux` provides a reducer factory and a set of thunk action creators that do this.
+**Status: Runnable from source for setup, open, read, and remote subscription; local editing is illustrative/deferred.**
 
-:::note
-The package targets classic Redux with `redux-thunk`. The in-repo examples (`examples/wiki-swarm`, `examples/browser-test`) demonstrate it with the Automerge CRDT backend; this recipe shows the same wiring with the golden-path Yjs backend and the reducer signature as currently implemented in `@swarmbase/collabswarm-redux`.
-:::
-
-## Install
-
-```sh
-npm install @swarmbase/collabswarm @swarmbase/collabswarm-yjs @swarmbase/collabswarm-redux redux redux-thunk react-redux yjs
-```
+The package is unpublished. Use repository workspaces and build them with `yarn build`. Unit tests cover Redux actions/reducers, and the Automerge examples build and smoke-test, but live multi-peer propagation is not asserted in a browser.
 
 ## Store setup
 
-`collabswarmReducer(...)` is a factory: it takes your identity keypair and the full provider stack, and returns a reducer whose initial state already contains a constructed (but uninitialized) `Collabswarm` node. That means you need the keypair *before* creating the store:
+The reducer factory needs a stable ECDSA P-384 identity before store creation. With redux-thunk 3, use its named export:
 
-```typescript
-// store.ts
-import { combineReducers, createStore, applyMiddleware } from 'redux';
-import thunk from 'redux-thunk';
-import * as Y from 'yjs';
-import { SubtleCrypto } from '@swarmbase/collabswarm';
+```ts
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import { thunk } from 'redux-thunk';
 import {
-  YjsProvider,
-  YjsJSONSerializer,
+  SubtleCrypto,
+  defaultBootstrapConfig,
+  defaultConfig,
+} from '@swarmbase/collabswarm';
+import {
   YjsACLProvider,
+  YjsJSONSerializer,
   YjsKeychainProvider,
+  YjsProvider,
 } from '@swarmbase/collabswarm-yjs';
-import { collabswarmReducer, CollabswarmState } from '@swarmbase/collabswarm-redux';
+import {
+  CollabswarmState,
+  closeDocumentAsync,
+  collabswarmReducer,
+  initializeAsync,
+  openDocumentAsync,
+} from '@swarmbase/collabswarm-redux';
+import * as Y from 'yjs';
 
-export type SwarmState = CollabswarmState<
-  Y.Doc,                 // DocType
-  Uint8Array,            // ChangesType
-  (doc: Y.Doc) => void,  // ChangeFnType
-  CryptoKey,             // PrivateKey
-  CryptoKey,             // PublicKey
-  CryptoKey              // DocumentKey
+type SwarmState = CollabswarmState<
+  Y.Doc,
+  Uint8Array,
+  (doc: Y.Doc) => void,
+  CryptoKey,
+  CryptoKey,
+  CryptoKey
 >;
+type RootState = { swarm: SwarmState };
 
-export interface RootState {
-  swarm: SwarmState;
-  // ...your other slices
-}
+const selectSwarm = (state: RootState) => state.swarm;
 
-// The swarm slice can live anywhere in your store; the *Async thunks find it
-// through a selector you pass in.
-export const selectSwarmState = (root: RootState): SwarmState => root.swarm;
-
-export async function makeStore() {
-  const keypair = await crypto.subtle.generateKey(
-    { name: 'ECDSA', namedCurve: 'P-384' },
-    true,
-    ['sign', 'verify'],
-  );
-
+function createSwarmStore(identity: CryptoKeyPair) {
   const serializer = new YjsJSONSerializer();
-  const rootReducer = combineReducers({
+  const reducer = combineReducers({
     swarm: collabswarmReducer(
-      keypair.privateKey,
-      keypair.publicKey,
+      identity.privateKey,
+      identity.publicKey,
       new YjsProvider(),
-      serializer,              // ChangesSerializer
-      serializer,              // SyncMessageSerializer
-      serializer,              // LoadMessageSerializer
-      new SubtleCrypto(),      // AuthProvider
+      serializer,
+      serializer,
+      serializer,
+      new SubtleCrypto(),
       new YjsACLProvider(),
       new YjsKeychainProvider(),
     ),
   });
-
-  return createStore(rootReducer, applyMiddleware(thunk));
+  return createStore(reducer, applyMiddleware(thunk));
 }
 ```
 
-## Dispatching document operations
+Persist `identity`; regenerating it changes ACL identity. The store intentionally contains non-serializable live node, document-ref, and Yjs values.
 
-Five thunk action creators cover the whole lifecycle. Each accepts your state selector as its final argument (omit it only if the collabswarm state *is* the store root):
+## Initialize once, then open and read
 
-```tsx
-// NoteEditor.tsx
-import React from 'react';
-import * as Y from 'yjs';
-import { useDispatch, useSelector } from 'react-redux';
-import { defaultConfig, defaultBootstrapConfig } from '@swarmbase/collabswarm';
-import {
-  initializeAsync,
-  connectAsync,
-  openDocumentAsync,
-  closeDocumentAsync,
-  changeDocumentAsync,
-} from '@swarmbase/collabswarm-redux';
-import { RootState, selectSwarmState } from './store';
+```ts
+async function openNote(identity: CryptoKeyPair) {
+  const store = createSwarmStore(identity);
+  const config = defaultConfig(defaultBootstrapConfig(
+    import.meta.env.VITE_RELAY_MULTIADDR
+      ? [import.meta.env.VITE_RELAY_MULTIADDR]
+      : [],
+  ));
 
-export function NoteEditor({ documentId }: { documentId: string }) {
-  const dispatch = useDispatch<any>();
-  const docState = useSelector(
-    (root: RootState) => root.swarm.documents[documentId],
-  );
-  const peers = useSelector((root: RootState) => root.swarm.peers);
+  await store.dispatch<any>(initializeAsync(config, selectSwarm));
+  await store.dispatch<any>(openDocumentAsync('/notes/hello', selectSwarm));
 
-  React.useEffect(() => {
-    const config = defaultConfig(
-      defaultBootstrapConfig([
-        // '/dns4/relay.example.com/tcp/443/wss/p2p/<relay-peer-id>',
-      ]),
-    );
-    dispatch(initializeAsync(config, selectSwarmState))
-      .then(() => dispatch(openDocumentAsync(documentId, selectSwarmState)));
-
-    return () => {
-      dispatch(closeDocumentAsync(documentId, selectSwarmState));
-    };
-  }, [documentId]);
-
-  if (!docState) return <p>Opening… ({peers.length} peers)</p>;
-
-  const doc: Y.Doc = docState.document;
-  return (
-    <div>
-      <pre>{doc.getText('content').toString()}</pre>
-      <button
-        onClick={() =>
-          dispatch(
-            changeDocumentAsync(
-              documentId,
-              (current: Y.Doc) => {
-                current.getText('content').insert(0, 'Hello from Redux! ');
-              },
-              undefined,          // optional change message
-              selectSwarmState,
-            ),
-          )
-        }
-      >
-        Edit
-      </button>
-    </div>
-  );
+  const opened = selectSwarm(store.getState()).documents['/notes/hello'];
+  const text = opened.document.getText('content').toString();
+  return { store, text };
 }
 ```
 
-`connectAsync(addresses, selector)` is available for dialing extra peers after initialization.
+Initialize the node once at application startup. `initializeAsync` installs peer listeners and has no matching Redux shutdown action; repeated component effects can duplicate initialization/listeners. `openDocumentAsync` subscribes with the `'remote'` filter and dispatches `SYNC_DOCUMENT` for subsequent remote events. Always pass the selector when the slice is nested.
 
-## How it works
+On teardown:
 
-The state shape is:
-
-```typescript
-interface CollabswarmState<...> {
-  node: Collabswarm<...>;                 // the swarm node itself
-  documents: {
-    [documentPath: string]: {
-      documentRef: CollabswarmDocument<...>;
-      document: DocType;                  // current CRDT value
-      peers?: string[];
-    };
-  };
-  peers: string[];                        // connected peer addresses
+```ts
+async function closeNote(store: ReturnType<typeof createSwarmStore>) {
+  await store.dispatch<any>(closeDocumentAsync('/notes/hello', selectSwarm));
 }
 ```
 
-- `initializeAsync` subscribes `peer-connect`/`peer-disconnect` handlers (dispatching `PEER_CONNECT`/`PEER_DISCONNECT`), calls `node.initialize(config)`, then dispatches `INITIALIZE`.
-- `openDocumentAsync` gets a document ref via `node.doc(id)`, subscribes with the `'remote'` origin filter so each incoming remote change dispatches `SYNC_DOCUMENT`, then awaits `open()` and dispatches `OPEN_DOCUMENT`. If `open()` returns `false` (nothing found on the network) the path is treated as a new document.
-- `changeDocumentAsync` calls `documentRef.change(fn, message)` and dispatches `CHANGE_DOCUMENT` with the updated document, so local edits update the store without a network round-trip.
-- `closeDocumentAsync` unsubscribes, closes the ref, and dispatches `CLOSE_DOCUMENT`, which removes the entry from `state.documents`.
-- The reducer handles `INITIALIZE`/`CONNECT` by shallow-copying state (the mutation happened inside the node — the copy forces subscribers to re-read), and `SYNC_DOCUMENT`/`CHANGE_DOCUMENT` by replacing the `document` value for that path.
+Cancellation is application-owned. If a component unmounts while initialization or open is pending, Redux does not abort that work; guard late continuations and avoid closing a newer open for the same path.
 
-All action type constants (`INITIALIZE`, `CONNECT`, `OPEN_DOCUMENT`, `CLOSE_DOCUMENT`, `SYNC_DOCUMENT`, `CHANGE_DOCUMENT`, `PEER_CONNECT`, `PEER_DISCONNECT`) and the plain action creators are exported if you need to reduce over them in your own slices.
+## Current local-edit bug
 
-## Pitfalls
+**Status: Deferred/incomplete integration for reliable local Yjs rendering.** `changeDocumentAsync` currently starts `documentRef.change(...)`, immediately dispatches `CHANGE_DOCUMENT` with `documentRef.document`, and only then awaits the change promise. The dispatched value can therefore be stale. Because the document subscription listens only for `'remote'` changes, no local subscription is guaranteed to repair the Redux state after the awaited mutation.
 
-- **The store holds non-serializable values by design.** `state.swarm.node` and each `documentRef` are live class instances, and Yjs mutates `document` in place. If you use Redux Toolkit, disable `serializableCheck` (and `immutableCheck`) for this slice; time-travel debugging will not faithfully replay swarm state.
-- **Keys before store.** Because the reducer factory takes the keypair, you must generate or load the user's keys before `createStore`. If your login flow produces keys later, create the store after login (or re-create it) — there is no built-in "set identity later" action.
-- **Always pass your selector.** The default selector assumes the collabswarm state is the *root* of the store. With `combineReducers` nesting, forgetting the selector argument on any `*Async` call reads `undefined` and logs "Node not initialized yet".
-- **Yjs identity vs. re-render.** `SYNC_DOCUMENT` replaces the `document` reference in the store, but for Yjs it's the same mutated `Y.Doc` object. Select derived values (e.g. `doc.getText('content').toString()`) in components rather than memoizing on the doc reference.
-- **Repo examples lag the package.** `examples/wiki-swarm` calls an older `collabswarmReducer` signature (no keypair, no load serializer). Follow the signature in this recipe, which matches the current package source.
+Yjs also mutates a `Y.Doc` in place, so selecting the document object does not guarantee a rerender from reference identity. Do not claim reliable local Yjs rerenders from the current thunk. Until the thunk dispatches after the awaited mutation (and has focused tests), perform local editing through an application layer that awaits the direct document ref, reports rejection, and explicitly publishes derived Redux state.
+
+Remote read state remains useful, but select derived primitives such as text strings rather than memoizing on the `Y.Doc` reference. See [Limitations](../../concepts/limitations/) for mutation and delivery semantics.

--- a/site/src/content/docs/cookbook/running-a-relay.md
+++ b/site/src/content/docs/cookbook/running-a-relay.md
@@ -1,6 +1,113 @@
 ---
-title: Run your own relay
-description: Deploy the bootstrap/relay node your peers use to find each other.
+title: Run your own relay node
+description: Deploy the Swarmbase bootstrap/relay server with Docker and point your clients at it.
 ---
 
-This page is being written. Until it lands, the [GitHub repository](https://github.com/swarmbase/swarmbase) is the best source.
+Browsers can't accept incoming connections, so two Swarmbase peers behind NATs need a meeting point: a relay server that provides **bootstrap** (initial peer discovery over GossipSub) and **circuit relay** (forwarding traffic until — and unless — a direct WebRTC connection can be established). Every deployment needs at least one; this recipe gets a single relay running with Docker and shows how clients dial it.
+
+## Run a single relay with Docker
+
+The relay lives in `relay-server/` in the repository. Build and run it:
+
+```bash
+# From the repository root
+docker build -t swarmbase-relay relay-server/
+
+docker run -d \
+  --name swarmbase-relay \
+  -p 9001:9001 \
+  -p 9002:9002 \
+  -v relay-data:/shared \
+  swarmbase-relay
+```
+
+Port **9001** serves WebSocket connections (browsers); port **9002** serves TCP (Node.js peers and relay-to-relay links). A single-server Compose file is also provided:
+
+```bash
+docker compose -f guides/docker/docker-compose.single.yaml up -d
+```
+
+## Get the relay's address
+
+On startup the relay generates a peer ID and writes its connection info:
+
+```bash
+docker exec swarmbase-relay cat /shared/relay-info.json
+```
+
+```json
+{
+  "peerId": "12D3KooW...",
+  "multiaddrs": [
+    "/ip4/0.0.0.0/tcp/9001/ws/p2p/12D3KooW...",
+    "/ip4/0.0.0.0/tcp/9002/p2p/12D3KooW..."
+  ],
+  "wsMultiaddr": "/ip4/0.0.0.0/tcp/9001/ws/p2p/12D3KooW..."
+}
+```
+
+:::caution
+The `wsMultiaddr` in that file contains the *listen* address (`0.0.0.0`), which is not dialable from another machine. Construct the client-facing multiaddr yourself from your server's public IP or DNS name plus the `peerId`:
+
+```text
+/dns4/relay.example.com/tcp/9001/ws/p2p/<peerId>
+# or
+/ip4/<PUBLIC_IP>/tcp/9001/ws/p2p/<peerId>
+```
+:::
+
+## Point clients at it
+
+In the browser, pass the relay multiaddr as a bootstrap peer:
+
+```typescript
+import { defaultConfig, defaultBootstrapConfig } from '@swarmbase/collabswarm';
+
+const config = defaultConfig(
+  defaultBootstrapConfig([
+    '/dns4/relay.example.com/tcp/9001/ws/p2p/12D3KooW...',
+  ]),
+);
+// pass `config` to collabswarm.initialize(config) / useCollabswarm(..., config)
+```
+
+In a Node.js process, use the Node-only helper from the `/node` subpath:
+
+```typescript
+import { defaultNodeConfig } from '@swarmbase/collabswarm/node';
+
+const config = defaultNodeConfig({
+  list: ['/dns4/relay.example.com/tcp/9001/ws/p2p/12D3KooW...'],
+});
+```
+
+The repository's example apps read the multiaddr from a `REACT_APP_RELAY_MULTIADDR` env var — any mechanism that gets the string into your client build works.
+
+## How it works
+
+1. The browser dials the relay over WebSocket and completes libp2p `identify`.
+2. `pubsub-peer-discovery` advertises the new peer to everyone connected to the relay, forming a GossipSub mesh.
+3. The relay auto-subscribes to document topics as peers join them, so it forwards sync messages between browsers that can't reach each other yet. When all peers leave a topic it unsubscribes.
+4. Where NATs allow, libp2p upgrades pairs of peers to direct WebRTC connections (using public STUN servers by default), taking the relay out of the data path.
+
+Useful environment variables: `WS_PORT` / `TCP_PORT` (listen ports), `TOPIC_ALLOWLIST` (comma-separated topic prefixes, e.g. `/document/,/documents` — set this in production), and `MAX_AUTO_TOPICS` (cap on auto-subscriptions, default 1000).
+
+## Going to production
+
+For anything beyond development, two things change — TLS and redundancy. The full reference is [`docs/deployment.md`](https://github.com/swarmbase/swarmbase/blob/main/docs/deployment.md) (Docker, Caddy/TLS, Kubernetes, Fly.io, monitoring); the short version:
+
+- **TLS is mandatory for HTTPS-served apps.** Browsers block plain `ws://` from HTTPS pages, so put a TLS-terminating reverse proxy (Caddy, nginx) in front of port 9001 and dial `/dns4/relay.example.com/tcp/443/wss/p2p/<peerId>`. Use a proxy that forwards WebSocket upgrades transparently — not one that splits the connection into a second upstream WebSocket.
+- **Run two or more relays, each with its own DNS name.** Configure clients with *all* of their multiaddrs; connecting to any one is enough to discover the network.
+- **Relays don't discover each other automatically.** Peers connected to different relays won't see each other's messages unless you peer the relays, e.g. by having each relay dial the others' TCP (`9002`) multiaddrs at startup.
+
+:::caution[One load-balanced hostname across relays breaks dialing]
+A libp2p multiaddr ends in a specific peer ID. If `relay.example.com` round-robins across relay-1 and relay-2, a dial to `/dns4/relay.example.com/.../p2p/<peerId-of-relay-1>` fails whenever the load balancer lands on relay-2. Give each relay its own hostname (`relay-1.example.com`, `relay-2.example.com`). In principle stable pre-generated peer IDs plus sticky sessions could make a shared hostname work, but the current relay generates a fresh peer ID on every start and exposes no option to persist one — one-hostname-per-relay is the supported path today.
+:::
+
+## Pitfalls
+
+- **Peer IDs are ephemeral.** Every relay restart generates a new peer ID, invalidating multiaddrs baked into deployed clients. Persist and inject the libp2p key if you need stable addresses (currently requires modifying the relay code).
+- **Dialing the listen address.** The most common "can't connect" cause is copying `wsMultiaddr` (a `0.0.0.0` address) straight into client config. Always construct the public address.
+- **Open topic mode by default.** Without `TOPIC_ALLOWLIST`, the relay auto-subscribes to any non-system topic peers use. Fine for development; restrict it in production.
+- **A relay is not a pinning service.** It forwards traffic and does not durably store document data. If all browsers holding a document go away, the relay won't save you — see [Keeping data alive](../pinning/).
+- **Health checking is TCP-only.** The images ship a TCP connect check on port 9001; there is no HTTP health endpoint.

--- a/site/src/content/docs/cookbook/running-a-relay.md
+++ b/site/src/content/docs/cookbook/running-a-relay.md
@@ -1,18 +1,18 @@
 ---
 title: Run your own relay node
-description: Deploy the Swarmbase bootstrap/relay server with Docker and point your clients at it.
+description: Run the repository's development relay and configure Vite browser clients to dial it.
 ---
 
-Browsers can't accept incoming connections, so two Swarmbase peers behind NATs need a meeting point: a relay server that provides **bootstrap** (initial peer discovery over GossipSub) and **circuit relay** (forwarding traffic until — and unless — a direct WebRTC connection can be established). Every deployment needs at least one; this recipe gets a single relay running with Docker and shows how clients dial it.
+**Status: Runnable development relay.** The relay builds and has unit coverage; deployment, failover, stable identity, and scale are not production-validated.
 
-## Run a single relay with Docker
+Browser deployments generally need bootstrap/relay infrastructure because browsers cannot usually accept arbitrary inbound connections. Not every topology routes all traffic through a relay: peers may discover direct WebRTC paths, and Node/LAN topologies may use other discovery. See [Networking](../../concepts/networking/).
 
-The relay lives in `relay-server/` in the repository. Build and run it:
+## Start the development relay
 
-```bash
-# From the repository root
+From the repository root:
+
+```sh
 docker build -t swarmbase-relay relay-server/
-
 docker run -d \
   --name swarmbase-relay \
   -p 9001:9001 \
@@ -21,93 +21,60 @@ docker run -d \
   swarmbase-relay
 ```
 
-Port **9001** serves WebSocket connections (browsers); port **9002** serves TCP (Node.js peers and relay-to-relay links). A single-server Compose file is also provided:
+Port 9001 is WebSocket; port 9002 is plain TCP. The equivalent checked-in Compose command is:
 
-```bash
+```sh
 docker compose -f guides/docker/docker-compose.single.yaml up -d
+docker compose -f guides/docker/docker-compose.single.yaml exec relay \
+  cat /shared/relay-info.json
 ```
 
-## Get the relay's address
+For the direct `docker run` container, inspect the same file with:
 
-On startup the relay generates a peer ID and writes its connection info:
-
-```bash
+```sh
 docker exec swarmbase-relay cat /shared/relay-info.json
 ```
 
-```json
-{
-  "peerId": "12D3KooW...",
-  "multiaddrs": [
-    "/ip4/0.0.0.0/tcp/9001/ws/p2p/12D3KooW...",
-    "/ip4/0.0.0.0/tcp/9002/p2p/12D3KooW..."
-  ],
-  "wsMultiaddr": "/ip4/0.0.0.0/tcp/9001/ws/p2p/12D3KooW..."
-}
-```
-
-:::caution
-The `wsMultiaddr` in that file contains the *listen* address (`0.0.0.0`), which is not dialable from another machine. Construct the client-facing multiaddr yourself from your server's public IP or DNS name plus the `peerId`:
+The file contains the generated peer ID and listen multiaddrs. Do not give clients `/ip4/0.0.0.0/...`; construct a dialable address:
 
 ```text
-/dns4/relay.example.com/tcp/9001/ws/p2p/<peerId>
-# or
-/ip4/<PUBLIC_IP>/tcp/9001/ws/p2p/<peerId>
-```
-:::
-
-## Point clients at it
-
-In the browser, pass the relay multiaddr as a bootstrap peer:
-
-```typescript
-import { defaultConfig, defaultBootstrapConfig } from '@swarmbase/collabswarm';
-
-const config = defaultConfig(
-  defaultBootstrapConfig([
-    '/dns4/relay.example.com/tcp/9001/ws/p2p/12D3KooW...',
-  ]),
-);
-// pass `config` to collabswarm.initialize(config) / useCollabswarm(..., config)
+/dns4/relay.example.com/tcp/9001/ws/p2p/<peer-id>
 ```
 
-In a Node.js process, use the Node-only helper from the `/node` subpath:
+## Configure Vite clients
 
-```typescript
-import { defaultNodeConfig } from '@swarmbase/collabswarm/node';
+The repository examples read `VITE_RELAY_MULTIADDR`:
 
-const config = defaultNodeConfig({
-  list: ['/dns4/relay.example.com/tcp/9001/ws/p2p/12D3KooW...'],
-});
+```sh
+VITE_RELAY_MULTIADDR='/dns4/relay.example.com/tcp/9001/ws/p2p/<peer-id>' \
+  yarn workspace @swarmbase/browser-test start
 ```
 
-The repository's example apps read the multiaddr from a `REACT_APP_RELAY_MULTIADDR` env var — any mechanism that gets the string into your client build works.
+Application code passes it to the bootstrap list:
 
-## How it works
+```ts
+const relay = import.meta.env.VITE_RELAY_MULTIADDR;
+const config = defaultConfig(defaultBootstrapConfig(relay ? [relay] : []));
+```
 
-1. The browser dials the relay over WebSocket and completes libp2p `identify`.
-2. `pubsub-peer-discovery` advertises the new peer to everyone connected to the relay, forming a GossipSub mesh.
-3. The relay auto-subscribes to document topics as peers join them, so it forwards sync messages between browsers that can't reach each other yet. When all peers leave a topic it unsubscribes.
-4. Where NATs allow, libp2p upgrades pairs of peers to direct WebRTC connections (using public STUN servers by default), taking the relay out of the data path.
+## TLS and reverse proxying
 
-Useful environment variables: `WS_PORT` / `TCP_PORT` (listen ports), `TOPIC_ALLOWLIST` (comma-separated topic prefixes, e.g. `/document/,/documents` — set this in production), and `MAX_AUTO_TOPICS` (cap on auto-subscriptions, default 1000).
+An HTTPS page must dial secure WebSockets. Terminate TLS at a reverse proxy on 443, configure it to preserve the WebSocket HTTP Upgrade and proxy that connection to relay port 9001, then use:
 
-## Going to production
+```text
+/dns4/relay.example.com/tcp/443/wss/p2p/<peer-id>
+```
 
-For anything beyond development, two things change — TLS and redundancy. The full reference is [`docs/deployment.md`](https://github.com/swarmbase/swarmbase/blob/main/docs/deployment.md) (Docker, Caddy/TLS, Kubernetes, Fly.io, monitoring); the short version:
+This source recipe does not establish a production deployment. Validate proxy timeouts, connection limits, certificates, resource limits, logs, and denial-of-service behavior in your environment.
 
-- **TLS is mandatory for HTTPS-served apps.** Browsers block plain `ws://` from HTTPS pages, so put a TLS-terminating reverse proxy (Caddy, nginx) in front of port 9001 and dial `/dns4/relay.example.com/tcp/443/wss/p2p/<peerId>`. Use a proxy that forwards WebSocket upgrades transparently — not one that splits the connection into a second upstream WebSocket.
-- **Run two or more relays, each with its own DNS name.** Configure clients with *all* of their multiaddrs; connecting to any one is enough to discover the network.
-- **Relays don't discover each other automatically.** Peers connected to different relays won't see each other's messages unless you peer the relays, e.g. by having each relay dial the others' TCP (`9002`) multiaddrs at startup.
+## Operational limits
 
-:::caution[One load-balanced hostname across relays breaks dialing]
-A libp2p multiaddr ends in a specific peer ID. If `relay.example.com` round-robins across relay-1 and relay-2, a dial to `/dns4/relay.example.com/.../p2p/<peerId-of-relay-1>` fails whenever the load balancer lands on relay-2. Give each relay its own hostname (`relay-1.example.com`, `relay-2.example.com`). In principle stable pre-generated peer IDs plus sticky sessions could make a shared hostname work, but the current relay generates a fresh peer ID on every start and exposes no option to persist one — one-hostname-per-relay is the supported path today.
-:::
+- The relay generates a new libp2p peer identity at startup. Restart changes the peer ID and invalidates client multiaddrs. Stable identity requires unsupported application/code work today.
+- There is no supported relay-meshing or startup-dial configuration. Multiple isolated relays are not proven failover simply because all addresses are listed in a client.
+- `TOPIC_ALLOWLIST` limits which non-system topics the relay **auto-subscribes** to. It is not user authentication, document authorization, or a confidentiality boundary.
+- `MAX_AUTO_TOPICS` caps automatic subscriptions. `EXTRA_TOPICS` adds static subscriptions; neither creates relay peering.
+- Docker health checks only establish a TCP connection to port **9001**. There is no HTTP readiness endpoint and the check does not prove GossipSub, circuit reservation, or end-to-end document sync.
+- The relay forwards traffic and metadata but does not durably store documents. Pinning remains [incomplete](../pinning/).
+- Relay failover during edits, upgrade/rollback, capacity, abuse resistance, monitoring, and production scale are unverified. Relays can observe metadata and can censor, delay, or partition traffic.
 
-## Pitfalls
-
-- **Peer IDs are ephemeral.** Every relay restart generates a new peer ID, invalidating multiaddrs baked into deployed clients. Persist and inject the libp2p key if you need stable addresses (currently requires modifying the relay code).
-- **Dialing the listen address.** The most common "can't connect" cause is copying `wsMultiaddr` (a `0.0.0.0` address) straight into client config. Always construct the public address.
-- **Open topic mode by default.** Without `TOPIC_ALLOWLIST`, the relay auto-subscribes to any non-system topic peers use. Fine for development; restrict it in production.
-- **A relay is not a pinning service.** It forwards traffic and does not durably store document data. If all browsers holding a document go away, the relay won't save you — see [Keeping data alive](../pinning/).
-- **Health checking is TCP-only.** The images ship a TCP connect check on port 9001; there is no HTTP health endpoint.
+Use separate DNS names for distinct peer IDs; a load-balanced hostname can route a multiaddr ending in one peer ID to the wrong relay process. Consult [Limitations](../../concepts/limitations/) before deployment.

--- a/site/src/content/docs/cookbook/search-indexing.md
+++ b/site/src/content/docs/cookbook/search-indexing.md
@@ -1,6 +1,188 @@
 ---
-title: Search encrypted documents
-description: Blind indexing and bloom-filter gossip with collabswarm-index.
+title: Searching encrypted documents
+description: Query your Swarmbase documents locally, and search across peers without revealing plaintext, with @swarmbase/collabswarm-index.
 ---
 
-This page is being written. Until it lands, the [GitHub repository](https://github.com/swarmbase/swarmbase) is the best source.
+Your documents are end-to-end encrypted, so no server can build a search index for you — and you wouldn't want one that could. You still need "find all articles by Alice, newest first" to be fast, and ideally to discover which *peers* might hold matching documents without telling them what you're looking for. `@swarmbase/collabswarm-index` gives you three composable pieces: a local materialized index, blind index tokens for encrypted equality search, and Bloom filter gossip for peer discovery.
+
+## Install
+
+```sh
+npm install @swarmbase/collabswarm-index
+```
+
+## Local index: query the documents you hold
+
+Since every peer decrypts the documents it has access to, each peer can index its *own* copies. `IndexManager` maintains a queryable materialized view, fed by document change events:
+
+```typescript
+import * as Y from 'yjs';
+import {
+  IndexManager,
+  IDBIndexStorage,        // IndexedDB persistence (browser)
+  // MemoryIndexStorage,  // in-memory alternative (tests / Node)
+  CollabswarmIndexIntegration,
+} from '@swarmbase/collabswarm-index';
+
+// The extractor turns your CRDT doc into a plain snapshot for indexing.
+const storage = new IDBIndexStorage('my-app-index');
+const manager = new IndexManager<Y.Doc>(
+  storage,
+  (doc) => doc.getMap('meta').toJSON(),
+);
+
+await manager.defineIndex({
+  name: 'articles',
+  collectionPrefix: '/articles/',   // which document paths belong to this index
+  fields: [
+    { path: 'title', type: 'string' },
+    { path: 'author', type: 'string' },
+    { path: 'createdOn', type: 'date' },
+    { path: 'viewCount', type: 'number' },
+  ],
+});
+
+// Keep the index in sync with a live document. CollabswarmDocument
+// satisfies the SubscribableDocument interface directly.
+const integration = new CollabswarmIndexIntegration(manager);
+integration.trackDocument(docRef);      // indexes now + on every change
+// later: integration.untrackDocument(docRef);
+
+// Query it.
+const result = await manager.query({
+  indexName: 'articles',
+  filters: [{ path: 'author', operator: 'eq', value: 'Alice' }],
+  sort: [{ path: 'createdOn', direction: 'desc' }],
+  limit: 20,
+});
+// result.documents: [{ documentPath, snapshot }, ...]
+// result.totalCount: matches before limit/offset
+```
+
+Supported filter operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `prefix`, `in`, `contains`.
+
+### React hooks
+
+Live query results come from the `react` subpath:
+
+```tsx
+import { IndexManager, IndexDefinition } from '@swarmbase/collabswarm-index';
+import { useDefineIndexes, useIndexQuery } from '@swarmbase/collabswarm-index/react';
+
+function ArticleSearch({
+  manager,
+  definitions,
+}: {
+  manager: IndexManager<unknown>;
+  definitions: IndexDefinition[];   // e.g. [the 'articles' definition above]
+}) {
+  const ready = useDefineIndexes(manager, definitions);
+  const result = useIndexQuery(manager, {
+    indexName: 'articles',
+    filters: [{ path: 'author', operator: 'eq', value: 'Alice' }],
+  });
+
+  if (!ready) return <p>Preparing index…</p>;
+  return (
+    <ul>
+      {result.documents.map((d) => (
+        <li key={d.documentPath}>{String((d.snapshot as any).title)}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`useIndexQuery` subscribes to the manager and re-renders whenever the result set may have changed; `useDefineIndexes` registers definitions on mount and removes them on unmount.
+
+## Blind index: equality search without plaintext
+
+A blind index maps a field value to a deterministic token — `HMAC-SHA-256(fieldKey, normalize(value))`, truncated and base64url-encoded. Whoever holds the field key can compute the token for a query value and compare tokens; anyone else sees only opaque strings. Field keys are derived per field path with HKDF, so tokens for `title` and `author` are cryptographically unrelated:
+
+```typescript
+import {
+  SubtleBlindIndexProvider,
+  BlindIndexQuery,
+  BlindIndexEntry,
+} from '@swarmbase/collabswarm-index';
+
+const provider = new SubtleBlindIndexProvider(); // 16-byte (128-bit) tokens by default
+
+// Derive a per-field key from 32 bytes of shared secret material.
+// (deriveFieldKey(masterCryptoKey, path) also exists, but requires a
+// raw-exportable key; the raw-bytes form is preferred.)
+const fieldKey = await provider.deriveFieldKeyFromRaw(rawKeyMaterial, 'author');
+
+// Writer side: compute a token when a document changes.
+const token = await provider.computeToken(fieldKey, 'Alice');
+// e.g. store alongside the encrypted change: { author: 'q1w2e3...' }
+
+// Query side: match entries by token equality.
+const query = new BlindIndexQuery(provider);
+const matches: BlindIndexEntry[] = await query.exactMatch(
+  fieldKey,
+  'author',
+  'alice',            // values are normalized (lowercased/trimmed) before HMAC
+  entries,            // BlindIndexEntry[]: { documentPath, blindIndexTokens }
+);
+
+// Multi-field equality with a single compound token:
+const compound = await provider.computeCompoundToken(fieldKey, ['Alice', 'Technology']);
+```
+
+The Swarmbase wire format already reserves a slot for these: every encrypted change block has an optional `blindIndexTokens: Record<string, string>` field that serializers validate and carry end-to-end. There is not yet a high-level `document.change()` option that computes and attaches tokens for you — today you compute tokens with the provider and distribute the `BlindIndexEntry` records at the application level. This wiring is an active area of development.
+
+## Bloom filter gossip: which peers should I even ask?
+
+To search beyond your own documents, peers periodically gossip Bloom filters summarizing the (tokenized) terms in their indexes. You can then ask "which peers *might* match all these terms?" without any peer learning your query terms in plaintext:
+
+```typescript
+import { BloomFilterGossip } from '@swarmbase/collabswarm-index';
+
+const gossip = new BloomFilterGossip({
+  // defaults: topic '/collabswarm/bloom-index/1.0.0',
+  // 65,536-bit filter, 7 hash functions, republish every 30s
+});
+
+// Wire it to your libp2p pubsub before starting.
+gossip.setPubSub(
+  async (topic, data) => { /* pubsub.publish(topic, data) */ },
+  (topic, handler) => { /* pubsub.subscribe + route messages to handler(peerId, data) */ },
+  (topic) => { /* pubsub.unsubscribe(topic) */ },
+);
+gossip.start();
+
+// Advertise blind-index tokens (not plaintext!) from your own documents.
+gossip.addTerm(token);
+
+// Find candidate peers for a query (must match ALL terms).
+const candidatePeers = gossip.queryPeers([queryToken]);
+// Then fetch/ask only those peers. Expect false positives — verify locally.
+
+gossip.stop();
+```
+
+## Privacy trade-offs — read before shipping
+
+Blind indexing is a deliberate compromise, not "free" encrypted search:
+
+- **Equality patterns leak.** Tokens are deterministic: an observer can tell that two documents share the same (unknown) author, and can build frequency histograms. If they can *guess* a value and obtain the field key, they can confirm it.
+- **Token truncation is a dial.** The default 16-byte tokens balance collision resistance against leakage; shorter tokens (`new SubtleBlindIndexProvider(8)`) increase false positives but reveal less.
+- **Bloom filters leak probabilistic membership.** A gossiped filter lets anyone test candidate tokens against your document set. Filters also only ever *add* bits — they don't forget deleted documents until rebuilt.
+- **Only equality (and compound equality).** No substring, range, or relevance queries over encrypted data — those run on your local decrypted index instead.
+
+## Performance framing
+
+The package ships benchmark suites (`packages/collabswarm-index/src/__benchmarks__/`) you can run with `yarn benchmark`:
+
+- **Blind index ops are cheap** — a token is one HMAC-SHA-256 (plus a one-time HKDF per field key); the suite measures derivation, string/numeric/compound token generation, and match throughput.
+- **Local queries are measured up to 100k entries** — exact-match, range, prefix, compound, and sorted queries against `MemoryIndexStorage`, plus a full-scan baseline, so you can see where an index stops being "instant" for your data size.
+- **Bloom filters scale by size, not content** — insert/query/merge/serialize are benchmarked from 1k-bit to 1M-bit filters; false-positive rate is measured against fill ratio, which is what you tune `filterSizeInBits` against.
+
+## Pitfalls
+
+- **The index only covers documents you track.** There is no network crawler: if you never opened and `trackDocument`-ed a document, it isn't in your local index. Design an index document or use the Bloom gossip layer for discovery.
+- **`removeIndex` deletes stored entries**, and `useDefineIndexes` removes its definitions on unmount — don't treat the materialized index as durable app data; treat it as a rebuildable cache (`rebuildIndex` exists for exactly that).
+- **Keep indexed fields at stable paths.** The extractor + dot-notation field paths (`meta.author`) only work if all documents in a collection put fields in the same place — see the schema recipe's [indexing guidance](../yjs-schema-design/).
+- **Guard the field keys.** Anyone holding a blind-index field key can run confirmation attacks on that field forever. Distribute them like document keys, and don't reuse them across unrelated collections.
+- **Alpha status.** The local index and blind-index/Bloom primitives are implemented and tested, but the end-to-end story (auto-attaching tokens to change blocks, cross-peer query execution) is still being assembled. Expect APIs to move.

--- a/site/src/content/docs/cookbook/search-indexing.md
+++ b/site/src/content/docs/cookbook/search-indexing.md
@@ -1,188 +1,111 @@
 ---
 title: Searching encrypted documents
-description: Query your Swarmbase documents locally, and search across peers without revealing plaintext, with @swarmbase/collabswarm-index.
+description: Use tested local index primitives and assess incomplete blind-index and Bloom-gossip integration.
 ---
 
-Your documents are end-to-end encrypted, so no server can build a search index for you — and you wouldn't want one that could. You still need "find all articles by Alice, newest first" to be fast, and ideally to discover which *peers* might hold matching documents without telling them what you're looking for. `@swarmbase/collabswarm-index` gives you three composable pieces: a local materialized index, blind index tokens for encrypted equality search, and Bloom filter gossip for peer discovery.
+## Local materialized indexes
 
-## Install
+**Status: Runnable from source.** `IndexManager`, memory/IndexedDB storage, field extraction, and React query bindings have focused tests. They index decrypted documents already available to the local application; they are not a network crawler.
 
-```sh
-npm install @swarmbase/collabswarm-index
-```
+Packages are unpublished. Use the repository workspace after following the [quick start](../../getting-started/quick-start/).
 
-## Local index: query the documents you hold
+Define the index, wait for storage readiness, update it, and only then query:
 
-Since every peer decrypts the documents it has access to, each peer can index its *own* copies. `IndexManager` maintains a queryable materialized view, fed by document change events:
-
-```typescript
+```ts
 import * as Y from 'yjs';
 import {
+  IndexDefinition,
   IndexManager,
-  IDBIndexStorage,        // IndexedDB persistence (browser)
-  // MemoryIndexStorage,  // in-memory alternative (tests / Node)
-  CollabswarmIndexIntegration,
+  MemoryIndexStorage,
 } from '@swarmbase/collabswarm-index';
 
-// The extractor turns your CRDT doc into a plain snapshot for indexing.
-const storage = new IDBIndexStorage('my-app-index');
-const manager = new IndexManager<Y.Doc>(
-  storage,
-  (doc) => doc.getMap('meta').toJSON(),
-);
-
-await manager.defineIndex({
+const definition: IndexDefinition = {
   name: 'articles',
-  collectionPrefix: '/articles/',   // which document paths belong to this index
+  collectionPrefix: '/articles/',
   fields: [
     { path: 'title', type: 'string' },
     { path: 'author', type: 'string' },
-    { path: 'createdOn', type: 'date' },
-    { path: 'viewCount', type: 'number' },
   ],
-});
+};
+const manager = new IndexManager<Y.Doc>(
+  new MemoryIndexStorage(),
+  (doc) => doc.getMap('meta').toJSON(),
+);
+const article = new Y.Doc();
+article.getMap('meta').set('title', 'Local-first search');
+article.getMap('meta').set('author', 'Alice');
 
-// Keep the index in sync with a live document. CollabswarmDocument
-// satisfies the SubscribableDocument interface directly.
-const integration = new CollabswarmIndexIntegration(manager);
-integration.trackDocument(docRef);      // indexes now + on every change
-// later: integration.untrackDocument(docRef);
-
-// Query it.
+await manager.defineIndex(definition);
+await manager.updateIndex('/articles/local-first', article);
 const result = await manager.query({
   indexName: 'articles',
   filters: [{ path: 'author', operator: 'eq', value: 'Alice' }],
-  sort: [{ path: 'createdOn', direction: 'desc' }],
-  limit: 20,
 });
-// result.documents: [{ documentPath, snapshot }, ...]
-// result.totalCount: matches before limit/offset
 ```
 
-Supported filter operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `prefix`, `in`, `contains`.
+`CollabswarmIndexIntegration.trackDocument(docRef)` subscribes and starts indexing, but its initial update is fire-and-forget. If the first query must include the document, call and await `manager.updateIndex(docRef.documentPath, docRef.document)` before querying. Untrack or dispose subscriptions during teardown.
 
-### React hooks
+### Gate React queries after definition readiness
 
-Live query results come from the `react` subpath:
+Do not call the query hook in the same component before asynchronous definitions are ready. Gate a child component instead:
 
 ```tsx
-import { IndexManager, IndexDefinition } from '@swarmbase/collabswarm-index';
-import { useDefineIndexes, useIndexQuery } from '@swarmbase/collabswarm-index/react';
+function SearchRoot({ manager }: { manager: IndexManager<unknown> }) {
+  const ready = useDefineIndexes(manager, [definition]);
+  return ready ? <ReadySearch manager={manager} /> : <p>Preparing index…</p>;
+}
 
-function ArticleSearch({
-  manager,
-  definitions,
-}: {
-  manager: IndexManager<unknown>;
-  definitions: IndexDefinition[];   // e.g. [the 'articles' definition above]
-}) {
-  const ready = useDefineIndexes(manager, definitions);
+function ReadySearch({ manager }: { manager: IndexManager<unknown> }) {
   const result = useIndexQuery(manager, {
     indexName: 'articles',
     filters: [{ path: 'author', operator: 'eq', value: 'Alice' }],
   });
-
-  if (!ready) return <p>Preparing index…</p>;
-  return (
-    <ul>
-      {result.documents.map((d) => (
-        <li key={d.documentPath}>{String((d.snapshot as any).title)}</li>
-      ))}
-    </ul>
-  );
+  return <p>{result.totalCount} result(s)</p>;
 }
 ```
 
-`useIndexQuery` subscribes to the manager and re-renders whenever the result set may have changed; `useDefineIndexes` registers definitions on mount and removes them on unmount.
+`useDefineIndexes` removes its indexes on cleanup, which clears stored entries. Treat the local index as a rebuildable cache, not source data.
 
-## Blind index: equality search without plaintext
+## Blind-index primitives
 
-A blind index maps a field value to a deterministic token — `HMAC-SHA-256(fieldKey, normalize(value))`, truncated and base64url-encoded. Whoever holds the field key can compute the token for a query value and compare tokens; anyone else sees only opaque strings. Field keys are derived per field path with HKDF, so tokens for `title` and `author` are cryptographically unrelated:
+**Status: Illustrative pattern.** `SubtleBlindIndexProvider` and `BlindIndexQuery` implement tested equality-token primitives. The normal document change API does not automatically derive, attach, distribute, rotate, or query tokens.
 
-```typescript
+```ts
 import {
-  SubtleBlindIndexProvider,
   BlindIndexQuery,
-  BlindIndexEntry,
+  SubtleBlindIndexProvider,
 } from '@swarmbase/collabswarm-index';
+import type { BlindIndexEntry } from '@swarmbase/collabswarm-index';
 
-const provider = new SubtleBlindIndexProvider(); // 16-byte (128-bit) tokens by default
-
-// Derive a per-field key from 32 bytes of shared secret material.
-// (deriveFieldKey(masterCryptoKey, path) also exists, but requires a
-// raw-exportable key; the raw-bytes form is preferred.)
-const fieldKey = await provider.deriveFieldKeyFromRaw(rawKeyMaterial, 'author');
-
-// Writer side: compute a token when a document changes.
-const token = await provider.computeToken(fieldKey, 'Alice');
-// e.g. store alongside the encrypted change: { author: 'q1w2e3...' }
-
-// Query side: match entries by token equality.
-const query = new BlindIndexQuery(provider);
-const matches: BlindIndexEntry[] = await query.exactMatch(
-  fieldKey,
+const provider = new SubtleBlindIndexProvider();
+const rawKeyMaterial = crypto.getRandomValues(new Uint8Array(32));
+const fieldKey = await provider.deriveFieldKeyFromRaw(
+  rawKeyMaterial,
   'author',
-  'alice',            // values are normalized (lowercased/trimmed) before HMAC
-  entries,            // BlindIndexEntry[]: { documentPath, blindIndexTokens }
 );
-
-// Multi-field equality with a single compound token:
-const compound = await provider.computeCompoundToken(fieldKey, ['Alice', 'Technology']);
+const token = await provider.computeToken(fieldKey, 'Alice');
+const entries: BlindIndexEntry[] = [
+  {
+    documentPath: '/articles/local-first',
+    blindIndexTokens: { author: token },
+  },
+];
+const query = new BlindIndexQuery(provider);
+const matches = await query.exactMatch(fieldKey, 'author', 'Alice', entries);
 ```
 
-The Swarmbase wire format already reserves a slot for these: every encrypted change block has an optional `blindIndexTokens: Record<string, string>` field that serializers validate and carry end-to-end. There is not yet a high-level `document.change()` option that computes and attaches tokens for you — today you compute tokens with the provider and distribute the `BlindIndexEntry` records at the application level. This wiring is an active area of development.
+Applications must define authenticated token transport and key distribution. Deterministic equality tokens leak equality/frequency information and permit confirmation attacks to holders of the field key.
 
-## Bloom filter gossip: which peers should I even ask?
+## Bloom gossip
 
-To search beyond your own documents, peers periodically gossip Bloom filters summarizing the (tokenized) terms in their indexes. You can then ask "which peers *might* match all these terms?" without any peer learning your query terms in plaintext:
+**Status: Deferred/incomplete integration.** `BloomFilterGossip` returns only candidate peer IDs and can produce false positives. Its publish, subscribe, and unsubscribe callbacks must be wired by the application to actual pubsub; it does not fetch documents or execute a remote query.
 
-```typescript
-import { BloomFilterGossip } from '@swarmbase/collabswarm-index';
+Filters use grow-only OR merge state. There is no deletion, reset, or rebuild operation in the gossip API, so removed terms continue to match and repeated state accumulates. Create a new versioned filter/topic in application code if bounded rebuild semantics are required. Never gossip plaintext terms when the privacy design requires blind tokens.
 
-const gossip = new BloomFilterGossip({
-  // defaults: topic '/collabswarm/bloom-index/1.0.0',
-  // 65,536-bit filter, 7 hash functions, republish every 30s
-});
+## Verify
 
-// Wire it to your libp2p pubsub before starting.
-gossip.setPubSub(
-  async (topic, data) => { /* pubsub.publish(topic, data) */ },
-  (topic, handler) => { /* pubsub.subscribe + route messages to handler(peerId, data) */ },
-  (topic) => { /* pubsub.unsubscribe(topic) */ },
-);
-gossip.start();
-
-// Advertise blind-index tokens (not plaintext!) from your own documents.
-gossip.addTerm(token);
-
-// Find candidate peers for a query (must match ALL terms).
-const candidatePeers = gossip.queryPeers([queryToken]);
-// Then fetch/ask only those peers. Expect false positives — verify locally.
-
-gossip.stop();
+```sh
+yarn workspace @swarmbase/collabswarm-index test
 ```
 
-## Privacy trade-offs — read before shipping
-
-Blind indexing is a deliberate compromise, not "free" encrypted search:
-
-- **Equality patterns leak.** Tokens are deterministic: an observer can tell that two documents share the same (unknown) author, and can build frequency histograms. If they can *guess* a value and obtain the field key, they can confirm it.
-- **Token truncation is a dial.** The default 16-byte tokens balance collision resistance against leakage; shorter tokens (`new SubtleBlindIndexProvider(8)`) increase false positives but reveal less.
-- **Bloom filters leak probabilistic membership.** A gossiped filter lets anyone test candidate tokens against your document set. Filters also only ever *add* bits — they don't forget deleted documents until rebuilt.
-- **Only equality (and compound equality).** No substring, range, or relevance queries over encrypted data — those run on your local decrypted index instead.
-
-## Performance framing
-
-The package ships benchmark suites (`packages/collabswarm-index/src/__benchmarks__/`) you can run with `yarn benchmark`:
-
-- **Blind index ops are cheap** — a token is one HMAC-SHA-256 (plus a one-time HKDF per field key); the suite measures derivation, string/numeric/compound token generation, and match throughput.
-- **Local queries are measured up to 100k entries** — exact-match, range, prefix, compound, and sorted queries against `MemoryIndexStorage`, plus a full-scan baseline, so you can see where an index stops being "instant" for your data size.
-- **Bloom filters scale by size, not content** — insert/query/merge/serialize are benchmarked from 1k-bit to 1M-bit filters; false-positive rate is measured against fill ratio, which is what you tune `filterSizeInBits` against.
-
-## Pitfalls
-
-- **The index only covers documents you track.** There is no network crawler: if you never opened and `trackDocument`-ed a document, it isn't in your local index. Design an index document or use the Bloom gossip layer for discovery.
-- **`removeIndex` deletes stored entries**, and `useDefineIndexes` removes its definitions on unmount — don't treat the materialized index as durable app data; treat it as a rebuildable cache (`rebuildIndex` exists for exactly that).
-- **Keep indexed fields at stable paths.** The extractor + dot-notation field paths (`meta.author`) only work if all documents in a collection put fields in the same place — see the schema recipe's [indexing guidance](../yjs-schema-design/).
-- **Guard the field keys.** Anyone holding a blind-index field key can run confirmation attacks on that field forever. Distribute them like document keys, and don't reuse them across unrelated collections.
-- **Alpha status.** The local index and blind-index/Bloom primitives are implemented and tested, but the end-to-end story (auto-attaching tokens to change blocks, cross-peer query execution) is still being assembled. Expect APIs to move.
+Benchmark sources exist, but the current benchmark runner emits ESM and then marks its output directory as CommonJS, so `yarn workspace @swarmbase/collabswarm-index benchmark` is not a working verification command at this revision. Even after that runner is fixed, benchmark results are informational and have no pass/fail performance budget. Distributed search remains incomplete; see [Limitations](../../concepts/limitations/) and [Designing Yjs schemas](../yjs-schema-design/).

--- a/site/src/content/docs/cookbook/yjs-schema-design.md
+++ b/site/src/content/docs/cookbook/yjs-schema-design.md
@@ -1,6 +1,129 @@
 ---
-title: Design a Yjs schema
-description: Modeling application state in Yjs types.
+title: Designing Yjs schemas
+description: Choose the right Yjs shared types for your app state, avoid CRDT anti-patterns, and evolve schemas safely.
 ---
 
-This page is being written. Until it lands, the [GitHub repository](https://github.com/swarmbase/swarmbase) is the best source.
+In Swarmbase, every document wraps a `Y.Doc`, and there is no schema enforcement — structure is convention. But your choice of Yjs shared type *is* your conflict-resolution policy: pick the wrong type and concurrent edits get silently lost or duplicated. This recipe condenses the full [Yjs schema guide](https://github.com/swarmbase/swarmbase/blob/main/guides/yjs-schema-guide.md) in the repository into the decisions you'll actually make.
+
+## Pick the type by the merge behavior you want
+
+| You're storing… | Use | Concurrent edits resolve by… |
+|---|---|---|
+| Record fields, settings, metadata | `Y.Map` | Last-writer-wins **per key** |
+| Ordered collections (tasks, messages) | `Y.Array` | All insertions preserved, deterministic order |
+| Prose / collaborative text | `Y.Text` | Character-level merge (Quill-delta compatible) |
+| Editor trees (ProseMirror, Slate, TipTap) | `Y.XmlFragment` / `Y.XmlElement` | Array semantics for children, LWW per attribute |
+| A set (tags, labels, members) | `Y.Map<boolean>` | **Add wins** over concurrent delete |
+| A counter | per-peer `Y.Map<number>`, summed | No lost increments (different keys never conflict) |
+
+## Complete working example
+
+A task list exercising the main patterns, written against the same `change()` API Swarmbase gives you:
+
+```typescript
+import * as Y from 'yjs';
+
+// swarmDoc.change((doc: Y.Doc) => { ... }) hands you the Y.Doc.
+
+function addTask(doc: Y.Doc, title: string): void {
+  const tasks = doc.getArray<Y.Map<any>>('tasks');
+
+  // Items with mutable fields = nested Y.Map inside Y.Array.
+  const task = new Y.Map();
+  task.set('id', crypto.randomUUID());
+  task.set('title', title);
+  task.set('status', 'todo');          // LWW register
+  task.set('createdAt', Date.now());   // display only — never for ordering
+  const labels = new Y.Map<boolean>(); // add-wins set
+  task.set('labels', labels);
+  tasks.push([task]);
+}
+
+function toggleDone(task: Y.Map<any>): void {
+  // Updates ONE field; concurrent edits to other fields survive.
+  task.set('status', task.get('status') === 'done' ? 'todo' : 'done');
+}
+
+// Counter: per-peer keys, summed on read. A single shared key would
+// be LWW and lose concurrent increments.
+function upvote(doc: Y.Doc, peerId: string): void {
+  const counters = doc.getMap<number>('vote-counts');
+  counters.set(peerId, (counters.get(peerId) || 0) + 1);
+}
+function totalVotes(doc: Y.Doc): number {
+  let sum = 0;
+  doc.getMap<number>('vote-counts').forEach((v) => { sum += v; });
+  return sum;
+}
+
+// Batch related edits into one update event.
+function importTasks(doc: Y.Doc, titles: string[]): void {
+  doc.transact(() => {
+    for (const t of titles) addTask(doc, t);
+    doc.getMap('meta').set('updatedAt', Date.now());
+  });
+}
+```
+
+## Do / Don't
+
+**Do**
+
+- **Nest `Y.Map` inside `Y.Array`** for list items with editable fields — each field then merges independently.
+- **Reference items by ID, not index.** Array indices shift when other peers insert or delete.
+- **Use soft-delete flags** (`item.set('hidden', true)`) instead of delete + re-insert loops. Every deletion is a permanent tombstone.
+- **Model moves with fractional sort keys** when reordering is frequent: store items in a `Y.Map` keyed by ID with a sortable `sortKey` field, instead of physically moving array slots. Concurrent delete+insert moves of the same item can duplicate it.
+- **Split into multiple documents** when entities are independent, need different ACLs, exceed ~1 MB of encoded state, or should load lazily. Use an index document that maps IDs to metadata.
+- **Keep indexed/queryable fields at consistent paths** (e.g. every document has `meta.type`, `meta.status`) so [indexing](../search-indexing/) can work across a collection.
+
+**Don't**
+
+- **Don't store plain objects when you need field-level edits.** `tasks.push([{ id, title, done }])` makes the object an opaque LWW blob — updating `done` replaces the whole thing.
+- **Don't replace whole nested structures** (`config.set('settings', {...})`) — concurrent field-level edits to the old structure are lost. Set individual keys.
+- **Don't store derived data** (counts, totals) in the CRDT — two peers computing from different states will fight. Compute on read.
+- **Don't put JSON in `Y.Text`.** Concurrent character edits mid-JSON produce garbage. `Y.Text` is for prose.
+- **Don't nest deeper than 2–3 levels.** Flatten with composite keys (`members.set('org:team:alice', ...)`) or split documents.
+- **Don't use wall-clock timestamps for ordering or conflict resolution** — clocks skew and can be manipulated. Timestamps are for display; ordering comes from CRDT structure.
+
+## Migration and versioning
+
+Yjs documents are schema-less, so versions coexist on the network. The guide's rules:
+
+```typescript
+// Stamp a version on creation…
+doc.getMap('meta').set('schemaVersion', 2);
+
+// …and migrate idempotently on load.
+function onDocumentLoad(doc: Y.Doc): void {
+  const meta = doc.getMap('meta');
+  const version = (meta.get('schemaVersion') as number) || 1;
+
+  if (version < 2) {
+    const tasks = doc.getArray<Y.Map<any>>('tasks');
+    for (let i = 0; i < tasks.length; i++) {
+      const task = tasks.get(i);
+      if (!task.has('priority')) {       // has() check = idempotent
+        task.set('priority', 'medium');
+      }
+    }
+    meta.set('schemaVersion', 2);
+  }
+
+  if (version > 2) {
+    // Newer peer wrote this — read what you understand, never crash.
+    console.warn(`Schema version ${version} is newer than supported (2).`);
+  }
+}
+```
+
+- **Never remove fields** — older peers may still read them. Deprecate with `null`/sentinels.
+- **Never change a field's type** — if `title` was a string, add `titleText` (a `Y.Text`) instead of replacing it.
+- **Migrations must be idempotent** — multiple peers may run the same migration concurrently; guard with `has()`.
+- **Renames are copies**: write the new key, keep the old one readable.
+
+## Pitfalls
+
+- **`Y.Map` set-vs-delete races resolve add-wins; same-key set-vs-set races are LWW by client ID.** Neither is "wrong" — but make sure your UI copy doesn't promise merge behavior the type can't deliver (e.g., two people editing one `Y.Map` string field is last-writer-wins, not a merge).
+- **Documents only grow.** Deleted content leaves tombstones forever, and heavy `set()` churn on one key grows state linearly with writes. Don't stream high-frequency ephemeral state (cursor positions, presence) through the CRDT.
+- **A shared type instance can only have one parent.** Inserting the same `Y.Map` into two arrays throws — always construct a fresh instance per insertion.
+- **One document = one encryption key = one ACL.** You cannot selectively encrypt or share *parts* of a `Y.Doc` in Swarmbase; and key rotation protects future updates only, not already-synced history. Put data with different sensitivity in different documents.

--- a/site/src/content/docs/cookbook/yjs-schema-design.md
+++ b/site/src/content/docs/cookbook/yjs-schema-design.md
@@ -1,129 +1,91 @@
 ---
 title: Designing Yjs schemas
-description: Choose the right Yjs shared types for your app state, avoid CRDT anti-patterns, and evolve schemas safely.
+description: Choose Yjs shared types and migration patterns for Swarmbase documents.
 ---
 
-In Swarmbase, every document wraps a `Y.Doc`, and there is no schema enforcement — structure is convention. But your choice of Yjs shared type *is* your conflict-resolution policy: pick the wrong type and concurrent edits get silently lost or duplicated. This recipe condenses the full [Yjs schema guide](https://github.com/swarmbase/swarmbase/blob/main/guides/yjs-schema-guide.md) in the repository into the decisions you'll actually make.
+**Status: Illustrative schema patterns, not a complete application.** Yjs adapter behavior has focused tests, but these patterns do not prove multi-peer application convergence, persistence, or migration safety. See [CRDTs](../../concepts/crdts/) and [Limitations](../../concepts/limitations/).
 
-## Pick the type by the merge behavior you want
+## Choose merge behavior explicitly
 
-| You're storing… | Use | Concurrent edits resolve by… |
-|---|---|---|
-| Record fields, settings, metadata | `Y.Map` | Last-writer-wins **per key** |
-| Ordered collections (tasks, messages) | `Y.Array` | All insertions preserved, deterministic order |
-| Prose / collaborative text | `Y.Text` | Character-level merge (Quill-delta compatible) |
-| Editor trees (ProseMirror, Slate, TipTap) | `Y.XmlFragment` / `Y.XmlElement` | Array semantics for children, LWW per attribute |
-| A set (tags, labels, members) | `Y.Map<boolean>` | **Add wins** over concurrent delete |
-| A counter | per-peer `Y.Map<number>`, summed | No lost increments (different keys never conflict) |
+| Data | Shared type | Merge behavior |
+| --- | --- | --- |
+| Independent record fields | `Y.Map` | Same-key writes resolve by Yjs conflict rules; different keys survive |
+| Ordered items | `Y.Array` | Concurrent inserts are retained in deterministic order |
+| Collaborative prose | `Y.Text` | Character/operation-level merge |
+| Editor trees | `Y.XmlFragment` / `Y.XmlElement` | Shared tree operations |
+| Set-like membership | `Y.Map<boolean>` | Application interprets present/true keys as members |
+| Counter | `Y.Map<number>` keyed by stable replica ID | Each replica owns one component; sum on read |
 
-## Complete working example
+Do not treat plain objects stored inside shared types as recursively collaborative. Use nested shared types when fields require independent mutation.
 
-A task list exercising the main patterns, written against the same `change()` API Swarmbase gives you:
+## Mutate through Swarmbase
 
-```typescript
-import * as Y from 'yjs';
+All mutations, initialization, and migrations must run inside and await `swarmDoc.change`. A bare `Y.Doc` mutation is not automatically authorized, encrypted, stored, or published by Swarmbase.
 
-// swarmDoc.change((doc: Y.Doc) => { ... }) hands you the Y.Doc.
-
-function addTask(doc: Y.Doc, title: string): void {
-  const tasks = doc.getArray<Y.Map<any>>('tasks');
-
-  // Items with mutable fields = nested Y.Map inside Y.Array.
-  const task = new Y.Map();
+```ts
+await swarmDoc.change((doc: Y.Doc) => {
+  const tasks = doc.getArray<Y.Map<unknown>>('tasks');
+  const task = new Y.Map<unknown>();
   task.set('id', crypto.randomUUID());
-  task.set('title', title);
-  task.set('status', 'todo');          // LWW register
-  task.set('createdAt', Date.now());   // display only — never for ordering
-  const labels = new Y.Map<boolean>(); // add-wins set
-  task.set('labels', labels);
+  task.set('title', 'Review schema');
+  task.set('status', 'todo');
   tasks.push([task]);
-}
-
-function toggleDone(task: Y.Map<any>): void {
-  // Updates ONE field; concurrent edits to other fields survive.
-  task.set('status', task.get('status') === 'done' ? 'todo' : 'done');
-}
-
-// Counter: per-peer keys, summed on read. A single shared key would
-// be LWW and lose concurrent increments.
-function upvote(doc: Y.Doc, peerId: string): void {
-  const counters = doc.getMap<number>('vote-counts');
-  counters.set(peerId, (counters.get(peerId) || 0) + 1);
-}
-function totalVotes(doc: Y.Doc): number {
-  let sum = 0;
-  doc.getMap<number>('vote-counts').forEach((v) => { sum += v; });
-  return sum;
-}
-
-// Batch related edits into one update event.
-function importTasks(doc: Y.Doc, titles: string[]): void {
-  doc.transact(() => {
-    for (const t of titles) addTask(doc, t);
-    doc.getMap('meta').set('updatedAt', Date.now());
-  });
-}
+});
 ```
 
-## Do / Don't
+Use `doc.transact` inside that callback when several Yjs operations should emit one Yjs transaction:
 
-**Do**
+```ts
+await swarmDoc.change((doc: Y.Doc) => {
+  doc.transact(() => {
+    doc.getMap('meta').set('updatedAt', Date.now());
+    doc.getText('body').insert(0, 'Imported text');
+  });
+});
+```
 
-- **Nest `Y.Map` inside `Y.Array`** for list items with editable fields — each field then merges independently.
-- **Reference items by ID, not index.** Array indices shift when other peers insert or delete.
-- **Use soft-delete flags** (`item.set('hidden', true)`) instead of delete + re-insert loops. Every deletion is a permanent tombstone.
-- **Model moves with fractional sort keys** when reordering is frequent: store items in a `Y.Map` keyed by ID with a sortable `sortKey` field, instead of physically moving array slots. Concurrent delete+insert moves of the same item can duplicate it.
-- **Split into multiple documents** when entities are independent, need different ACLs, exceed ~1 MB of encoded state, or should load lazily. Use an index document that maps IDs to metadata.
-- **Keep indexed/queryable fields at consistent paths** (e.g. every document has `meta.type`, `meta.status`) so [indexing](../search-indexing/) can work across a collection.
+A Yjs transaction does not make network publication transactional, does not span Swarmbase documents, and does not roll back an in-place Yjs mutation if later asynchronous storage/publication fails.
 
-**Don't**
+## IDs, lists, and counters
 
-- **Don't store plain objects when you need field-level edits.** `tasks.push([{ id, title, done }])` makes the object an opaque LWW blob — updating `done` replaces the whole thing.
-- **Don't replace whole nested structures** (`config.set('settings', {...})`) — concurrent field-level edits to the old structure are lost. Set individual keys.
-- **Don't store derived data** (counts, totals) in the CRDT — two peers computing from different states will fight. Compute on read.
-- **Don't put JSON in `Y.Text`.** Concurrent character edits mid-JSON produce garbage. `Y.Text` is for prose.
-- **Don't nest deeper than 2–3 levels.** Flatten with composite keys (`members.set('org:team:alice', ...)`) or split documents.
-- **Don't use wall-clock timestamps for ordering or conflict resolution** — clocks skew and can be manipulated. Timestamps are for display; ordering comes from CRDT structure.
+Reference list entries by stable IDs, never array indexes. Reordering by delete/reinsert can duplicate an item under concurrency; for frequently sorted collections, consider a map keyed by ID plus an application-defined sortable key.
 
-## Migration and versioning
+For a distributed counter, persist one random `replicaId` per application replica/device. Do not use a transient libp2p peer ID or a newly generated value per increment:
 
-Yjs documents are schema-less, so versions coexist on the network. The guide's rules:
+```ts
+await swarmDoc.change((doc: Y.Doc) => {
+  const counts = doc.getMap<number>('votesByReplica');
+  counts.set(replicaId, (counts.get(replicaId) ?? 0) + 1);
+});
+```
 
-```typescript
-// Stamp a version on creation…
-doc.getMap('meta').set('schemaVersion', 2);
+This avoids same-key increment races between distinct replicas, but concurrent sessions incorrectly sharing one replica ID can still overwrite one another.
 
-// …and migrate idempotently on load.
-function onDocumentLoad(doc: Y.Doc): void {
-  const meta = doc.getMap('meta');
-  const version = (meta.get('schemaVersion') as number) || 1;
+## Migrations
+
+Run migrations through the same awaited change boundary:
+
+```ts
+await swarmDoc.change((doc: Y.Doc) => {
+  const meta = doc.getMap<unknown>('meta');
+  const version = (meta.get('schemaVersion') as number | undefined) ?? 1;
 
   if (version < 2) {
-    const tasks = doc.getArray<Y.Map<any>>('tasks');
-    for (let i = 0; i < tasks.length; i++) {
-      const task = tasks.get(i);
-      if (!task.has('priority')) {       // has() check = idempotent
-        task.set('priority', 'medium');
-      }
+    for (const task of doc.getArray<Y.Map<unknown>>('tasks').toArray()) {
+      if (!task.has('priority')) task.set('priority', 'medium');
     }
     meta.set('schemaVersion', 2);
   }
-
-  if (version > 2) {
-    // Newer peer wrote this — read what you understand, never crash.
-    console.warn(`Schema version ${version} is newer than supported (2).`);
-  }
-}
+});
 ```
 
-- **Never remove fields** — older peers may still read them. Deprecate with `null`/sentinels.
-- **Never change a field's type** — if `title` was a string, add `titleText` (a `Y.Text`) instead of replacing it.
-- **Migrations must be idempotent** — multiple peers may run the same migration concurrently; guard with `has()`.
-- **Renames are copies**: write the new key, keep the old one readable.
+Guards such as `has()` make repeated execution locally idempotent for that operation. They do not prove that arbitrary concurrent migrations commute: two versions can write incompatible values or observe different intermediate states. Prefer additive fields, tolerate unknown/newer fields, never reuse a field name with a different type, and test old/new peers concurrently.
 
-## Pitfalls
+## Heuristics, not limits
 
-- **`Y.Map` set-vs-delete races resolve add-wins; same-key set-vs-set races are LWW by client ID.** Neither is "wrong" — but make sure your UI copy doesn't promise merge behavior the type can't deliver (e.g., two people editing one `Y.Map` string field is last-writer-wins, not a merge).
-- **Documents only grow.** Deleted content leaves tombstones forever, and heavy `set()` churn on one key grows state linearly with writes. Don't stream high-frequency ephemeral state (cursor positions, presence) through the CRDT.
-- **A shared type instance can only have one parent.** Inserting the same `Y.Map` into two arrays throws — always construct a fresh instance per insertion.
-- **One document = one encryption key = one ACL.** You cannot selectively encrypt or share *parts* of a `Y.Doc` in Swarmbase; and key rotation protects future updates only, not already-synced history. Put data with different sensitivity in different documents.
+- Split documents at access-control, lazy-loading, ownership, and recovery boundaries.
+- Document size targets such as 1 MB and nesting guidance such as two or three levels are application heuristics, not Swarmbase or Yjs limits.
+- Deep structures, large histories, and high update rates require measurement with realistic peers and storage.
+- One Swarmbase document has one ACL/key domain; separately shared data belongs in separate documents.
+
+Yjs garbage collection can remove some deleted structs when safe in the local state, but GC changes history/update assumptions and does not mean every document or encoded history only shrinks. Retained updates, snapshots, peers with older state vectors, repeated writes, and Swarmbase's own change/block history all affect storage. Do not promise that tombstones are always permanent or that GC provides application-level deletion. See [Storage](../../concepts/storage/).


### PR DESCRIPTION
Replaces eight cookbook placeholders with recipes classified by current evidence rather than presenting every integration as complete.

## Recipe status
- Wiki: runnable source build/startup smoke; multi-user mutation and onboarding remain unverified.
- Password manager: runnable startup smoke; distinct-identity sharing and revocation are deferred.
- Pinning: incomplete integration checklist, not a runnable durability service.
- React: runnable basic single-identity hooks with explicit lifecycle, error, and KEM-wrapper limits.
- Redux: runnable setup/open/remote-read pattern; reliable local Yjs editing is deferred due current thunk ordering.
- Relay: runnable development relay with explicit identity, failover, TLS, allowlist, health, and production limits.
- Search: runnable local index primitives; blind indexing is illustrative and distributed Bloom search/deletion is incomplete.
- Yjs schemas: illustrative patterns with all mutations/migrations inside the awaited Swarmbase change boundary.

## Corrections
- Uses current Vite variables, workspace names, redux-thunk named export, and API signatures.
- Documents persistent signing/KEM identity requirements and the real add-reader/add-writer sequence.
- Removes automatic pinning, production-safe editor, relay-meshing, and Bloom-rebuild claims.
- Gates React index queries on async definition readiness and awaits initial local indexing.
- Corrects all generated internal links.
- Documents that the current index benchmark runner is broken by its ESM/CommonJS output mismatch.

## Verification
- `yarn workspace @swarmbase/site build`
- Generated internal-link validation across all site HTML
- `yarn build`
- `yarn test`
- `yarn test:e2e:wiki-swarm`
- `yarn test:e2e:password-manager`
- `yarn test:relay`
- `yarn workspace @swarmbase/collabswarm-index test`

All listed verification commands passed.