### PR TITLE
Add an agent-readable project index

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,0 +1,25 @@
+# Swarmbase
+
+> Alpha TypeScript software for encrypted, local-first CRDT documents synchronized over peer-to-peer networks. Not production-ready.
+
+Use the feature audit and concept documentation as the authority for capability claims. A primitive test does not establish complete multi-peer behavior.
+
+## Start
+
+- [Quick start](https://swarmbase.github.io/swarmbase/getting-started/quick-start/): Build Swarmbase from source and exercise the verified browser path.
+- [Examples](https://github.com/swarmbase/swarmbase/tree/main/examples): Runnable browser applications.
+- [API reference](https://swarmbase.github.io/swarmbase/reference/): Generated package documentation.
+
+## Architecture, evidence, and limits
+
+- [Feature and verification audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md): Capability-to-evidence map.
+- [Security model](https://swarmbase.github.io/swarmbase/concepts/security/): Threat model, guarantees, and non-goals.
+- [Networking](https://swarmbase.github.io/swarmbase/concepts/networking/): Peer discovery, transports, relays, and NAT constraints.
+- [Storage](https://swarmbase.github.io/swarmbase/concepts/storage/): Local and remote persistence boundaries.
+- [Limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/): Current alpha limitations and deployment caveats.
+
+## Contributing
+
+- [Contributor guide](https://swarmbase.github.io/swarmbase/community/contributing/): Development setup and verification commands.
+- [Help wanted](https://swarmbase.github.io/swarmbase/community/help-wanted/): Current contribution areas.
+- [Repository](https://github.com/swarmbase/swarmbase): Source, issues, and discussions.


### PR DESCRIPTION
## Summary

- add a concise llms.txt index for the documentation site
- direct readers and coding tools to the quick start, API reference, feature audit, security model, and current limitations
- keep the alpha and evidence boundaries visible at the discovery layer

## Verification

- yarn workspace @swarmbase/site build
- confirmed site/dist/llms.txt matches the source file
- confirmed all eight indexed documentation routes exist in the built site
- git diff --check