### PR TITLE
Replace stale example setup guides

### DIFF
--- a/examples/browser-test/README.md
+++ b/examples/browser-test/README.md
@@ -19,8 +19,8 @@ yarn build
 yarn workspace @swarmbase/browser-test start
 ```
 
-Open the URL printed by Vite. A document path such as `/demo/document` can be
-entered in the **Open Document** field.
+Open the URL printed by Vite. Enter a document path such as `/demo/document` in
+the text field beside **Open**, then select **Open**.
 
 ## Verify the supported browser path
 

--- a/examples/browser-test/README.md
+++ b/examples/browser-test/README.md
@@ -1,44 +1,43 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+# Swarmbase browser test
 
-## Available Scripts
+This Vite and React harness exercises the core Swarmbase package with its
+Automerge and Redux integrations. It exposes node addresses, peer connection
+controls, document open/edit controls, and ACL inspection for development and
+testing.
 
-In the project directory, you can run:
+> Swarmbase is alpha software and is not production-ready. This example is a
+> test harness, not an application template or a production deployment.
 
-### `npm start`
+## Run from source
 
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Use Node.js 22.19.0 and Yarn 4.5.0 through Corepack. From the repository root:
 
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
+```sh
+corepack enable
+yarn install --immutable
+yarn build
+yarn workspace @swarmbase/browser-test start
+```
 
-### `npm test`
+Open the URL printed by Vite. A document path such as `/demo/document` can be
+entered in the **Open Document** field.
 
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+## Verify the supported browser path
 
-### `npm run build`
+```sh
+yarn exec playwright install chromium
+yarn test:e2e:browser-test
+```
 
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
+The smoke test builds this workspace, starts its Vite preview, and opens one
+real encrypted Automerge document in a single Chromium process. It fails on
+browser runtime errors.
 
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
+This does not prove two-peer live convergence, restart persistence, invitation
+delivery, or production networking. The separate cross-NAT suite uses this
+harness with test-only document-key transfer and has its own narrower evidence
+boundary.
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
+- [Verified quick start](https://swarmbase.github.io/swarmbase/getting-started/quick-start/)
+- [Networking model](https://swarmbase.github.io/swarmbase/concepts/networking/)
+- [Current limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/)

--- a/examples/password-manager/README.md
+++ b/examples/password-manager/README.md
@@ -1,35 +1,37 @@
-# Demo: Password manager
+# Swarmbase password manager
 
-Shared secrets with item-specific access control.
+This Vite and React reference interface explores Yjs documents, Swarmbase React
+hooks, and item-specific access-control UI.
 
-## Prerequisites
+> Swarmbase is alpha software and is not production-ready. Do not enter real
+> credentials or other sensitive data into this example.
 
-- Node.js 16+
-- Yarn
+## Run from source
 
-## Install
-
-First, setup node modules and typescript:
-
-```sh
-yarn install
-yarn workspace @swarmbase/password-manager build
-```
-
-Then, start a local web server:
+Use Node.js 22.19.0 and Yarn 4.5.0 through Corepack. From the repository root:
 
 ```sh
+corepack enable
+yarn install --immutable
+yarn build
 yarn workspace @swarmbase/password-manager start
 ```
 
-_Make sure to 'allow' network connections if asked._
+Open the URL printed by Vite. The application redirects its root route to the
+login interface.
 
-Now, you can open a browser tab to:
+## Verify the current example
 
-- <http://localhost:3000/login>
+```sh
+yarn exec playwright install chromium
+yarn test:e2e:password-manager
+```
 
-You now have a local instance running and should be able to log in.
+The smoke test builds this workspace and verifies that the login interface
+renders in Chromium without runtime errors. It does not prove distinct-identity
+sharing, invitation delivery, restart recovery, revocation, or protection of
+real credentials.
 
-## Application quickstart
-
-Coming soon!
+- [Encrypted shared-secrets guide](https://swarmbase.github.io/swarmbase/cookbook/password-manager/)
+- [Security model](https://swarmbase.github.io/swarmbase/concepts/security/)
+- [Current limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/)

--- a/examples/wiki-swarm/README.md
+++ b/examples/wiki-swarm/README.md
@@ -1,44 +1,37 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+# Swarmbase wiki
 
-## Available Scripts
+This Vite and React example explores a collaborative wiki interface with the
+Swarmbase Automerge and Redux packages.
 
-In the project directory, you can run:
+> Swarmbase is alpha software and is not production-ready. This workspace is a
+> source example with startup coverage, not a complete collaborative product.
 
-### `npm start`
+## Run from source
 
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Use Node.js 22.19.0 and Yarn 4.5.0 through Corepack. From the repository root:
 
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
+```sh
+corepack enable
+yarn install --immutable
+yarn build
+yarn workspace @swarmbase/wiki-swarm start
+```
 
-### `npm test`
+Open the URL printed by Vite. The landing page provides a document ID field for
+navigating to the wiki editor.
 
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+## Verify the current example
 
-### `npm run build`
+```sh
+yarn exec playwright install chromium
+yarn test:e2e:wiki-swarm
+```
 
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
+The smoke test builds this workspace and verifies that Automerge WASM loads and
+the wiki interface renders in Chromium without runtime errors. It does not
+assert article mutation, two-browser synchronization, concurrent editing,
+restart recovery, or invitation delivery.
 
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
+- [Collaborative wiki guide](https://swarmbase.github.io/swarmbase/cookbook/collaborative-wiki/)
+- [Verified quick start](https://swarmbase.github.io/swarmbase/getting-started/quick-start/)
+- [Current limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/)


### PR DESCRIPTION
## Summary

- replace obsolete Create React App instructions with the current Vite and Yarn workspace workflow
- correct the password-manager prerequisites and add an explicit real-credentials warning
- document what each Chromium smoke test proves and link to the matching canonical guides

## Verification

- `yarn build`
- `yarn test:e2e`
- `git diff --check`
- checked all nine documentation targets against the built site
- checked that obsolete setup text is absent from all three READMEs
