### PR TITLE
Make quick start the primary homepage action

### DIFF
--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -11,8 +11,8 @@ hero:
   image:
     file: ../../assets/logo.svg
   actions:
-    - text: Explore examples
-      link: https://github.com/swarmbase/swarmbase/tree/main/examples
+    - text: Run the quick start
+      link: ./getting-started/quick-start/
       icon: rocket
     - text: Star on GitHub
       link: https://github.com/swarmbase/swarmbase
@@ -114,10 +114,10 @@ and unusual network tests can materially shape the project.
 </CardGrid>
 
 <LinkButton
-  href="https://github.com/swarmbase/swarmbase/tree/main/examples"
+  href="./getting-started/quick-start/"
   icon="rocket"
 >
-  Explore runnable examples
+  Run the quick start
 </LinkButton>{' '}
 <LinkButton
   href="https://github.com/swarmbase/swarmbase"


### PR DESCRIPTION
Changes the homepage's primary and closing calls to action to the verified quick start. Runnable examples remain linked from the page.

Verification:

- `yarn workspace @swarmbase/site build`
- `node site/scripts/check-links.mjs`
- `git diff --check`
