### PR TITLE
Validate links in the agent index

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'site/**'
       - 'packages/**'
+      - 'docs/feature-audit.md'
+      - 'examples/**'
+      - 'AGENTS.md'
       - '.github/workflows/site.yml'
       - 'package.json'
       - 'yarn.lock'
@@ -16,6 +19,9 @@ on:
     paths:
       - 'site/**'
       - 'packages/**'
+      - 'docs/feature-audit.md'
+      - 'examples/**'
+      - 'AGENTS.md'
       - '.github/workflows/site.yml'
       - 'package.json'
       - 'yarn.lock'
@@ -52,7 +58,9 @@ jobs:
         run: yarn install --immutable
       - name: Build site
         run: yarn workspace @swarmbase/site build
-      - name: Check internal site links
+      - name: Test site link checker
+        run: node --test site/scripts/check-links.test.mjs
+      - name: Check site and agent index links
         run: node site/scripts/check-links.mjs
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v5

--- a/site/scripts/check-links.mjs
+++ b/site/scripts/check-links.mjs
@@ -1,13 +1,37 @@
 #!/usr/bin/env node
 
-import { readFileSync, readdirSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { readFileSync, readdirSync, realpathSync, statSync } from 'node:fs';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const defaultDistDirectory = fileURLToPath(
-  new URL('../dist', import.meta.url),
-);
+const defaultDistDirectory = fileURLToPath(new URL('../dist', import.meta.url));
 const distDirectory = resolve(process.argv[2] ?? defaultDistDirectory);
+const defaultRepositoryDirectory = fileURLToPath(
+  new URL('../..', import.meta.url),
+);
+const repositoryDirectory = resolve(
+  process.argv[3] ?? defaultRepositoryDirectory,
+);
+const repositoryUrl = new URL('https://github.com/swarmbase/swarmbase/');
+const repositoryWebRoutes = new Set([
+  'actions',
+  'branches',
+  'commit',
+  'commits',
+  'compare',
+  'discussions',
+  'issues',
+  'labels',
+  'milestones',
+  'network',
+  'projects',
+  'pull',
+  'pulls',
+  'releases',
+  'security',
+  'tags',
+  'wiki',
+]);
 const maxDiagnostics = 100;
 
 function decodeHtmlEntities(value) {
@@ -90,6 +114,50 @@ function* tagsIn(html) {
   }
 }
 
+function linksInMarkdown(markdown) {
+  const inlineLinkPattern =
+    /\[[^\]\n]+\]\(\s*(?:<([^>\n]+)>|([^\s)\n]+))(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^\n)]*\)))?\s*\)/g;
+  const inlineLinkOpeningPattern = /\[[^\]\n]+\]\(/g;
+  const referenceLinkPattern =
+    /^\s*\[([^\]\n]+)\]:\s*(?:<([^>\n]+)>|([^\s\n]+))/gm;
+  const referenceUsePattern = /\[([^\]\n]+)\]\[([^\]\n]*)\]/g;
+  const links = [];
+  const validInlineStarts = new Set();
+  const definitions = new Map();
+  const undefinedReferences = [];
+  const malformedInlineLinks = [];
+
+  for (const match of markdown.matchAll(inlineLinkPattern)) {
+    validInlineStarts.add(match.index);
+    links.push(match[1] ?? match[2]);
+  }
+  for (const match of markdown.matchAll(referenceLinkPattern)) {
+    const label = normalizeReferenceLabel(match[1]);
+    if (!definitions.has(label)) {
+      definitions.set(label, match[2] ?? match[3]);
+    }
+  }
+  for (const match of markdown.matchAll(referenceUsePattern)) {
+    const label = normalizeReferenceLabel(match[2] || match[1]);
+    const href = definitions.get(label);
+    if (href) links.push(href);
+    else undefinedReferences.push(match[2] || match[1]);
+  }
+  for (const match of markdown.matchAll(inlineLinkOpeningPattern)) {
+    if (!validInlineStarts.has(match.index)) {
+      malformedInlineLinks.push(
+        markdown.slice(0, match.index).split('\n').length,
+      );
+    }
+  }
+
+  return { links, malformedInlineLinks, undefinedReferences };
+}
+
+function normalizeReferenceLabel(label) {
+  return label.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
 function collectFiles(directory, relativeDirectory = '', files = new Set()) {
   const entries = readdirSync(resolve(directory, relativeDirectory), {
     withFileTypes: true,
@@ -169,6 +237,48 @@ function decodedPath(pathname) {
     .join('/');
 }
 
+function repositoryTargetFor(url) {
+  if (url.origin !== repositoryUrl.origin) return;
+
+  const segments = decodedPath(url.pathname).split('/').filter(Boolean);
+  if (segments[0] !== 'swarmbase' || segments[1] !== 'swarmbase') return;
+  if (segments.length === 2) {
+    return { kind: 'tree', relativePath: '' };
+  }
+
+  const [kind, branch, ...pathSegments] = segments.slice(2);
+  if (!['blob', 'tree'].includes(kind)) {
+    if (repositoryWebRoutes.has(kind)) return;
+    const route = [kind, branch].filter(Boolean).join('/');
+    return { error: `uses unsupported repository route "${route}"` };
+  }
+  if (branch !== 'main') {
+    return { error: `uses unsupported repository branch "${branch ?? ''}"` };
+  }
+  if (
+    pathSegments.some(
+      (segment) =>
+        segment === '.' ||
+        segment === '..' ||
+        segment === '' ||
+        segment.includes('\\'),
+    )
+  ) {
+    return { error: 'escapes the repository checkout' };
+  }
+
+  return { kind, relativePath: pathSegments.join('/') };
+}
+
+function pathEscapesDirectory(directory, path) {
+  const relativePath = relative(directory, path);
+  return (
+    relativePath === '..' ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  );
+}
+
 function artifactFor(url, files, basePath) {
   if (
     basePath &&
@@ -207,15 +317,133 @@ function anchorFrom(hash) {
   return decodeURIComponent(fragment);
 }
 
+function checkSiteLink({
+  href,
+  sourceUrl,
+  sourceName,
+  siteRoot,
+  files,
+  basePath,
+  anchorsByFile,
+  diagnostics,
+}) {
+  let url;
+  try {
+    url = new URL(href, sourceUrl);
+  } catch {
+    diagnostics.push(`${sourceName}: invalid href="${href}"`);
+    return {};
+  }
+
+  if (!['http:', 'https:'].includes(url.protocol)) return { url };
+  if (url.origin !== siteRoot.origin) return { url };
+
+  let result;
+  try {
+    result = artifactFor(url, files, basePath);
+  } catch {
+    diagnostics.push(
+      `${sourceName}: href="${href}" has invalid percent encoding`,
+    );
+    return { internal: true, url };
+  }
+
+  if (result.error) {
+    diagnostics.push(`${sourceName}: href="${href}" -> ${result.error}`);
+    return { internal: true, url };
+  }
+
+  if (!result.artifact.endsWith('.html')) return { internal: true, url };
+
+  let anchor;
+  try {
+    anchor = anchorFrom(url.hash);
+  } catch {
+    diagnostics.push(
+      `${sourceName}: href="${href}" has invalid fragment encoding`,
+    );
+    return { internal: true, url };
+  }
+
+  if (anchor && !anchorsByFile.get(result.artifact)?.has(anchor)) {
+    diagnostics.push(
+      `${sourceName}: href="${href}" -> missing anchor "${anchor}"`,
+    );
+  }
+
+  return { internal: true, url };
+}
+
+function checkRepositoryLink(href, url, diagnostics) {
+  let target;
+  try {
+    target = repositoryTargetFor(url);
+  } catch {
+    diagnostics.push(
+      `llms.txt: href="${href}" has invalid repository path encoding`,
+    );
+    return true;
+  }
+  if (!target) return false;
+  if (target.error) {
+    diagnostics.push(`llms.txt: href="${href}" -> ${target.error}`);
+    return true;
+  }
+
+  const targetPath = resolve(repositoryDirectory, target.relativePath);
+  if (pathEscapesDirectory(repositoryDirectory, targetPath)) {
+    diagnostics.push(
+      `llms.txt: href="${href}" -> escapes the repository checkout`,
+    );
+    return true;
+  }
+
+  let realRepositoryPath;
+  let realTargetPath;
+  try {
+    realRepositoryPath = realpathSync(repositoryDirectory);
+    realTargetPath = realpathSync(targetPath);
+  } catch {
+    diagnostics.push(
+      `llms.txt: href="${href}" -> missing repository target "${target.relativePath || '.'}"`,
+    );
+    return true;
+  }
+  if (pathEscapesDirectory(realRepositoryPath, realTargetPath)) {
+    diagnostics.push(
+      `llms.txt: href="${href}" -> repository target escapes the checkout through a symbolic link`,
+    );
+    return true;
+  }
+  let stats;
+  try {
+    stats = statSync(realTargetPath);
+  } catch {
+    diagnostics.push(
+      `llms.txt: href="${href}" -> missing repository target "${target.relativePath || '.'}"`,
+    );
+    return true;
+  }
+
+  const hasExpectedType =
+    target.kind === 'blob' ? stats.isFile() : stats.isDirectory();
+  if (!hasExpectedType) {
+    const expectedType = target.kind === 'blob' ? 'file' : 'directory';
+    diagnostics.push(
+      `llms.txt: href="${href}" -> repository target "${target.relativePath || '.'}" is not a ${expectedType}`,
+    );
+  }
+  return true;
+}
+
 function run() {
   let files;
   try {
     files = collectFiles(distDirectory);
   } catch (error) {
-    throw new Error(
-      `${distDirectory} does not exist; build the site first`,
-      { cause: error },
-    );
+    throw new Error(`${distDirectory} does not exist; build the site first`, {
+      cause: error,
+    });
   }
 
   const htmlFiles = [...files]
@@ -241,6 +469,28 @@ function run() {
       anchorsFor(htmlByFile.get(relativePath), relativePath, diagnostics),
     ]),
   );
+  let agentIndex;
+  try {
+    agentIndex = readFileSync(resolve(distDirectory, 'llms.txt'), 'utf8');
+  } catch (error) {
+    throw new Error(`${distDirectory}/llms.txt does not exist`, {
+      cause: error,
+    });
+  }
+  const {
+    links: agentIndexLinks,
+    malformedInlineLinks,
+    undefinedReferences,
+  } = linksInMarkdown(agentIndex);
+  if (agentIndexLinks.length === 0) {
+    diagnostics.push('llms.txt: contains no Markdown links');
+  }
+  for (const line of malformedInlineLinks) {
+    diagnostics.push(`llms.txt:${line}: malformed inline Markdown link`);
+  }
+  for (const label of undefinedReferences) {
+    diagnostics.push(`llms.txt: undefined link reference "${label}"`);
+  }
   let internalLinkCount = 0;
 
   for (const relativePath of htmlFiles) {
@@ -252,52 +502,47 @@ function run() {
       const href = attributesFor(tag.source).get('href');
       if (href === undefined) continue;
 
-      let url;
-      try {
-        url = new URL(href, sourceUrl);
-      } catch {
-        diagnostics.push(`${relativePath}: invalid href="${href}"`);
-        continue;
-      }
-
-      if (!['http:', 'https:'].includes(url.protocol)) continue;
-      if (url.origin !== siteRoot.origin) continue;
-      internalLinkCount += 1;
-
-      let result;
-      try {
-        result = artifactFor(url, files, basePath);
-      } catch {
-        diagnostics.push(
-          `${relativePath}: href="${href}" has invalid percent encoding`,
-        );
-        continue;
-      }
-
-      if (result.error) {
-        diagnostics.push(`${relativePath}: href="${href}" -> ${result.error}`);
-        continue;
-      }
-
-      if (!result.artifact.endsWith('.html')) continue;
-
-      let anchor;
-      try {
-        anchor = anchorFrom(url.hash);
-      } catch {
-        diagnostics.push(
-          `${relativePath}: href="${href}" has invalid fragment encoding`,
-        );
-        continue;
-      }
-
-      if (anchor && !anchorsByFile.get(result.artifact)?.has(anchor)) {
-        diagnostics.push(
-          `${relativePath}: href="${href}" -> missing anchor "${anchor}"`,
-        );
-      }
+      const result = checkSiteLink({
+        href,
+        sourceUrl,
+        sourceName: relativePath,
+        siteRoot,
+        files,
+        basePath,
+        anchorsByFile,
+        diagnostics,
+      });
+      if (result.internal) internalLinkCount += 1;
     }
   }
+
+  const agentIndexUrl = new URL('llms.txt', siteRoot);
+  let agentIndexSiteLinkCount = 0;
+  let agentIndexRepositoryLinkCount = 0;
+  for (const href of agentIndexLinks) {
+    const result = checkSiteLink({
+      href,
+      sourceUrl: agentIndexUrl,
+      sourceName: 'llms.txt',
+      siteRoot,
+      files,
+      basePath,
+      anchorsByFile,
+      diagnostics,
+    });
+    if (result.internal) {
+      agentIndexSiteLinkCount += 1;
+    } else if (
+      result.url &&
+      checkRepositoryLink(href, result.url, diagnostics)
+    ) {
+      agentIndexRepositoryLinkCount += 1;
+    }
+  }
+  const agentIndexExternalLinkCount =
+    agentIndexLinks.length -
+    agentIndexSiteLinkCount -
+    agentIndexRepositoryLinkCount;
 
   diagnostics.sort();
   if (diagnostics.length > 0) {
@@ -315,7 +560,7 @@ function run() {
   }
 
   console.log(
-    `Checked ${internalLinkCount} internal links in ${htmlFiles.length} HTML files; 0 issues.`,
+    `Checked ${internalLinkCount} internal links in ${htmlFiles.length} HTML files and ${agentIndexLinks.length} links in llms.txt (${agentIndexSiteLinkCount} site, ${agentIndexRepositoryLinkCount} repository, ${agentIndexExternalLinkCount} external); 0 issues.`,
   );
 }
 

--- a/site/scripts/check-links.test.mjs
+++ b/site/scripts/check-links.test.mjs
@@ -1,0 +1,275 @@
+import assert from 'node:assert/strict';
+import { after, test } from 'node:test';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const checkerPath = fileURLToPath(
+  new URL('./check-links.mjs', import.meta.url),
+);
+const fixtureDirectories = [];
+
+after(() => {
+  for (const directory of fixtureDirectories) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function createFixture({
+  indexBody = '',
+  llms = '[Home](https://swarmbase.github.io/swarmbase/)',
+  pages = {},
+  repositoryDirectories = [],
+  repositoryFiles = {},
+} = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'swarmbase-site-links-'));
+  const directory = join(root, 'dist');
+  const repositoryDirectory = join(root, 'repository');
+  fixtureDirectories.push(root);
+  mkdirSync(directory);
+  mkdirSync(repositoryDirectory);
+  writeFileSync(
+    join(directory, 'index.html'),
+    '<!doctype html><link rel="canonical" href="https://swarmbase.github.io/swarmbase/">' +
+      indexBody,
+  );
+
+  for (const [relativePath, html] of Object.entries(pages)) {
+    const path = join(directory, relativePath);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, html);
+  }
+
+  for (const relativePath of repositoryDirectories) {
+    mkdirSync(join(repositoryDirectory, relativePath), { recursive: true });
+  }
+  for (const [relativePath, contents] of Object.entries(repositoryFiles)) {
+    const path = join(repositoryDirectory, relativePath);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, contents);
+  }
+
+  if (llms !== null) writeFileSync(join(directory, 'llms.txt'), llms);
+  return { directory, repositoryDirectory, root };
+}
+
+function check(fixture) {
+  return spawnSync(
+    process.execPath,
+    [checkerPath, fixture.directory, fixture.repositoryDirectory],
+    { encoding: 'utf8' },
+  );
+}
+
+function outputFor(result) {
+  return `${result.stdout}${result.stderr}`;
+}
+
+test('accepts valid site and repository links from llms.txt', () => {
+  const fixture = createFixture({
+    indexBody: '<a href="./guide/#topic">Guide</a>',
+    llms: [
+      '[Guide][guide]',
+      '[guide]: https://swarmbase.github.io/swarmbase/guide/#topic',
+      '[Audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md)',
+      '[Examples](https://github.com/swarmbase/swarmbase/tree/main/examples)',
+      '[Issue](https://github.com/swarmbase/swarmbase/issues/1)',
+      '[Node.js](https://nodejs.org/)',
+    ].join('\n'),
+    pages: {
+      'guide/index.html': '<h2 id="topic">Topic</h2>',
+    },
+    repositoryDirectories: ['examples'],
+    repositoryFiles: { 'docs/feature-audit.md': '# Feature audit' },
+  });
+
+  const result = check(fixture);
+  assert.equal(result.status, 0, outputFor(result));
+  assert.match(
+    outputFor(result),
+    /5 links in llms\.txt \(1 site, 2 repository, 2 external\)/,
+  );
+});
+
+test('keeps validating links from generated HTML', () => {
+  const result = check(
+    createFixture({
+      indexBody: '<a href="./guide/#missing">Guide</a>',
+      pages: { 'guide/index.html': '<h2 id="topic">Topic</h2>' },
+    }),
+  );
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /index\.html:.*missing anchor "missing"/);
+});
+
+test('rejects a missing site target from llms.txt', () => {
+  const result = check(
+    createFixture({
+      llms: '[Missing](https://swarmbase.github.io/swarmbase/missing/)',
+    }),
+  );
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /llms\.txt:.*missing target/);
+});
+
+test('rejects a missing site anchor from llms.txt', () => {
+  const result = check(
+    createFixture({
+      llms: '[Guide](https://swarmbase.github.io/swarmbase/guide/#missing)',
+      pages: { 'guide/index.html': '<h2 id="topic">Topic</h2>' },
+    }),
+  );
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /llms\.txt:.*missing anchor "missing"/);
+});
+
+test('rejects a site link outside the configured base path', () => {
+  const result = check(
+    createFixture({
+      llms: '[Outside](https://swarmbase.github.io/outside/)',
+    }),
+  );
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /llms\.txt:.*escapes base path/);
+});
+
+test('rejects a malformed URL from llms.txt', () => {
+  const result = check(createFixture({ llms: '[Bad](https://[invalid)' }));
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(
+    outputFor(result),
+    /llms\.txt: invalid href="https:\/\/\[invalid"/,
+  );
+});
+
+test('rejects an inline Markdown link without a closing delimiter', () => {
+  const result = check(
+    createFixture({
+      llms: [
+        '[Home](https://swarmbase.github.io/swarmbase/)',
+        '[Guide](https://swarmbase.github.io/swarmbase/guide/',
+      ].join('\n'),
+    }),
+  );
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(
+    outputFor(result),
+    /llms\.txt:2: malformed inline Markdown link/,
+  );
+});
+
+test('rejects an undefined Markdown link reference', () => {
+  const result = check(
+    createFixture({
+      llms: [
+        '[Home](https://swarmbase.github.io/swarmbase/)',
+        '[Guide][missing]',
+        '[guide]: https://swarmbase.github.io/swarmbase/guide/',
+      ].join('\n'),
+    }),
+  );
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /undefined link reference "missing"/);
+});
+
+test('rejects a missing repository target from llms.txt', () => {
+  const result = check(
+    createFixture({
+      llms: '[Missing](https://github.com/swarmbase/swarmbase/blob/main/docs/not-here.md)',
+    }),
+  );
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(
+    outputFor(result),
+    /missing repository target "docs\/not-here\.md"/,
+  );
+});
+
+test('rejects unsupported same-repository source routes', () => {
+  const result = check(
+    createFixture({
+      llms: [
+        '[Branch](https://github.com/swarmbase/swarmbase/blob/dev/docs/file.md)',
+        '[Route](https://github.com/swarmbase/swarmbase/blbo/main/docs/file.md)',
+        '[Short route](https://github.com/swarmbase/swarmbase/blbo/main)',
+        '[Other branch](https://github.com/swarmbase/swarmbase/blbo/dev/docs/file.md)',
+      ].join('\n'),
+    }),
+  );
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /unsupported repository branch "dev"/);
+  assert.match(outputFor(result), /unsupported repository route "blbo\/main"/);
+  assert.match(outputFor(result), /unsupported repository route "blbo\/dev"/);
+});
+
+test('rejects repository paths containing encoded backslashes', () => {
+  const result = check(
+    createFixture({
+      llms: '[Escape](https://github.com/swarmbase/swarmbase/blob/main/docs/..%5Coutside.md)',
+    }),
+  );
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /escapes the repository checkout/);
+});
+
+test('rejects repository targets that symlink outside the checkout', () => {
+  const fixture = createFixture({
+    llms: '[Escape](https://github.com/swarmbase/swarmbase/blob/main/docs/link.md)',
+    repositoryDirectories: ['docs'],
+  });
+  writeFileSync(join(fixture.root, 'outside.md'), 'outside');
+  symlinkSync(
+    join('..', '..', 'outside.md'),
+    join(fixture.repositoryDirectory, 'docs/link.md'),
+  );
+
+  const result = check(fixture);
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(
+    outputFor(result),
+    /escapes the checkout through a symbolic link/,
+  );
+});
+
+test('accepts repository targets that symlink within the checkout', () => {
+  const fixture = createFixture({
+    llms: '[Link](https://github.com/swarmbase/swarmbase/blob/main/docs/link.md)',
+    repositoryFiles: { 'docs/target.md': 'target' },
+  });
+  symlinkSync('target.md', join(fixture.repositoryDirectory, 'docs/link.md'));
+
+  const result = check(fixture);
+  assert.equal(result.status, 0, outputFor(result));
+});
+
+test('rejects an empty llms.txt', () => {
+  const result = check(createFixture({ llms: '' }));
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /llms\.txt: contains no Markdown links/);
+});
+
+test('requires llms.txt in the built site', () => {
+  const result = check(createFixture({ llms: null }));
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /llms\.txt does not exist/);
+});


### PR DESCRIPTION
## Summary

- validate links in the built `llms.txt` alongside generated HTML links
- resolve Swarmbase site routes, anchors, and repository source links offline
- add fixture coverage for malformed, missing, and escaping targets
- rerun Site CI when repository-local index targets change

## Why

The site link check previously scanned generated HTML only. A stale route in the published agent index, or a renamed repository target linked from it, could pass Site CI unnoticed.

The check remains deterministic: same-site destinations are resolved against `site/dist`, `blob/main` and `tree/main` destinations are resolved against the checkout, and unrelated external origins are counted but not crawled.

## Validation

- `node --test site/scripts/check-links.test.mjs`
- `yarn workspace @swarmbase/site build`
- `node site/scripts/check-links.mjs`
- `git diff --check`

The built-site check reports 28,759 HTML links and 27 `llms.txt` links with zero issues.

## Stack

The prerequisite in #344 is merged. The focused change in this pull request is commit `228d9e76`.
