### PR TITLE
Update release validation boundaries

### DIFF
--- a/docs/feature-audit.md
+++ b/docs/feature-audit.md
@@ -76,8 +76,8 @@ Status meanings:
 
 | Feature | Status | Current evidence | Missing or adversarial case |
 | --- | --- | --- | --- |
-| Buildable ESM workspace packages | Verified | Topological TypeScript build and full unit suite pass | Packages are not yet published; tarball installation in a clean external consumer is not yet tested. |
-| Node entry point | Partial | TypeScript build passes; repository now requires Node >=22.19 because of the Undici dependency graph | A clean-package runtime import on the declared minimum Node version is not yet automated. |
+| Buildable ESM workspace packages | Verified | Topological TypeScript build and full unit suite; exact packed tarballs are inspected and installed in a clean consumer for ESM imports, strict NodeNext typechecking, and a Vite build | Packages are not yet published; registry installation, browser runtime execution, and packaged daemon execution are not tested. |
+| Node entry point | Verified | The packed `/node` export imports at runtime and typechecks from a clean consumer on Node 22.19.0 | No clean-consumer Node behavior beyond module import is exercised. |
 | Password-manager reference app | Partial | Vite production build and strict Chromium startup smoke test pass | No two-browser synchronization test; bundle is about 2.0 MB minified. |
 | Wiki reference app | Partial | Vite production build and strict Automerge-WASM Chromium startup test pass | Article mutation and cross-browser convergence are not yet asserted. |
 | Generic browser-test app | Partial | Vite production build, real Helia/libp2p Chromium initialization, and relay-only cross-NAT document load pass | Live post-load cross-browser mutation is not yet asserted. |

--- a/site/src/content/docs/concepts/limitations.md
+++ b/site/src/content/docs/concepts/limitations.md
@@ -9,7 +9,7 @@ See the [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/fe
 
 ## Distribution and operations
 
-- **Packages are unpublished.** The `@swarmbase/*` packages are source workspaces, not published to npm. You must clone and build from source.
+- **Packages are unpublished.** The `@swarmbase/*` packages are source workspaces, not published to npm. Clean local-tarball installation, Node ESM imports, strict NodeNext typechecking, and a Vite build are automated; registry installation, browser runtime behavior, and packaged daemon execution remain unverified. You must clone and build from source.
 - **No deployment automation.** There is no CI/CD pipeline for deploying relays, bootstrap nodes, or pinning services.
 - **No upgrade or migration path.** API changes between commits may break your application without warning. There is no changelog, no semver, and no deprecation period.
 

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -127,9 +127,12 @@ commands without their services.
 
 ## Current package boundaries
 
-The source packages already expose ESM output and TypeScript declarations, but
-registry publication and clean external-consumer installation are not yet
-verified. Until that work lands:
+Release validation packs all six libraries and installs the exact tarballs in a
+clean Node 22.19.0 consumer. It checks all supported library ESM import paths,
+strict TypeScript typechecking with NodeNext module resolution, and a Vite
+build. The packages remain unpublished; this does not prove registry
+installation, browser runtime behavior, or packaged daemon execution. Until
+publication:
 
 - use Yarn workspace package names such as `@swarmbase/collabswarm`;
 - do not copy future `npm install` commands from issues or old documentation;


### PR DESCRIPTION
## Summary

- replace stale claims that clean external-package installation and the packed Node entry point are untested
- record the exact-tarball ESM import, strict NodeNext typecheck, and Vite build evidence now enforced by release validation
- retain the unverified registry-installation, browser-runtime, packaged-daemon, and broader Node-behavior boundaries

## Stack

- rebased onto `main` after #343
- this PR's diff is limited to the three canonical validation-boundary documents
- the focused change is commit `5a40f7cd`

## Validation

- `yarn test:release`
- `yarn workspace @swarmbase/site build`
- `node site/scripts/check-links.mjs` (28,759 internal links, 0 issues)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package validation guidance to reflect clean consumer installation, ESM import checks, TypeScript validation, and Vite builds.
  * Clarified Node entry-point verification using Node 22.19.0.
  * Documented remaining coverage gaps, including registry installation, browser runtime behavior, and packaged daemon execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->