### PR TITLE
Add package selection guides

### DIFF
--- a/packages/collabswarm-automerge/README.md
+++ b/packages/collabswarm-automerge/README.md
@@ -1,3 +1,27 @@
-# `collabswarm-automerge`
+# `@swarmbase/collabswarm-automerge`
 
-See the main [collabswarm](https://github.com/swarmbase/swarmbase) README for more information.
+Automerge CRDT, serialization, access-control, and keychain adapters for Swarmbase documents.
+
+> **Alpha:** Swarmbase is not production-ready and may lose data or change APIs. The project examples and [verified quick start](https://swarmbase.github.io/swarmbase/getting-started/quick-start/) use the repository source workspaces.
+
+Swarmbase is the project name; some exported APIs retain the historical `Collabswarm` prefix.
+
+## Choose this package
+
+Use this adapter for Automerge-backed collaborative documents. It works with:
+
+- `@swarmbase/collabswarm`, included as a package dependency;
+- `@automerge/automerge`, required as a peer dependency;
+- optional React or Redux bindings for application state.
+
+## Runtime entry point
+
+`@swarmbase/collabswarm-automerge` exports `AutomergeProvider`, `AutomergeJSONSerializer`, Automerge-backed ACL and keychain implementations, and the document change handler.
+
+## Start here
+
+- [Collaborative wiki guide](https://swarmbase.github.io/swarmbase/cookbook/collaborative-wiki/)
+- [Automerge and Redux example](https://github.com/swarmbase/swarmbase/tree/main/examples/wiki-swarm)
+- [API reference](https://swarmbase.github.io/swarmbase/reference/)
+- [Current limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/)
+- [Documentation index for coding agents](https://swarmbase.github.io/swarmbase/llms.txt)

--- a/packages/collabswarm-index/README.md
+++ b/packages/collabswarm-index/README.md
@@ -1,5 +1,25 @@
-# @swarmbase/collabswarm-index
+# `@swarmbase/collabswarm-index`
 
 Local and privacy-oriented indexing primitives with optional React query bindings for Swarmbase documents.
 
-Swarmbase is alpha software and is not production-ready. See the [project documentation](https://swarmbase.github.io/swarmbase/) for usage, security notes, and limitations.
+> **Alpha:** Swarmbase is not production-ready and may lose data or change APIs. The project examples and [verified quick start](https://swarmbase.github.io/swarmbase/getting-started/quick-start/) use the repository source workspaces.
+
+Swarmbase is the project name; some exported APIs retain the historical `Collabswarm` prefix.
+
+## Choose this package
+
+Use this package to build local memory or IndexedDB indexes over documents already available to an application. It also contains blind-index and Bloom-filter gossip primitives, but does not provide a complete distributed-search workflow.
+
+It depends on `@swarmbase/collabswarm` and `idb`. React is declared as a peer dependency for the optional query hooks.
+
+## Runtime entry points
+
+- `@swarmbase/collabswarm-index` — index definitions, storage, queries, document integration, blind indexes, and Bloom-filter primitives.
+- `@swarmbase/collabswarm-index/react` — `useDefineIndexes` and `useIndexQuery`.
+
+## Start here
+
+- [Search indexing guide](https://swarmbase.github.io/swarmbase/cookbook/search-indexing/)
+- [API reference](https://swarmbase.github.io/swarmbase/reference/)
+- [Current limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/)
+- [Documentation index for coding agents](https://swarmbase.github.io/swarmbase/llms.txt)

--- a/packages/collabswarm-react/README.md
+++ b/packages/collabswarm-react/README.md
@@ -1,3 +1,25 @@
-# `collabswarm-automerge`
+# `@swarmbase/collabswarm-react`
 
-See the main [collabswarm](https://github.com/swarmbase/swarmbase) README for more information.
+React context and hooks for initializing Swarmbase and loading or editing collaborative documents.
+
+> **Alpha:** Swarmbase is not production-ready and may lose data or change APIs. The project examples and [verified quick start](https://swarmbase.github.io/swarmbase/getting-started/quick-start/) use the repository source workspaces.
+
+Swarmbase is the project name; some exported APIs retain the historical `Collabswarm` prefix.
+
+## Choose this package
+
+Use these bindings in a React application.
+
+It depends on `@swarmbase/collabswarm`, declares React as a peer dependency, and requires compatible CRDT provider, serializer, ACL, and keychain implementations. The shipped Automerge and Yjs adapters provide those implementations.
+
+## Runtime entry point
+
+`@swarmbase/collabswarm-react` exports `useCollabswarm`, `useCollabswarmDocumentState`, `CollabswarmContext`, and the context result type.
+
+## Start here
+
+- [React integration guide](https://swarmbase.github.io/swarmbase/cookbook/react/)
+- [Yjs and React example](https://github.com/swarmbase/swarmbase/tree/main/examples/password-manager)
+- [API reference](https://swarmbase.github.io/swarmbase/reference/)
+- [Current limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/)
+- [Documentation index for coding agents](https://swarmbase.github.io/swarmbase/llms.txt)

--- a/packages/collabswarm-redux/README.md
+++ b/packages/collabswarm-redux/README.md
@@ -1,3 +1,25 @@
-# `collabswarm-redux`
+# `@swarmbase/collabswarm-redux`
 
-See the main [collabswarm](https://github.com/swarmbase/swarmbase) README for more information.
+Redux actions, asynchronous thunks, and reducers for Swarmbase documents and peers.
+
+> **Alpha:** Swarmbase is not production-ready and may lose data or change APIs. The project examples and [verified quick start](https://swarmbase.github.io/swarmbase/getting-started/quick-start/) use the repository source workspaces.
+
+Swarmbase is the project name; some exported APIs retain the historical `Collabswarm` prefix.
+
+## Choose this package
+
+Use these bindings when Swarmbase state belongs in a Redux store. The package declares `@swarmbase/collabswarm`, Redux, and Redux Thunk as peer dependencies. The application must also supply compatible CRDT provider, serializer, ACL, and keychain implementations; the shipped Automerge and Yjs adapters provide them.
+
+## Runtime entry point
+
+`@swarmbase/collabswarm-redux` exports synchronous and asynchronous action creators, action constants and types, `initialState`, and `collabswarmReducer`.
+
+The current local-change thunk has a documented ordering limitation; review the integration guide before relying on local Redux rendering.
+
+## Start here
+
+- [Redux integration guide](https://swarmbase.github.io/swarmbase/cookbook/redux/)
+- [Automerge and Redux example](https://github.com/swarmbase/swarmbase/tree/main/examples/wiki-swarm)
+- [API reference](https://swarmbase.github.io/swarmbase/reference/)
+- [Current limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/)
+- [Documentation index for coding agents](https://swarmbase.github.io/swarmbase/llms.txt)

--- a/packages/collabswarm-yjs/README.md
+++ b/packages/collabswarm-yjs/README.md
@@ -1,3 +1,27 @@
-# `collabswarm-yjs`
+# `@swarmbase/collabswarm-yjs`
 
-See the main [collabswarm](https://github.com/swarmbase/swarmbase) README for more information.
+Yjs CRDT, serialization, access-control, and keychain adapters for Swarmbase documents.
+
+> **Alpha:** Swarmbase is not production-ready and may lose data or change APIs. The project examples and [verified quick start](https://swarmbase.github.io/swarmbase/getting-started/quick-start/) use the repository source workspaces.
+
+Swarmbase is the project name; some exported APIs retain the historical `Collabswarm` prefix.
+
+## Choose this package
+
+Use this adapter for Yjs-backed collaborative documents. It works with:
+
+- `@swarmbase/collabswarm`, included as a package dependency;
+- `yjs`, required as a peer dependency;
+- optional React or Redux bindings for application state.
+
+## Runtime entry point
+
+`@swarmbase/collabswarm-yjs` exports `YjsProvider`, `YjsJSONSerializer`, Yjs-backed ACL and keychain implementations, the document change handler, and key serialization helpers.
+
+## Start here
+
+- [Yjs schema design guide](https://swarmbase.github.io/swarmbase/cookbook/yjs-schema-design/)
+- [Yjs and React example](https://github.com/swarmbase/swarmbase/tree/main/examples/password-manager)
+- [API reference](https://swarmbase.github.io/swarmbase/reference/)
+- [Current limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/)
+- [Documentation index for coding agents](https://swarmbase.github.io/swarmbase/llms.txt)

--- a/packages/collabswarm/README.md
+++ b/packages/collabswarm/README.md
@@ -1,3 +1,29 @@
-# `collabswarm`
+# `@swarmbase/collabswarm`
 
-See the main [collabswarm](https://github.com/swarmbase/swarmbase) README for more information.
+Core document, storage, networking, encryption, access-control, and key-management primitives for Swarmbase.
+
+> **Alpha:** Swarmbase is not production-ready and may lose data or change APIs. The project examples and [verified quick start](https://swarmbase.github.io/swarmbase/getting-started/quick-start/) use the repository source workspaces.
+
+Swarmbase is the project name; some exported APIs retain the historical `Collabswarm` prefix.
+
+## Choose this package
+
+Use this package for Swarmbase document and runtime APIs. Most applications pair it with one of the shipped CRDT adapters:
+
+- [`@swarmbase/collabswarm-automerge`](https://github.com/swarmbase/swarmbase/tree/main/packages/collabswarm-automerge) for Automerge documents;
+- [`@swarmbase/collabswarm-yjs`](https://github.com/swarmbase/swarmbase/tree/main/packages/collabswarm-yjs) for Yjs documents.
+
+Applications can instead supply compatible provider, serializer, ACL, and keychain implementations. Add the React or Redux package only when those bindings are useful.
+
+## Runtime entry points
+
+- `@swarmbase/collabswarm` — shared document, provider, configuration, cryptography, ACL, and key-management APIs.
+- `@swarmbase/collabswarm/node` — the Node-only `CollabswarmNode` runtime and default node configuration.
+- `@swarmbase/collabswarm/browser-primitives` — targeted browser-safe primitives without the full libp2p and Helia stack.
+
+## Start here
+
+- [API reference](https://swarmbase.github.io/swarmbase/reference/)
+- [Minimal Automerge and Redux example](https://github.com/swarmbase/swarmbase/tree/main/examples/browser-test)
+- [Security model](https://swarmbase.github.io/swarmbase/concepts/security/) and [current limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/)
+- [Documentation index for coding agents](https://swarmbase.github.io/swarmbase/llms.txt)


### PR DESCRIPTION
## Summary

- replace the six stale package README stubs with exact scoped names and package-selection guidance
- document manifest-backed runtime entry points and dependency relationships
- route readers to the verified quick start, relevant cookbooks, API reference, limitations, and documentation map
- preserve alpha and evidence boundaries without advertising unvalidated CLI paths

## Validation

- `yarn build`
- `yarn test:release`
- `yarn workspace @swarmbase/site build`
- `node site/scripts/check-links.mjs` (26,698 internal links, 0 issues)
- release tarball preparation and exact-tarball clean-consumer validation for all supported ESM entry points, strict NodeNext typechecking, and a Vite build
- `git diff --check`