### PR TITLE
Fix cookbook review follow-ups

### DIFF
--- a/site/src/content/docs/cookbook/password-manager.md
+++ b/site/src/content/docs/cookbook/password-manager.md
@@ -50,8 +50,8 @@ const kemKeyPair = await crypto.subtle.generateKey(
   ['deriveBits'],
 );
 
-await documentRef.setKemKeyPair(kemKeyPair);
-const kemRaw = documentRef.getKemPublicKeyRaw();
+await recipientDocumentRef.setKemKeyPair(kemKeyPair);
+const recipientKemRaw = recipientDocumentRef.getKemPublicKeyRaw();
 
 await ownerDocumentRef.addReader(recipientIdentityPublicKey, recipientKemRaw);
 await ownerDocumentRef.addWriter(recipientIdentityPublicKey);

--- a/site/src/content/docs/cookbook/search-indexing.md
+++ b/site/src/content/docs/cookbook/search-indexing.md
@@ -5,7 +5,7 @@ description: Use tested local index primitives and assess incomplete blind-index
 
 ## Local materialized indexes
 
-**Status: Runnable from source.** `IndexManager`, memory/IndexedDB storage, field extraction, and React query bindings have focused tests. They index decrypted documents already available to the local application; they are not a network crawler.
+**Status: Runnable from source for the local manager APIs.** `IndexManager`, memory/IndexedDB storage, and field extraction have focused tests. React query bindings are exported, but their effects and cleanup are not render-tested; the current React tests exercise backing manager primitives. These APIs index decrypted documents already available to the local application; they are not a network crawler.
 
 Packages are unpublished. Use the repository workspace after following the [quick start](../../getting-started/quick-start/).
 
@@ -50,12 +50,12 @@ const result = await manager.query({
 Do not call the query hook in the same component before asynchronous definitions are ready. Gate a child component instead:
 
 ```tsx
-function SearchRoot({ manager }: { manager: IndexManager<unknown> }) {
+function SearchRoot({ manager }: { manager: IndexManager<Y.Doc> }) {
   const ready = useDefineIndexes(manager, [definition]);
   return ready ? <ReadySearch manager={manager} /> : <p>Preparing index…</p>;
 }
 
-function ReadySearch({ manager }: { manager: IndexManager<unknown> }) {
+function ReadySearch({ manager }: { manager: IndexManager<Y.Doc> }) {
   const result = useIndexQuery(manager, {
     indexName: 'articles',
     filters: [{ path: 'author', operator: 'eq', value: 'Alice' }],


### PR DESCRIPTION
## Summary
- make the password-manager onboarding snippet use the recipient document ref and matching KEM variable
- narrow local-index evidence to tested manager APIs
- use the concrete `IndexManager<Y.Doc>` type in the React query continuation

## Verification
- `yarn workspace @swarmbase/site build`
- generated internal-link validation across all site HTML
- `yarn build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the password manager onboarding example to use recipient-specific document references when installing keys and configuring access.
  * Clarified testing coverage and limitations for local search indexing and React query bindings.
  * Updated search-indexing examples to use the appropriate document type for index managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->