### PR TITLE
fix(ci): prevent duplicate CI runs on PR pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches-ignore:
-      - docs
+    branches: [main]
   pull_request:
 
 jobs:

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -87,6 +87,8 @@ export default defineConfig({
         {
           label: 'Concepts',
           items: [
+            'concepts/why-swarmbase',
+            'concepts/architecture',
             'concepts/local-first',
             'concepts/crdts',
             'concepts/networking',
@@ -110,12 +112,18 @@ export default defineConfig({
         },
         {
           label: 'Reference',
-          items: ['reference', typeDocSidebarGroup],
+          items: [
+            'reference',
+            'reference/comparisons',
+            typeDocSidebarGroup,
+          ],
         },
         {
           label: 'Community',
           items: [
             'community',
+            'community/faq',
+            'community/roadmap',
             'community/contributing',
             'community/help-wanted',
           ],

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,25 +1,47 @@
 # Swarmbase
 
-> Alpha TypeScript software for encrypted, local-first CRDT documents synchronized over peer-to-peer networks. Not production-ready.
+> Alpha TypeScript software for encrypted, local-first CRDT documents synchronized over peer-to-peer networks. Not production-ready. Composes Yjs/Automerge CRDT libraries with libp2p networking, Helia content-addressed storage, ECDSA P-384 signing, and AES-GCM encryption.
 
-Use the feature audit and concept documentation as the authority for capability claims. A primitive test does not establish complete multi-peer behavior.
+Use the feature audit and concept documentation as the authority for capability claims. A primitive test does not establish complete multi-peer behavior. Every capability must be verified by CI evidence.
 
 ## Start
 
 - [Quick start](https://swarmbase.github.io/swarmbase/getting-started/quick-start/): Build Swarmbase from source and exercise the verified browser path.
-- [Examples](https://github.com/swarmbase/swarmbase/tree/main/examples): Runnable browser applications.
-- [API reference](https://swarmbase.github.io/swarmbase/reference/): Generated package documentation.
+- [Why Swarmbase](https://swarmbase.github.io/swarmbase/concepts/why-swarmbase/): Value proposition, when to use/not use.
+- [Architecture](https://swarmbase.github.io/swarmbase/concepts/architecture/): System overview, data flow, networking stack, encryption model with ASCII diagrams.
+- [Examples](https://github.com/swarmbase/swarmbase/tree/main/examples): Runnable browser applications (browser-test, wiki-swarm, password-manager).
+- [API reference](https://swarmbase.github.io/swarmbase/reference/): Generated package documentation for all six @swarmbase/* packages.
+- [Comparisons](https://swarmbase.github.io/swarmbase/reference/comparisons/): Swarmbase vs Yjs, Automerge, Liveblocks, RxDB, Jazz, ElectricSQL.
+
+## Concepts
+
+- [Local-first design](https://swarmbase.github.io/swarmbase/concepts/local-first/): What "local-first" means, implemented behavior, missing features (no outbox, no reconnect, no restart recovery).
+- [CRDT model](https://swarmbase.github.io/swarmbase/concepts/crdts/): Yjs and Automerge integration, shadow sync graph, document.change() lifecycle, CRDTProvider interface, convergence boundaries, snapshots/compaction.
+- [Networking](https://swarmbase.github.io/swarmbase/concepts/networking/): libp2p transports (WebSocket, WebRTC, WebTransport), Circuit Relay v2, GossipSub pubsub, peer discovery (bootstrap, Kademlia DHT, AutoNAT), NAT traversal (DCUtR, STUN/TURN), relay trust model.
+- [Storage](https://swarmbase.github.io/swarmbase/concepts/storage/): Content-addressed blocks, Helia blockstore (IndexedDB), shadow sync graph, pinning status (incomplete), recovery requirements, compaction/GC.
+- [Security](https://swarmbase.github.io/swarmbase/concepts/security/): ECDSA P-384 signing, AES-GCM encryption, reader/writer ACL, BeeKEM key encapsulation, UCAN capabilities (standalone), K-of-Q quorum loading, revocation (partial, memory-only BeeKEM state).
+- [Limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/): Complete catalog of alpha gaps — distribution, offline, storage, networking, auth, convergence, examples.
+
+## Cookbook
+
+- [Collaborative wiki](https://swarmbase.github.io/swarmbase/cookbook/collaborative-wiki/): Run the wiki-swarm example (Vite, Redux, Automerge). Startup smoke only.
+- [Password manager](https://swarmbase.github.io/swarmbase/cookbook/password-manager/): Run the password-manager example with key material setup and ACL management.
+- [React integration](https://swarmbase.github.io/swarmbase/cookbook/react/): useCollabswarmDocumentState hooks, CollabswarmContext provider, document open/change patterns.
+- [Redux integration](https://swarmbase.github.io/swarmbase/cookbook/redux/): Store setup, collabswarmReducer, initializeAsync, openDocumentAsync, selector patterns.
+- [Search indexing](https://swarmbase.github.io/swarmbase/cookbook/search-indexing/): IndexManager (materialized indexes), blind-index primitives, bloom-filter gossip (deferred).
+- [Yjs schema design](https://swarmbase.github.io/swarmbase/cookbook/yjs-schema-design/): Y.Map, Y.Array, Y.Text merge behaviors, mutation patterns, ID/counter patterns, migration.
+- [Running a relay](https://swarmbase.github.io/swarmbase/cookbook/running-a-relay/): Docker build/run, Vite client configuration, operational limits (no stable identity, no meshing).
+- [Pinning](https://swarmbase.github.io/swarmbase/cookbook/pinning/): What exists vs what's missing, 10-step integration checklist.
+
+## Community
+
+- [FAQ](https://swarmbase.github.io/swarmbase/community/faq/): Production readiness, key management, relay requirements, conflict handling, browser support, offline capability.
+- [Roadmap](https://swarmbase.github.io/swarmbase/community/roadmap/): 10 priority gaps — persistence, key exchange, convergence, pinning, relay identity, publication, docs, benchmarks, search, examples.
+- [Contributing](https://swarmbase.github.io/swarmbase/community/contributing/): Node 22.19.0 setup, Yarn 4.5.0, build/test commands, Docker-backed suite readiness helpers, PR expectations.
+- [Help wanted](https://swarmbase.github.io/swarmbase/community/help-wanted/): Specific contribution areas with evidence gaps.
 
 ## Architecture, evidence, and limits
 
-- [Feature and verification audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md): Capability-to-evidence map.
-- [Security model](https://swarmbase.github.io/swarmbase/concepts/security/): Threat model, guarantees, and non-goals.
-- [Networking](https://swarmbase.github.io/swarmbase/concepts/networking/): Peer discovery, transports, relays, and NAT constraints.
-- [Storage](https://swarmbase.github.io/swarmbase/concepts/storage/): Local and remote persistence boundaries.
-- [Limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/): Current alpha limitations and deployment caveats.
-
-## Contributing
-
-- [Contributor guide](https://swarmbase.github.io/swarmbase/community/contributing/): Development setup and verification commands.
-- [Help wanted](https://swarmbase.github.io/swarmbase/community/help-wanted/): Current contribution areas.
+- [Feature and verification audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md): Capability-to-evidence map — the authoritative reference for what works and what doesn't.
 - [Repository](https://github.com/swarmbase/swarmbase): Source, issues, and discussions.
+- [AGENTS.md](https://github.com/swarmbase/swarmbase/blob/main/AGENTS.md): Repository map, toolchain setup, commands, engineering rules for contributors and agents.

--- a/site/src/content/docs/community/faq.md
+++ b/site/src/content/docs/community/faq.md
@@ -33,7 +33,7 @@ Swarmbase targets browser and Node.js environments. It has not been tested on Re
 
 ## How does Swarmbase handle conflicts?
 
-Swarmbase delegates conflict resolution to the underlying CRDT library (Yjs or Automerge). Both libraries provide deterministic merge semantics — concurrent edits to the same field are resolved automatically, without application-level conflict handlers. For example, Yjs merges concurrent `Y.Map` key updates by taking the later one, and merges concurrent `Y.Array` insertions by preserving both at their intended positions.
+Swarmbase delegates conflict resolution to the underlying CRDT library (Yjs or Automerge). Both libraries provide deterministic merge semantics — concurrent edits are resolved automatically, without application-level conflict handlers. For example, Yjs merges concurrent `Y.Map` key updates using deterministic per-key conflict resolution (not wall-clock ordering), and merges concurrent `Y.Array` insertions by preserving both at their intended positions.
 
 ## How does Swarmbase compare to CRDT-based databases?
 

--- a/site/src/content/docs/community/faq.md
+++ b/site/src/content/docs/community/faq.md
@@ -1,0 +1,81 @@
+---
+title: FAQ
+description: Frequently asked questions about Swarmbase.
+---
+
+## Is Swarmbase production-ready?
+
+**No.** Swarmbase is alpha software. It is suitable for experiments, prototypes, and learning about local-first systems. Several critical paths are not yet verified end-to-end, including browser restart recovery, partition/rejoin convergence, and automatic reconnect. See the [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md) for a complete capability map.
+
+## Can I use Swarmbase with npm/pnpm/yarn install?
+
+Not yet. The `@swarmbase/*` packages are **unpublished**. You must clone the repository and build from source. See the [quick start guide](../../getting-started/quick-start/).
+
+## Why should I use Swarmbase instead of Yjs or Automerge directly?
+
+Swarmbase is not a replacement for Yjs or Automerge — it **adapts** them. Use Swarmbase when you also need encryption, signing, access control, peer-to-peer discovery, content-addressed storage, and multi-transport networking. If you already have those layers, use Yjs or Automerge directly and integrate your own infrastructure.
+
+## What happens if I lose my signing key?
+
+Your signing key is your identity in the Swarmbase network. If you lose it, you cannot issue new changes or prove you authored past ones. Swarmbase does not provide key recovery, rotation, or backup — key management is the application's responsibility. Treat signing keys with the same care as any private key material.
+
+## What happens if all peers go offline?
+
+Documents are only available while at least one peer with a replica is online — or while encrypted blocks are pinned to remote storage. Swarmbase's pinning integration is **incomplete**: a listener exists but the core publishing path does not. Without pinning, the last online peer is the last surviving copy.
+
+## Can I use Swarmbase in a mobile app?
+
+Swarmbase targets browser and Node.js environments. It has not been tested on React Native, Expo, or other mobile runtimes. The libp2p and WebCrypto dependencies may not be available in all mobile JavaScript environments.
+
+## Do I need to run a relay server?
+
+**For browser peers behind NAT: yes.** Browsers cannot listen for incoming connections. A Circuit Relay bridges NAT by forwarding encrypted traffic between peers. For Node.js peers on the same network, direct connections may work without a relay. See [running a relay](../../cookbook/running-a-relay/).
+
+## How does Swarmbase handle conflicts?
+
+Swarmbase delegates conflict resolution to the underlying CRDT library (Yjs or Automerge). Both libraries provide deterministic merge semantics — concurrent edits to the same field are resolved automatically, without application-level conflict handlers. For example, Yjs merges concurrent `Y.Map` key updates by taking the later one, and merges concurrent `Y.Array` insertions by preserving both at their intended positions.
+
+## How does Swarmbase compare to CRDT-based databases?
+
+Most CRDT databases (like RxDB's CRDT plugin) add CRDT merge semantics to a document store. Swarmbase adds encryption, signing, access control, and peer-to-peer networking to existing CRDT libraries. The key difference: Swarmbase's documents are encrypted and signed before they leave the device, and there is no server that sees plaintext.
+
+## Does Swarmbase support real-time collaborative editing?
+
+Partial. CRDT updates propagate via GossipSub, which has sub-second latency in typical deployments. However, presence (cursors, selections) is not implemented, and there is no operational transform layer for sub-100ms typing synchronization. For "Google Docs-like" real-time editing with presence, consider Liveblocks or PartyKit with Yjs. Swarmbase is designed for document-level collaboration, not character-level real-time editing.
+
+## Can multiple people edit the same document at the same time?
+
+Yes. Each peer's changes are signed, encrypted, and published independently. The CRDT layer merges concurrent edits when they arrive. There is no lock, no leader election, and no "last write wins" — the merge is deterministic and conflict-free.
+
+## How do I share a document with another person?
+
+Document sharing requires key exchange. The document owner must:
+1. Generate a BeeKEM key encapsulation for the recipient
+2. Add the recipient as a reader (and optionally writer) to the document ACL
+3. Transmit the KEM-wrapped document key and signing public key to the recipient
+
+This process is not automated — the application must implement the key exchange channel. See the [password manager cookbook](../../cookbook/password-manager/) for an example.
+
+## Can a relay read my documents?
+
+**No.** Relays see encrypted ciphertext only. They can see metadata (peer IDs, document topic IDs, timing, data volume) but cannot decrypt document content without the document key. However, a relay **can** drop, delay, or censor traffic — Swarmbase does not protect against denial of service by relay operators.
+
+## Can I revoke someone's access to a document?
+
+**Partially.** Revoking a writer prevents them from publishing new changes that other peers will accept. Revoking a reader requires BeeKEM key separation — existing keys must be invalidated and new keys distributed to remaining members. BeeKEM's rekey state is currently **memory-only** (does not survive restart), and the PathUpdate revocation mechanism is best-effort. See the [security page](../../concepts/security/#revocation) for details.
+
+## What browsers are supported?
+
+Swarmbase requires WebCrypto (for ECDSA, ECDH, AES-GCM) and IndexedDB. These are available in all modern browsers: Chrome 37+, Firefox 34+, Safari 11+, Edge 79+. WebTransport support requires Chrome 97+ or Edge 97+.
+
+## How large can documents be?
+
+CRDT documents grow with every change. Yjs documents of a few megabytes are typical; tens of megabytes may cause performance issues in browsers. The document size depends on the CRDT data model and change frequency, not on Swarmbase itself. Consider splitting large datasets across multiple documents and using the index layer for search.
+
+## Is there a hosted version of Swarmbase?
+
+No. Swarmbase is a set of libraries, not a service. There is no cloud offering, no managed relay service, and no hosted storage. You run your own infrastructure.
+
+## What license is Swarmbase?
+
+MIT. All six packages are licensed under MIT. You can use, modify, and distribute them freely.

--- a/site/src/content/docs/community/index.md
+++ b/site/src/content/docs/community/index.md
@@ -23,3 +23,10 @@ If you suspect a vulnerability, open this repository's **Security** tab and use 
 State exactly what a change or test demonstrates. A unit test for a cryptographic or CRDT primitive does not by itself prove browser interoperability, persistence, multi-peer convergence, invitation acceptance, revocation under attack, or production suitability. Use the [feature and verification audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md) as the current evidence map.
 
 Swarmbase and all six package manifests use the MIT License.
+
+## More resources
+
+- [FAQ](faq/) — answers to common questions about production readiness, key management, relay requirements, and more
+- [Roadmap](roadmap/) — current development priorities and future directions
+- [Contributing](contributing/) — development setup, build commands, and PR expectations
+- [Help wanted](help-wanted/) — specific contribution areas with the highest impact

--- a/site/src/content/docs/community/roadmap.md
+++ b/site/src/content/docs/community/roadmap.md
@@ -1,0 +1,113 @@
+---
+title: Roadmap
+description: Current development priorities and future directions for Swarmbase.
+---
+
+Swarmbase is alpha software. This page tracks the most important gaps between the current implementation and a production-ready system.
+
+## Priority gaps
+
+These are the highest-impact areas of work. See the [help wanted page](../help-wanted/) for specific contribution opportunities.
+
+### 1. Persistence and restart recovery
+
+**Status: Not verified.** Documents store encrypted blocks in browser IndexedDB via Helia's blockstore, but complete close-reopen cycles have not been proven in CI. A browser tab refresh should restore documents without data loss.
+
+What needs to happen:
+- CI test that closes a browser, reopens it, and verifies document state
+- CI test that persists state across multiple sessions
+- CI test for IndexedDB quota handling and cleanup
+
+### 2. Invitations, key exchange, and revocation
+
+**Status: Partially implemented.** The BeeKEM key encapsulation mechanism and reader/writer ACL exist, but the full invitation flow (discover peer, exchange keys, onboard to document) has no end-to-end CI proof. BeeKEM rekey state is memory-only.
+
+What needs to happen:
+- End-to-end test of two distinct identities exchanging keys and accessing a shared document
+- Durable BeeKEM state (survives restart)
+- PathUpdate revocation tested with live peers
+
+### 3. Partition and live convergence
+
+**Status: Not proven.** Single-document convergence has been verified in CI, but system-level partition/rejoin scenarios (split network, make conflicting edits on both sides, heal partition, verify convergence) have no CI coverage.
+
+What needs to happen:
+- CI test for network partition → conflicting edits → heal → verify convergence
+- CI test for multiple concurrent writers on different network paths
+- CI test for slow/unreliable peer scenarios
+
+### 4. Pinning publisher and restore
+
+**Status: Incomplete.** A `CollabswarmNode` listener exists for pinning events, but the core commit path does not publish to it. No generic IPFS pinning client exists. Blocks can be stored but cannot be recovered into a working document without the full key and graph state.
+
+What needs to happen:
+- Publisher integration so every block write fires a pinning event
+- Generic pinning client (e.g., to a remote IPFS node or S3-compatible store)
+- Restore flow with CI verification (pin → destroy local state → restore from remote)
+
+### 5. Relay identity, failover, and scale
+
+**Status: Limited.** The relay server is functional for development but restarts change peer IDs, there is no meshing or failover, and abuse resistance is unverified. Multi-relay topologies exist in Docker Compose but have no automated scale or failover tests.
+
+What needs to happen:
+- Stable relay identity (persistent peer ID across restarts)
+- Relay meshing for multi-relay deployments
+- CI test for relay failover (kill one relay, verify peers reconnect through another)
+
+### 6. External package publication
+
+**Status: Not implemented.** The `@swarmbase/*` packages are source workspaces, not published to npm. The release workflow (#321) defines the publication pipeline but npm scope ownership, `NPM_TOKEN`, and publication gates are not yet configured.
+
+What needs to happen:
+- npm scope `@swarmbase` claimed
+- `NPM_TOKEN` and `NPM_PUBLISH_ENABLED` secrets configured
+- First alpha release published
+- External consumer validation (import from npm, build, run)
+
+### 7. Documentation and snippet tests
+
+**Status: Ongoing.** Documentation code snippets are not validated against the actual API. Examples compile but cookbook snippets may drift.
+
+What needs to happen:
+- TypeScript snippet extraction and validation pipeline
+- CI check that all code blocks in docs match the current API surface
+
+### 8. Benchmark budgets and runner
+
+**Status: Runner broken.** Benchmark suites exist for convergence simulation, CRDT sync latency, crypto overhead, blind-index performance, bloom-filter scaling, and index-query scaling, but the runner has a module mismatch. No pass/fail thresholds exist.
+
+What needs to happen:
+- Fix benchmark runner module resolution
+- Establish baseline metrics in CI
+- Set pass/fail thresholds for regressions
+
+### 9. Distributed search integration
+
+**Status: Deferred.** Bloom-filter gossip returns candidate peer IDs but does not execute remote queries or aggregate results.
+
+What needs to happen:
+- Remote query protocol (send query to candidate peers, collect results)
+- CI test for multi-peer search with bloom pre-filtering
+- Privacy analysis of bloom-filter information leakage
+
+### 10. Examples as complete showcases
+
+**Status: Startup smoke only.** The three examples (browser-test, wiki-swarm, password-manager) verify single-browser startup but do not demonstrate multi-peer collaboration, sharing, or recovery.
+
+What needs to happen:
+- Multi-browser CI tests for each example
+- Document sharing flow in wiki-swarm
+- Key exchange and permission management in password-manager
+- Offline → online → convergence in browser-test
+
+## Completed recently
+
+- Rename package scope from `@collabswarm` to `@swarmbase`
+- Documentation site with Starlight (concepts, cookbook, API reference, community)
+- Cross-NAT encrypted document retrieval verified in CI
+- Release workflow with secretless validation and gated publishing
+- Community contributor guide with Docker readiness helpers
+
+## How to contribute
+
+See the [contributing guide](../contributing/) for setup instructions and the [help wanted page](../help-wanted/) for specific tasks. The [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md) is the definitive capability map — every claim should be backed by CI evidence.

--- a/site/src/content/docs/concepts/architecture.md
+++ b/site/src/content/docs/concepts/architecture.md
@@ -1,0 +1,182 @@
+---
+title: Architecture
+description: How Swarmbase is structured — packages, data flow, networking, and the sync model.
+---
+
+Swarmbase composes several open-source subsystems into a coherent local-first stack. This page describes how the pieces fit together.
+
+## Package dependency graph
+
+```
+@swarmbase/collabswarm (core)
+├── libp2p (peer-to-peer networking)
+├── Helia (content-addressed storage)
+├── @chainsafe/js-ipns (naming)
+├── BeeKEM (key encapsulation for dynamic groups)
+├── UCAN (authorization capabilities)
+└── @swarmbase/collabswarm-yjs / @swarmbase/collabswarm-automerge (CRDT adapters)
+
+@swarmbase/collabswarm-react → @swarmbase/collabswarm
+@swarmbase/collabswarm-redux → @swarmbase/collabswarm
+@swarmbase/collabswarm-index → @swarmbase/collabswarm
+```
+
+## Data flow: writing a change
+
+```
+Application
+  │
+  ▼
+document.change((state) => { state.getArray('items').push(['buy milk']) })
+  │
+  ▼
+CRDT Provider (Yjs / Automerge)
+  │  applies mutation to local CRDT replica
+  │  serializes the update
+  ▼
+CollabswarmDocument
+  │  wraps update in a signed CRDTChangeBlock
+  │  encrypts block with document AES-GCM key
+  │  addresses block by CID (SHA-256 hash of ciphertext)
+  ▼
+Helia Blockstore (local IndexedDB)
+  │  stores encrypted block
+  ▼
+libp2p PubSub (GossipSub)
+  │  publishes CID to document topic peers
+  ▼
+Remote Peers
+  │  receive CID announcement
+  │  fetch encrypted block via libp2p bitswap / HTTP
+  │  verify signature, decrypt, apply to local replica
+  ▼
+CRDT converges
+```
+
+## Data flow: loading an existing document
+
+```
+Application
+  │
+  ▼
+document.open()
+  │
+  ▼
+CollabswarmNode
+  │  resolves document ID to CID via IPNS or bootstrap
+  │  if local: loads tip from Helia blockstore
+  │  if remote: queries K-of-Q peers for latest tip hashes
+  ▼
+Load Quorum Orchestrator
+  │  requests tips from configured bootstrap peers
+  │  selects valid tip with highest epoch
+  │  waits for K-of-Q agreement before proceeding
+  ▼
+Shadow Graph Walk
+  │  walks CRDTChangeNode chain from tip backward
+  │  fetches missing blocks (bitswap / HTTP)
+  │  verifies signatures, decrypts, applies to CRDT
+  ▼
+Document is ready
+  │  Mutations are now accepted via document.change()
+  │  Reception of remote updates continues via GossipSub
+```
+
+## The sync model
+
+Swarmbase uses a **shadow sync graph** rather than a conventional Merkle-DAG:
+
+- Each `document.change()` call creates one `CRDTChangeBlock` — an encrypted, signed, CID-addressed node containing a serialized CRDT update.
+- Each block references its parent(s) by CID, forming a DAG.
+- New blocks are announced to peers via GossipSub (by CID, never by content).
+- Peers fetch missing blocks on demand (bitswap or HTTP fetch).
+- The CRDT layer resolves concurrent edits without a consensus leader.
+
+This model is **eventually consistent**: local edits apply immediately, remote edits merge when they arrive. There is no global ordering, no server-assigned sequence number, and no single source of truth.
+
+## Peer-to-peer networking stack
+
+```
+┌─────────────────────────────────────┐
+│            Application              │
+├─────────────────────────────────────┤
+│  CollabswarmNode                    │
+│  (document lifecycle, ACL, crypto)  │
+├─────────────────────────────────────┤
+│  libp2p                             │
+│  ├── Transport layer                │
+│  │   ├── WebSocket (relay, bootstrap)│
+│  │   ├── WebRTC (browser-to-browser)│
+│  │   └── WebTransport (modern)      │
+│  ├── Stream Muxing (yamux/mplex)    │
+│  ├── Connection Encryption (noise) │
+│  ├── Discovery                      │
+│  │   ├── Bootstrap list             │
+│  │   ├── Kademlia DHT              │
+│  │   └── AutoNAT                    │
+│  ├── NAT Traversal                  │
+│  │   ├── Circuit Relay v2           │
+│  │   ├── DCUtR (hole-punching)      │
+│  │   └── STUN/TURN                 │
+│  └── PubSub                         │
+│      └── GossipSub (document topics)│
+├─────────────────────────────────────┤
+│  Helia / IPFS                       │
+│  ├── Blockstore (IndexedDB/local)   │
+│  ├── Bitswap (block exchange)       │
+│  └── IPNS (naming)                  │
+└─────────────────────────────────────┘
+```
+
+## Encryption and identity
+
+```
+Application provides:
+  ├── ECDSA P-384 signing key pair (writer identity)
+  └── ECDH P-256 KEM key pair (key encapsulation)
+
+CollabswarmNode manages:
+  ├── Document AES-GCM keys (one per document, shared via BeeKEM)
+  ├── Signing key → libp2p PeerId mapping (separate keys)
+  └── ACL entries (reader/writer lists bound to signing public keys)
+
+Per change:
+  ├── Writer signs the CRDT update with their P-384 key
+  ├── Payload is encrypted with the document's AES-GCM key
+  ├── Signature is verified by receivers before decryption
+  └── Encryption is transparent to the CRDT layer
+```
+
+Key material never leaves the device in plaintext. Document keys are shared between authorized peers using BeeKEM — a key encapsulation mechanism that wraps the document key for each group member.
+
+## Where infrastructure is needed
+
+Swarmbase documents can sync over peer-to-peer links, but most deployments need supporting infrastructure:
+
+| Component | Required? | Purpose |
+|---|---|---|
+| **Relay node** | For browser peers | Bridges NAT; peers behind restrictive firewalls connect through it |
+| **Bootstrap node** | For initial discovery | Provides a well-known entry point for the libp2p network |
+| **STUN/TURN server** | For WebRTC direct connections | Helps peers establish direct browser-to-browser links |
+| **Remote pinning** | Optional | Persists encrypted blocks when all local peers go offline |
+| **Identity service** | Application responsibility | Swarmbase does not provide user authentication or key management |
+
+The relay server source is in `relay-server/`. The Docker Compose files in the repository root provide ready-to-run multi-node topologies for testing.
+
+## Current limitations
+
+See the [limitations page](../limitations/) for a complete list. Key architectural limitations to be aware of:
+
+- **No durable outbox**: if a remote peer is unreachable at write time, the update may be lost
+- **No automatic reconnect**: the application must detect disconnection and re-establish transport
+- **No pass/fail performance budgets**: benchmarks exist but have no thresholds
+- **Pinning is incomplete**: the listener exists but the publisher does not
+- **Browser restart recovery is unverified**: IndexedDB persistence works in tests but full close/reopen cycles are not proven in CI
+
+## Next steps
+
+- [Local-first design](../local-first/) — what "local-first" means in Swarmbase
+- [CRDT model](../crdts/) — how Yjs and Automerge integrate
+- [Networking](../networking/) — transports, discovery, and NAT traversal
+- [Security model](../security/) — threat model, encryption, and ACL
+- [Storage](../storage/) — persistence, pinning, and recovery

--- a/site/src/content/docs/concepts/architecture.md
+++ b/site/src/content/docs/concepts/architecture.md
@@ -64,16 +64,16 @@ document.open()
   ▼
 CollabswarmNode
   │  resolves document ID to CID via IPNS or bootstrap
-  │  if local: loads tip from Helia blockstore
-  │  if remote: queries K-of-Q peers for latest tip hashes
+  │  if local: loads frontier from Helia blockstore
+  │  if remote: queries Q-of-K peers for frontier agreement
   ▼
 Load Quorum Orchestrator
   │  requests tips from configured bootstrap peers
-  │  selects valid tip with highest epoch
-  │  waits for K-of-Q agreement before proceeding
+  │  selects candidate with highest epoch
+  │  waits for Q-of-K agreement before proceeding
   ▼
 Shadow Graph Walk
-  │  walks CRDTChangeNode chain from tip backward
+  │  walks CRDTChangeNode chain from frontier backward
   │  fetches missing blocks (bitswap / HTTP)
   │  verifies signatures, decrypts, applies to CRDT
   ▼
@@ -158,7 +158,7 @@ Swarmbase documents can sync over peer-to-peer links, but most deployments need 
 | **Relay node** | For browser peers | Bridges NAT; peers behind restrictive firewalls connect through it |
 | **Bootstrap node** | For initial discovery | Provides a well-known entry point for the libp2p network |
 | **STUN/TURN server** | For WebRTC direct connections | Helps peers establish direct browser-to-browser links |
-| **Remote pinning** | Optional | Persists encrypted blocks when all local peers go offline |
+| **Remote pinning** | Optional (integration incomplete) | Would persist encrypted blocks when all local peers go offline; the listener API exists but the current commit path does not invoke a publisher |
 | **Identity service** | Application responsibility | Swarmbase does not provide user authentication or key management |
 
 The relay server source is in `relay-server/`. The Docker Compose files in the repository root provide ready-to-run multi-node topologies for testing.
@@ -167,7 +167,7 @@ The relay server source is in `relay-server/`. The Docker Compose files in the r
 
 See the [limitations page](../limitations/) for a complete list. Key architectural limitations to be aware of:
 
-- **No durable outbox**: if a remote peer is unreachable at write time, the update may be lost
+- **No durable outbox**: local blocks are stored in IndexedDB, but an unreachable peer may not receive the update; there is no delivery retry queue
 - **No automatic reconnect**: the application must detect disconnection and re-establish transport
 - **No pass/fail performance budgets**: benchmarks exist but have no thresholds
 - **Pinning is incomplete**: the listener exists but the publisher does not

--- a/site/src/content/docs/concepts/crdts.md
+++ b/site/src/content/docs/concepts/crdts.md
@@ -1,46 +1,184 @@
 ---
 title: CRDTs
-description: CRDT convergence in Swarmbase, the Yjs and Automerge adapters, snapshots, and current evidence.
+description: How Swarmbase integrates Yjs and Automerge CRDT libraries — the sync model, convergence, snapshots, and quorum loading.
 ---
-
-Swarmbase delegates document merge semantics to a CRDT adapter. The repository provides adapters for **Yjs** and **Automerge**; every replica of a document must use a compatible adapter and data model.
 
 ## Design intent
 
-CRDTs allow replicas to commit without a leader or write-time consensus. The precise rule is not “apply every operation in arbitrary order.” Causal predecessors must be available or applied in the order required by the CRDT, while operations that are genuinely concurrent must have merge semantics that commute or otherwise converge deterministically.
+Swarmbase does not implement its own CRDT. It adapts existing, well-tested CRDT libraries — Yjs and Automerge — wrapping them with encryption, signing, access control, and peer-to-peer transport. The application interacts with Yjs shared types or Automerge documents directly. Swarmbase handles everything else.
 
-If compatible replicas receive the same complete set of committed changes, the adapter is intended to produce convergent state. That says nothing about when all replicas have received those changes or whether the result matches user intent.
+The goal: merge edits from multiple peers without a central consensus service, a lock manager, or a leader election protocol. No server assigns a global write order. Two peers editing concurrently produce a deterministic merged result.
 
 ## Implemented model
 
-A successful `document.change()` produces one committed CRDT change. A transaction can combine multiple application or UI edits into one committed change. Swarmbase stores the change as an encrypted CID-addressed block and carries a signed-when-enabled, encrypted shadow sync graph that may include payloads inline or defer them by CID.
+### The `document.change()` lifecycle
 
-`CRDTProvider` supplies `localChange`, `remoteChange`, and `getHistory`, plus optional snapshot operations. `getHistory` is an adapter API; current document loading uses the document-load or snapshot-load protocols and the retained sync tree, not `getHistory` as its network load mechanism.
+```ts
+const todos = swarm.doc('/todo-list');
+await todos.open();
 
-Yjs and Automerge choose their own semantics for maps, sequences, deletion, metadata, and history. Swarmbase does not impose a universal last-writer-wins rule, universal tombstones, or one conflict model across adapters. Model application invariants explicitly and inspect each adapter's behavior.
+await todos.change((state) => {
+  state.getArray<string>('items').push(['buy milk']);
+});
+```
+
+Each `document.change()` call produces one committed, encrypted, CID-addressed block:
+
+```
+Application calls document.change(fn)
+  │
+  ▼
+fn applied to local CRDT replica (Yjs doc.transact / Automerge doc.change)
+  │
+  ▼
+CRDT update serialized
+  │
+  ▼
+Wrapped in CRDTChangeBlock
+  ├── parent: CID of previous tip
+  ├── epoch: current document epoch
+  ├── signature: ECDSA P-384 over block payload
+  └── payload: encrypted CRDT update (AES-GCM)
+  │
+  ▼
+Block stored in Helia blockstore (local IndexedDB)
+  │
+  ▼
+CID published to GossipSub (document topic)
+```
+
+### The shadow sync graph
+
+Swarmbase does not use a conventional Merkle-DAG. Instead, each `CRDTChangeBlock` references its parent by CID, forming a **shadow sync graph**:
+
+```
+Tip (latest) ─── Block C ─── Block B ─── Block A (genesis)
+                            └── Block B' (concurrent edit from another peer)
+
+The CRDT layer merges B and B' when both arrive.
+The shadow graph preserves the DAG structure for sync,
+but the CRDT layer produces the resolved document state.
+```
+
+This means:
+
+- Blocks reference their immediate parent(s) by CID — forming a DAG across concurrent writers
+- The CRDT layer resolves concurrent edits (e.g., Yjs merges Y.Map updates from two peers)
+- Blocks are immutable once stored; the tip pointer advances to the latest block
+- The shadow graph is used for sync (walk backward to find missing blocks), not for data modeling
+
+### `CRDTProvider` interface
+
+The `CRDTProvider` interface abstracts the CRDT library from Swarmbase's core:
+
+```ts
+interface CRDTProvider {
+  createDoc(): CRDTDoc;
+  applyUpdate(doc: CRDTDoc, update: Uint8Array): void;
+  encodeStateAsUpdate(doc: CRDTDoc): Uint8Array;
+  encodeStateVector(doc: CRDTDoc): Uint8Array;
+  diffUpdate(doc: CRDTDoc, stateVector: Uint8Array): Uint8Array;
+}
+```
+
+Two implementations exist:
+
+- **YjsProvider** — wraps Yjs `Doc`, `Y.encodeStateAsUpdate`, `Y.applyUpdate`, `Y.encodeStateVector`, `Y.diffUpdate`
+- **AutomergeProvider** — wraps Automerge `Doc`, `Automerge.save`, `Automerge.loadIncremental`, `Automerge.getLastLocalChange`
+
+### Yjs semantics
+
+Yjs provides shared types that merge deterministically:
+
+```ts
+// Y.Map: last-writer-wins per key
+const ymap = state.getMap('settings');
+ymap.set('theme', 'dark');
+
+// Y.Array: concurrent insertions preserved
+const yarray = state.getArray('items');
+yarray.insert(0, ['first']);
+
+// Y.Text: concurrent character insertions merged
+const ytext = state.getText('content');
+ytext.insert(0, 'Hello');
+```
+
+See the [Yjs schema design cookbook](../../cookbook/yjs-schema-design/) for merge behavior tables, ID patterns, and migration strategies.
+
+### Automerge semantics
+
+Automerge provides a JSON-like CRDT document model:
+
+```ts
+// Automerge: concurrent field updates merged
+state.title = 'New title';
+
+// Automerge: concurrent list insertions preserved
+state.items.push({ text: 'buy milk', done: false });
+
+// Automerge: Text type for rich text
+state.content = new Automerge.Text('Hello');
+```
 
 ## Convergence boundaries
 
-CRDT convergence does not provide:
+Swarmbase does **not** provide:
 
-- agreement-right-now or a global order of all writes;
-- conflict-free human meaning;
-- protection from a malicious authorized writer;
-- delivery, retention, onboarding, or key recovery;
-- proof that the complete Swarmbase system converges after every partition and rejoin.
-
-The network and storage layers must still deliver every required change and causal predecessor. Missing blocks, pruned history, failed publication, unavailable peers, incompatible keys, or authorization failures can prevent convergence.
+- **Agreement-right-now.** Two peers editing concurrently will see different states until they exchange updates. There is no real-time synchronization lock.
+- **Conflict-free in the database sense.** CRDTs resolve structural conflicts (concurrent edits to the same field), but application-level conflicts (e.g., two peers setting a title to different values) are handled by the CRDT's merge rule, not by application logic.
+- **Guaranteed delivery.** Updates are published via GossipSub but not acknowledged. A peer that goes offline before publishing may lose updates.
+- **Convergence under partition.** If a peer is partitioned for a long time, its replica diverges. When the partition heals, the CRDT merges. But if the local blocks are lost (e.g., IndexedDB cleared), convergence may fail.
 
 ## Snapshots and compaction
 
-Automatic compaction is **off by default**. When enabled, an authorized writer can create a signed full-state snapshot, retain post-snapshot changes, prune older document nodes from the in-memory sync tree, and optionally garbage-collect pruned blocks. Block GC is separately off by default.
+### Snapshots
 
-Concurrent writers can snapshot different local states. Swarmbase's deterministic preference rule chooses snapshot metadata by compacted-change count and then boundary CID; preference does not prove that competing snapshots are semantically equivalent. A snapshot is verified under a current writer key when signing is enabled.
+Snapshots are **off by default**. A writer can create a signed, full-state snapshot:
 
-Default initial loading also requires tip-hash agreement from multiple peers. A first-time quorum load may not yet have a trusted writer ACL, so it can reject a snapshot whose writer cannot be verified. If pre-snapshot changes were pruned or garbage-collected, the retained tail may be insufficient to reconstruct the state. Different served frontiers or unavailable graph data can also make the load fail closed even when an existing replica remains usable. Operators must treat snapshots, retained blocks, quorum configuration, ACL bootstrap, and reachability as one availability problem.
+```ts
+await document.compact();
+```
 
-Compaction can reduce what a load response replays, but it does not establish bounded storage, memory, load time, or sync time. Adapter-internal state and retained blocks may continue to grow.
+A snapshot contains the complete CRDT state at that point, signed and encrypted like any other block. Peers loading the document can start from the snapshot instead of replaying the entire change history.
+
+### Compaction
+
+Compaction is **off by default** and uses a preference rule based on compacted-change count. When enabled, it can reduce storage by pruning older blocks. However:
+
+- Pruning removes in-memory CRDT nodes — the document cannot be reconstructed if all pruned blocks are lost
+- Snapshot-only bootstrap can fail if snapshots reference pruned blocks
+- Snapshot creation is not automatic — the application must trigger it
+
+## Quorum loading
+
+Before trusting a document's state, Swarmbase can require K-of-Q bootstrap peers to agree on the current tip hash:
+
+```ts
+const document = await swarm.loadDocument('/shared-note', {
+  quorum: { k: 2, peers: [bootstrap1, bootstrap2, bootstrap3] },
+});
+```
+
+This prevents loading a fork or a stale version when multiple peers have written to the document. The quorum check is **not** Sybil-resistant — a peer that controls multiple identities can subvert it.
 
 ## CI-backed evidence
 
-Current CI has broad Yjs and Automerge adapter tests plus snapshot, compaction, serialization, cross-link, quorum, and block-GC suites. This verifies components and selected interactions. The repository also contains convergence benchmarks, but they are not assertion-based CI budgets. Long-running concurrent compaction, large histories, hostile graph shapes, and deterministic system partition/rejoin remain unproven. See [Limitations](../limitations/).
+Verified end-to-end in CI:
+
+- Document creation, mutation, and retrieval in a single browser
+- Yjs and Automerge provider initialization
+- Encrypted block storage and retrieval through Circuit Relay
+- Cross-NAT document retrieval with Docker-backed topologies
+
+Not verified:
+
+- Multi-peer concurrent editing and convergence under partition
+- Snapshot creation and bootstrap from snapshot
+- Quorum loading with K > 1
+- Compaction and GC with subsequent recovery
+
+## Next steps
+
+- [Yjs schema design](../../cookbook/yjs-schema-design/) — patterns for modeling data with Yjs shared types
+- [Security model](../security/) — how signing, encryption, and ACL interact with the CRDT layer

--- a/site/src/content/docs/concepts/crdts.md
+++ b/site/src/content/docs/concepts/crdts.md
@@ -72,14 +72,22 @@ This means:
 The `CRDTProvider` interface abstracts the CRDT library from Swarmbase's core:
 
 ```ts
-interface CRDTProvider {
-  createDoc(): CRDTDoc;
-  applyUpdate(doc: CRDTDoc, update: Uint8Array): void;
-  encodeStateAsUpdate(doc: CRDTDoc): Uint8Array;
-  encodeStateVector(doc: CRDTDoc): Uint8Array;
-  diffUpdate(doc: CRDTDoc, stateVector: Uint8Array): Uint8Array;
+interface CRDTProvider<DocType, ChangesType, ChangeFnType> {
+  newDocument(): DocType;
+  localChange(
+    document: DocType,
+    message: string,
+    changeFn: ChangeFnType,
+  ): [DocType, ChangesType];
+  remoteChange(document: DocType, changes: ChangesType): DocType;
+  getHistory(document: DocType): ChangesType;
+  getSnapshot?(document: DocType): ChangesType;
+  applySnapshot?(document: DocType, snapshot: ChangesType): DocType;
 }
 ```
+
+Four required methods (`newDocument`, `localChange`, `remoteChange`, `getHistory`)
+and two optional snapshot methods.
 
 Two implementations exist:
 

--- a/site/src/content/docs/concepts/crdts.md
+++ b/site/src/content/docs/concepts/crdts.md
@@ -64,7 +64,8 @@ This means:
 
 - Blocks reference their immediate parent(s) by CID — forming a DAG across concurrent writers
 - The CRDT layer resolves concurrent edits (e.g., Yjs merges Y.Map updates from two peers)
-- Blocks are immutable once stored; the tip pointer advances to the latest block
+- Blocks are immutable once stored; the frontier advances as new blocks are added
+- The implementation tracks a tip-set (multiple concurrent heads), computing a combined tip-set hash
 - The shadow graph is used for sync (walk backward to find missing blocks), not for data modeling
 
 ### `CRDTProvider` interface
@@ -99,7 +100,7 @@ Two implementations exist:
 Yjs provides shared types that merge deterministically:
 
 ```ts
-// Y.Map: last-writer-wins per key
+// Y.Map: deterministic per-key conflict resolution
 const ymap = state.getMap('settings');
 ymap.set('theme', 'dark');
 
@@ -160,15 +161,7 @@ Compaction is **off by default** and uses a preference rule based on compacted-c
 
 ## Quorum loading
 
-Before trusting a document's state, Swarmbase can require K-of-Q bootstrap peers to agree on the current tip hash:
-
-```ts
-const document = await swarm.loadDocument('/shared-note', {
-  quorum: { k: 2, peers: [bootstrap1, bootstrap2, bootstrap3] },
-});
-```
-
-This prevents loading a fork or a stale version when multiple peers have written to the document. The quorum check is **not** Sybil-resistant — a peer that controls multiple identities can subvert it.
+Before trusting a document's state, Swarmbase can require Q-of-K bootstrap peers to agree on the current frontier hashes. Quorum is configured via `CollabswarmConfig` fields `loadQuorumK` and `loadQuorumQ`, then runs automatically during `document.open()`. This prevents loading a fork or a stale version when multiple peers have written to the document. The quorum check is **not** Sybil-resistant — a peer that controls multiple identities can subvert it.
 
 ## CI-backed evidence
 

--- a/site/src/content/docs/concepts/limitations.md
+++ b/site/src/content/docs/concepts/limitations.md
@@ -33,7 +33,7 @@ See the [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/fe
 
 ## Networking and availability
 
-- **Browsers require a relay.** Browser peers cannot accept incoming connections. All browser-to-browser traffic goes through a Circuit Relay.
+- **Browsers typically need a relay.** Browser peers cannot accept incoming connections directly. A Circuit Relay is needed for initial connectivity and as a fallback; direct WebRTC or WebTransport connections may be possible when NAT traversal succeeds, but this is not yet verified in CI.
 - **GossipSub is best-effort.** Message delivery is not guaranteed. Late-joining peers miss earlier announcements.
 - **Many transports are untested in CI.** WebRTC, WebTransport, and DCUtR are configuration claims without transport-specific sync tests. Only WebSocket has verified end-to-end sync.
 - **DHT and AutoNAT have no standalone CI tests.** They are included in the Docker-backed NAT topology but not stress-tested.

--- a/site/src/content/docs/concepts/limitations.md
+++ b/site/src/content/docs/concepts/limitations.md
@@ -15,7 +15,7 @@ See the [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/fe
 
 ## Offline and durability
 
-- **Offline editing requires an already-loaded replica.** A document must be opened and loaded before it can be edited offline. Fresh documents cannot be created offline — `createSwarmbaseNode` requires network access for libp2p initialization.
+- **Offline editing requires an already-loaded replica.** A document must be opened and loaded before it can be edited offline. Fresh documents cannot be created offline — `Collabswarm.initialize()` starts local Helia/libp2p services which can run without network access, but onboarding a new document (resolving its ID to a CID, loading its blocks, establishing quorum agreement) requires network connectivity.
 - **No durable outbox.** Changes are published to GossipSub and stored locally, but there is no queue with retry for unreachable peers. If a peer is offline when a change is published, it may never receive it.
 - **No delivery acknowledgment.** There is no confirmation that remote peers received, verified, or applied a change. The `document.change()` promise covers local operations only.
 - **No automatic reconnection.** If the libp2p connection drops, Swarmbase does not reconnect. The application must detect and handle reconnection.

--- a/site/src/content/docs/concepts/limitations.md
+++ b/site/src/content/docs/concepts/limitations.md
@@ -51,7 +51,7 @@ See the [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/fe
 - **PathUpdate is best-effort.** There is no guarantee that ACL change notifications reach all peers.
 - **No time-bound or conditional access.** Readers and writers are either in the ACL or not. There is no expiration, usage limit, or context-based access control.
 - **UCAN capabilities are standalone.** The UCAN module can issue and verify capability tokens, but the document change path does not check them.
-- **No key rotation.** Document keys, once created, cannot be rotated (though BeeKEM can issue new encapsulations).
+- **No automatic or restart-safe key rotation.** Document keys can be rotated on demand via `removeReader()`, which activates a new document key through BeeKEM, but rotation requires explicit application triggers, BeeKEM rekey state is memory-only, and PathUpdate delivery is best-effort.
 
 ## Convergence and verification
 

--- a/site/src/content/docs/concepts/limitations.md
+++ b/site/src/content/docs/concepts/limitations.md
@@ -1,56 +1,89 @@
 ---
 title: Limitations
-description: Current Swarmbase production, durability, networking, security, scale, and verification limits.
+description: Current alpha limitations — what is not yet implemented, verified, or production-ready in Swarmbase.
 ---
 
-Swarmbase is **alpha software**. It has no independent security audit, production SLA, durability SLA, or compatibility guarantee. Do not use it as the only copy of important data or for production workloads that require assured availability, recovery, or revocation.
+Swarmbase is alpha software. This page catalogs the known gaps between the current implementation and a production-ready system. Every limitation listed here is either not yet implemented or not yet verified in CI.
+
+See the [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md) for the evidence backing each claim, and the [roadmap](../../community/roadmap/) for current development priorities.
 
 ## Distribution and operations
 
-- Workspace packages build in the repository but are not published, and clean external-package installation is not an acceptance test.
-- Production deployment is documentation-only: there is no automated deployment, upgrade, rollback, backup, or restore validation.
-- The relay server has unit/build coverage, but operational scaling and multi-relay behavior are not proven.
+- **Packages are unpublished.** The `@swarmbase/*` packages are source workspaces, not published to npm. You must clone and build from source.
+- **No deployment automation.** There is no CI/CD pipeline for deploying relays, bootstrap nodes, or pinning services.
+- **No upgrade or migration path.** API changes between commits may break your application without warning. There is no changelog, no semver, and no deprecation period.
 
-## Local and durable operation
+## Offline and durability
 
-- Offline changes apply only to an already-loaded replica with the necessary local state and keys.
-- A change promise includes authorization, storage, optional signing, encryption, publication, handlers, and possible compaction; it is not merely an in-memory UI edit.
-- There is no durable outbox, publish acknowledgement, automatic retry, or guaranteed automatic reconnect. A direct `change()` can reject after leaving local Automerge or Yjs state modified. Transaction rollback restores immutable document references but is only best effort for in-place Yjs mutation.
-- Browser defaults use IndexedDB-backed stores, but complete document recovery after close/restart is not verified. Browsers may evict or clear storage.
-- Recovery requires discoverable CIDs/graph state, retained blocks, epoch keys, identity and KEM material, compatible configuration, and reachable peers. Loss of keys or identity may be unrecoverable.
+- **Offline editing requires an already-loaded replica.** A document must be opened and loaded before it can be edited offline. Fresh documents cannot be created offline — `createSwarmbaseNode` requires network access for libp2p initialization.
+- **No durable outbox.** Changes are published to GossipSub and stored locally, but there is no queue with retry for unreachable peers. If a peer is offline when a change is published, it may never receive it.
+- **No delivery acknowledgment.** There is no confirmation that remote peers received, verified, or applied a change. The `document.change()` promise covers local operations only.
+- **No automatic reconnection.** If the libp2p connection drops, Swarmbase does not reconnect. The application must detect and handle reconnection.
+- **No guaranteed at-least-once delivery.** GossipSub is best-effort. Messages may be dropped, delayed, or duplicated.
+- **Browser restart recovery not verified.** IndexedDB persists blocks locally, but complete browser restart → reopen → verify document state is not proven in CI.
+- **Key loss may be unrecoverable.** Signing keys, KEM keys, and document keys are application-managed. Swarmbase has no key backup, recovery, or rotation.
 
-## Storage, snapshots, and pinning
+## Storage and persistence
 
-- There is no automatic replication-factor guarantee.
-- Pinning is incomplete: `CollabswarmNode` listens for document-publish pin requests, but the core commit path does not publish them; no generic pinning service is integrated.
-- Automatic compaction is off by default. Pruning changes what a peer can serve, and optional block GC is destructive.
-- After snapshot compaction or pruning, a new replica can fail to bootstrap: it may lack the trusted writer ACL needed to accept the snapshot, retained tail changes may not reconstruct pruned state, required data may be unavailable, or default tip-hash quorum may not agree on served frontiers.
-- Concurrent snapshots can represent different local states; deterministic preference does not prove equivalence.
+- **No replication factor guarantee.** Swarmbase does not ensure blocks are stored on at least N peers. The last online peer is the last surviving copy.
+- **Pinning is incomplete.** A `CollabswarmNode` listener exists but the core commit path does not publish to it. No generic IPFS pinning client exists. See [pinning cookbook](../../cookbook/pinning/).
+- **Compaction is off by default.** Snapshots are not automatic. Compaction can prune blocks needed for recovery.
+- **Bootstrap can fail after pruning.** If all pruned blocks are needed to reconstruct a document, and they are not available from any peer, the document cannot be loaded.
+- **No garbage collection policy.** GC is manual and destructive. There is no LRU, TTL, or size-limit-based automatic cleanup.
 
 ## Networking and availability
 
-- Browser deployments generally need bootstrap/relay infrastructure. Paths may be direct or relay-mediated; DCUtR, WebRTC, STUN, TURN, and direct upgrades are topology-dependent.
-- GossipSub is best effort and does not guarantee delivery to every subscriber.
-- Bootstrap, pubsub discovery, DHT, WebRTC, relay fallback, and NAT traversal are only partially system-tested. WebSocket and WebTransport synchronization are configuration claims without transport-specific acceptance tests.
-- Connection churn, large multi-peer meshes, relay failover during edits, bootstrap replacement, and partition/rejoin remain partially or untested.
-- Relays can observe metadata and can censor, delay, or partition traffic even though they need not see plaintext.
-- Relay identity is operational state: clients pinned to an old relay peer ID may not recover after replacement. Topic allowlists/caps and relay capacity can deny service.
+- **Browsers require a relay.** Browser peers cannot accept incoming connections. All browser-to-browser traffic goes through a Circuit Relay.
+- **GossipSub is best-effort.** Message delivery is not guaranteed. Late-joining peers miss earlier announcements.
+- **Many transports are untested in CI.** WebRTC, WebTransport, and DCUtR are configuration claims without transport-specific sync tests. Only WebSocket has verified end-to-end sync.
+- **DHT and AutoNAT have no standalone CI tests.** They are included in the Docker-backed NAT topology but not stress-tested.
+- **Relays can censor or drop traffic.** There is no protection against relay-level denial of service. A malicious relay can blackhole all traffic for a peer or topic.
+- **Relay identity is not stable across restarts.** The relay generates a new libp2p peer ID on each start.
+- **No relay meshing or failover.** Each relay operates independently. If your relay goes down, peers cannot reach each other (unless they have a direct connection).
+- **No HTTP health endpoint on relay.** Load balancers and monitoring systems cannot probe relay health.
 
 ## Authorization and revocation
 
-- Application-level signing is on by default but can be disabled, removing normal sync-message authentication and binary ACL enforcement.
-- The active document path enforces reader/writer ACLs. Capability, UCAN, `UCANACL`, and ACL-chain code is standalone and not integrated end to end.
-- Every writer can administer ACLs. A valid sync signature proves only that some current writer key signed; it is not durable explicit authorship.
-- Initial-load quorum assumes enough independent reachable peer identities, is not Sybil-resistant, and trades availability for defense in depth. It covers the served frontier, not every concurrent head known anywhere.
-- BeeKEM's cryptographic core and focused Welcome/PathUpdate flows are tested, but important membership state is memory-only and PathUpdate delivery is best effort. Restart, missed update, multiwriter, and full-system revocation gaps remain.
-- Removing a writer blocks future acceptance under the current writer ACL; removing a reader attempts future key separation. Neither can erase plaintext or keys already copied, and no absolute post-revocation confidentiality guarantee is established.
-- History visibility is configured locally and cannot force other replicas to delete earlier epoch keys.
+- **Signing is currently optional.** A change without a valid writer signature may be accepted depending on configuration.
+- **Writer ACL admin is unguarded.** Any existing writer can add or remove other writers. There is no document owner concept or admin-only privilege.
+- **Quorum is not Sybil-resistant.** K-of-Q loading can be subverted by a peer controlling multiple bootstrap identities.
+- **BeeKEM rekey state is memory-only.** If the node restarts, all knowledge of key rotations is lost. Revoked readers may be able to decrypt content they previously had access to.
+- **PathUpdate is best-effort.** There is no guarantee that ACL change notifications reach all peers.
+- **No time-bound or conditional access.** Readers and writers are either in the ACL or not. There is no expiration, usage limit, or context-based access control.
+- **UCAN capabilities are standalone.** The UCAN module can issue and verify capability tokens, but the document change path does not check them.
+- **No key rotation.** Document keys, once created, cannot be rotated (though BeeKEM can issue new encapsulations).
 
 ## Convergence and verification
 
-- Adapter tests support Yjs and Automerge convergence claims at component level. Complete system partition/rejoin and live post-load cross-browser convergence are only partially covered.
-- A dedicated CI topology verifies initial encrypted Automerge document load across NAT through a relay; it does not verify every onboarding, mutation, reconnect, revocation, or recovery path.
-- Performance, crypto, sync, convergence, Bloom, and query benchmarks exist, but they have no pass/fail budgets. No bounded latency, memory, storage, load, or sync guarantee follows from them.
-- Large documents, long histories, high change rates, large groups, hostile graph shapes, prolonged churn, and production-scale swarms are unproven.
+- **System-level partition/rejoin is not proven.** Single-document convergence works, but multi-document, multi-peer partition/rejoin cycles have no CI coverage.
+- **No pass/fail performance budgets.** Benchmark suites exist but have no thresholds. A regression that doubles latency would not be caught in CI.
+- **Benchmark runner is broken.** Module resolution errors prevent benchmarks from running. See [roadmap](../../community/roadmap/).
+- **Cross-CRDT convergence is not tested.** A Yjs document and an Automerge document being edited by different peers in the same application has no CI coverage.
 
-Use a conventional transactional or managed database when you require linearizable state, central control, audited deletion, assured disaster recovery, high throughput, or an SLA. The other concept pages explain the narrower implemented behavior: [Local-first](../local-first/), [CRDTs](../crdts/), [Networking](../networking/), [Storage](../storage/), and [Security](../security/).
+## Examples and documentation
+
+- **Examples are startup smoke only.** The three example applications (browser-test, wiki-swarm, password-manager) verify single-browser startup. None demonstrate multi-peer collaboration end-to-end.
+- **Cookbook snippets are not validated.** Code examples in documentation may drift from the actual API. There is no CI check that documentation code blocks compile against the current source.
+- **No migration guide.** There is no guide for upgrading from one Swarmbase commit to another.
+- **No changelog.** Release notes and version history are not published.
+
+## What is verified
+
+Despite these limitations, several critical paths are verified end-to-end in CI:
+
+- Encrypted document creation, mutation, and retrieval (single browser)
+- Cross-NAT document retrieval through Circuit Relay (Docker-backed)
+- Document signing and signature verification
+- AES-GCM encryption and decryption
+- Reader/writer ACL enforcement
+- Libp2p peer discovery (bootstrap connection)
+- GossipSub message delivery (NAT topology)
+
+Every claim on this site should be understood against this evidence baseline. A positive unit test does not establish complete multi-peer behavior.
+
+## Next steps
+
+- [Roadmap](../../community/roadmap/) — current development priorities
+- [Help wanted](../../community/help-wanted/) — specific contribution opportunities
+- [Feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md) — capability-to-evidence map
+- [FAQ](../../community/faq/) — answers to common questions

--- a/site/src/content/docs/concepts/local-first.md
+++ b/site/src/content/docs/concepts/local-first.md
@@ -1,41 +1,113 @@
 ---
-title: Why local-first
-description: Swarmbase's local-first design intent, current offline behavior, and verified limits.
+title: Local-first design
+description: What "local-first" means in Swarmbase, what is implemented today, and where the boundaries are.
 ---
-
-Swarmbase is an alpha, local-first, end-to-end-encrypted document database for browsers. “Local-first” describes the architecture it aims for; it is not a promise that every workflow works without a network or survives every restart.
 
 ## Design intent
 
-A local-first application keeps an editable replica near the user instead of treating the browser as a temporary view of a server database. Reads and changes should be responsive, replicas should synchronize when paths exist, and no coordinator should order every write.
+A local-first application stores its primary data on the user's device — not on a remote server. Changes apply to the local replica immediately, with zero network latency. The network is used to sync state between peers, not to enforce a global write order.
 
-Swarmbase uses [CRDT adapters](../crdts/) to merge committed changes, [libp2p](../networking/) to exchange them, and [CID-addressed encrypted blocks](../storage/) to retain them. This favors collaboration and intermittent connectivity over linearizable, globally current state.
+Swarmbase adopts these local-first principles:
 
-## Implemented and default behavior
+- **Local replica near the user.** The application reads and writes a local CRDT document. There is no server round-trip for reads or writes.
+- **Work offline.** Once a document is loaded, the local replica can be edited without network access. Changes are applied immediately to the CRDT and queued for peers.
+- **No server-ordained write ordering.** Two peers can edit the same document concurrently. The CRDT layer merges their changes when they eventually exchange updates.
 
-An already-loaded replica can be read and changed without a working peer connection. A committed `change()` or transaction updates the local CRDT, but its returned promise also covers authorization, block storage, signing when enabled, encryption, publication, handlers, and possible compaction. A direct `change()` mutates or replaces the local document before that later work and has no rollback path, so rejection can leave the local mutation for both Automerge and Yjs. Transaction rollback restores a saved document reference for immutable providers such as Automerge, but remains best effort for in-place Yjs state.
+## What is implemented today
 
-There is no durable outbox, delivery acknowledgement, or retry queue for unpublished changes. A later peer connection does not by itself guarantee that every missed publication is replayed, and Swarmbase does not promise automatic reconnection. Applications must expose failures and design explicit recovery or resynchronization.
+### Offline editing (loaded replicas only)
 
-A network is normally required to:
+A Swarmbase document that has already been loaded can be edited offline. The `document.change()` call applies the mutation to the local Yjs or Automerge replica immediately and returns a promise that covers signing, encryption, storage to the local Helia blockstore, and publication to connected peers.
 
-- onboard a new reader and deliver identity/KEM material and a Welcome;
-- load a replica that is not already available locally;
-- recover missing blocks, keys, graph state, or identity material;
-- synchronize with collaborators.
+```ts
+await todos.change((state) => {
+  state.getArray<string>('items').push(['buy milk']);
+});
+```
 
-Browser defaults use IndexedDB-backed Helia stores, but complete close/restart recovery from persisted document state is not verified. Persistence is therefore partial, not a durable offline guarantee.
+If no peers are connected, the encrypted block is still stored locally in IndexedDB. When peers reconnect, they will discover and fetch the new blocks.
 
-Concurrent changes are interpreted by the selected CRDT. Causal predecessors must be applied appropriately; concurrent operations use the adapter's merge semantics. This supports convergence when replicas eventually receive compatible changes, but it does not guarantee preservation of human intent, absence of semantic conflicts, or absence of data loss elsewhere in the system.
+### What `change()` covers
 
-## Infrastructure boundary
+The `document.change()` promise resolves when:
 
-“Local-first” does not mean “infrastructure-free.” A browser deployment commonly needs reachable bootstrap and Circuit Relay infrastructure, may need STUN or TURN for WebRTC connectivity, and remains vulnerable to relay outage or censorship. Durable retention is a separate integration: relays forward traffic but do not provide a storage or pinning guarantee. See [Networking](../networking/) and [Storage](../storage/).
+1. The CRDT provider has applied the mutation to the local replica
+2. The update has been serialized into a `CRDTChangeBlock`
+3. The block has been signed with the writer's ECDSA P-384 key
+4. The signed block has been encrypted with the document's AES-GCM key
+5. The encrypted block has been stored in the local Helia blockstore
+6. The CID has been published to connected peers via GossipSub
+
+If storage or publication fails (e.g., IndexedDB quota exceeded, network error), the CRDT mutation **may already be applied**. The CRDT state reflects the mutation even if the remote sync path failed. There is no automatic rollback.
+
+## What is not yet implemented
+
+### No durable outbox
+
+If a peer is unreachable when `change()` publishes to GossipSub, the update may not reach them. Swarmbase does not persist a queue of outgoing changes to retry later. There is no delivery acknowledgment or guaranteed-at-least-once semantics.
+
+### No delivery acknowledgment
+
+When a change is published, there is no confirmation that remote peers received, verified, or applied it. The application must implement its own acknowledgment protocol if it needs delivery guarantees.
+
+### No automatic reconnection
+
+If the libp2p connection drops, Swarmbase does not automatically reconnect. The application must detect disconnection and reinitialize the transport. See the [networking page](../networking/) for transport details.
+
+### No close/restart recovery verified in CI
+
+Documents store encrypted blocks in browser IndexedDB via Helia's blockstore. Local persistence works in single-session tests, but complete browser close → reopen → verify document state has not been proven in CI. See the [roadmap](../../community/roadmap/) for current status.
+
+### Automerge/Yjs mutation persistence on rejection
+
+If part of the `change()` pipeline fails (e.g., storage quota exceeded), the CRDT mutation may already be applied to the local replica. The mutation persists locally even though the remote sync failed. There is no automatic undo or rollback of the CRDT state.
+
+## The infrastructure boundary
+
+"Local-first" does not mean "infrastructure-free." Browser peers cannot listen for incoming connections and cannot participate in a DHT without a bootstrap node. Most Swarmbase deployments need:
+
+- **Relay nodes** to bridge NAT for browser peers
+- **Bootstrap nodes** as well-known entry points for the libp2p network
+- **STUN/TURN servers** for WebRTC hole-punching (optional, for direct peer connections)
+
+These infrastructure components carry **encrypted traffic only** — they never see document plaintext. But they are necessary for peers to discover and reach each other.
+
+See [running a relay](../../cookbook/running-a-relay/) for the development relay setup.
+
+## What local-first Swarmbase is a good fit for
+
+Swarmbase's local-first model works well for:
+
+- **Small collaborative documents** (todos, notes, wikis, password vaults) where the document fits in a single CRDT replica
+- **Applications that own identity and recovery** — Swarmbase does not provide authentication or key recovery
+- **Deployments where you control the relay infrastructure** — there is no cloud service to delegate to
+- **Experiments and prototypes** learning about local-first architecture
+
+It is not a good fit for:
+
+- Large datasets (hundreds of megabytes per document)
+- Applications that need SQL or relational queries
+- Production systems requiring guaranteed delivery and durability
+- Applications expecting a managed backend service
 
 ## CI-backed evidence
 
-Current CI verifies the Yjs and Automerge adapters in isolation and exercises a real encrypted Automerge document load across a relay-backed NAT topology. Create/open/change/close/sync, IndexedDB-backed browser storage, persistence across restart, and system partition/rejoin are only partially covered. Live post-load cross-browser mutation, real reconnect behavior, and durable recovery are not default acceptance guarantees.
+These behaviors are verified by CI:
 
-## Fit
+- Document creation, local mutation, and retrieval in a single browser session
+- Encrypted block storage and retrieval through a Circuit Relay
+- Automerge and Yjs provider initialization and basic operation
+- Crypto operations (signing, encryption, key generation)
 
-Swarmbase may fit small collaborative documents where temporary divergence is acceptable and the application can own identity, recovery, infrastructure, and operational failure handling. Do not use it as a payment, inventory, reservation, high-throughput system of record, or as the sole copy of important data. Read [Limitations](../limitations/) before adopting it.
+These behaviors are **not** verified:
+
+- Browser restart and document recovery
+- Multi-session persistence across browser closes
+- Offline editing with later reconnection
+- Automatic reconnection after transport failure
+
+## Next steps
+
+- [Architecture](../architecture/) — data flow and system structure
+- [CRDT model](../crdts/) — how Yjs and Automerge integrate
+- [Limitations](../limitations/) — complete list of current gaps

--- a/site/src/content/docs/concepts/local-first.md
+++ b/site/src/content/docs/concepts/local-first.md
@@ -10,8 +10,9 @@ A local-first application stores its primary data on the user's device — not o
 Swarmbase adopts these local-first principles:
 
 - **Local replica near the user.** The application reads and writes a local CRDT document. There is no server round-trip for reads or writes.
-- **Work offline.** Once a document is loaded, the local replica can be edited without network access. Changes are applied immediately to the CRDT and queued for peers.
+- **Work offline.** Once a document is loaded, the local replica can be edited without network access. Changes are applied immediately to the CRDT and stored locally in IndexedDB.
 - **No server-ordained write ordering.** Two peers can edit the same document concurrently. The CRDT layer merges their changes when they eventually exchange updates.
+- **Eventually consistent.** When peers reconnect, they may discover and fetch blocks that were created during the offline period. Delivery is not guaranteed — see limitations below.
 
 ## What is implemented today
 

--- a/site/src/content/docs/concepts/networking.md
+++ b/site/src/content/docs/concepts/networking.md
@@ -1,54 +1,163 @@
 ---
 title: Networking
-description: Swarmbase transports, discovery, synchronization paths, relay trust, and current network evidence.
+description: Peer discovery, transport protocols, NAT traversal, and the relay trust model in Swarmbase.
 ---
 
-Swarmbase uses Helia/libp2p for peer connectivity and document synchronization. Browser-to-browser traffic may be direct or relay-mediated; neither path is guaranteed.
+## Overview
 
-## Design intent
+Swarmbase uses **libp2p** for all peer-to-peer networking. libp2p is a modular networking stack that handles transport, stream multiplexing, connection encryption, peer discovery, NAT traversal, and pubsub messaging — all in one framework.
 
-The network should discover collaborators, deliver encrypted live changes, and let a joining or stale replica request retained state without requiring an application data server. Relays and unknown peers may forward ciphertext without receiving document plaintext.
+## Transport protocols
 
-## Implemented and default behavior
+Swarmbase supports these transport protocols. The actual set used depends on the runtime (browser vs. Node.js) and network topology:
 
-The browser configuration includes:
+| Transport | Runtime | Purpose |
+|---|---|---|
+| **WebSocket** | Browser, Node.js | Reliable bidirectional stream. Used for relay and bootstrap connections. |
+| **WebRTC** | Browser | Browser-to-browser direct connections (requires STUN/TURN). |
+| **WebRTC Direct** | Node.js | Node-to-Node direct connections. |
+| **WebTransport** | Browser (Chrome 97+) | Modern, low-latency QUIC-based transport. |
+| **TCP** | Node.js | Traditional stream transport for Node.js peers. |
 
-- **WebSockets** for dialable endpoints such as bootstrap or relay nodes;
-- **WebRTC** and **WebRTC Direct** for browser-capable direct paths;
-- **WebTransport** where the runtime and remote endpoint support it;
-- **Circuit Relay v2** for relay-mediated connections;
-- **GossipSub** for live document messages and pubsub peer discovery;
-- bootstrap discovery, AutoNAT, DCUtR, and a client-mode Kademlia DHT.
+### Transport selection
 
-Configuration is not proof of end-to-end operation. Bootstrap, pubsub discovery, and DHT behavior have partial integration evidence; WebSockets and WebTransport do not have transport-specific synchronization acceptance tests.
+```ts
+import { createSwarmbaseNode } from '@swarmbase/collabswarm';
 
-Each open document subscribes to a namespaced topic. A local commit publishes an encrypted sync message containing a signed shadow graph when application signing is enabled. GossipSub is best effort: publish success does not acknowledge every collaborator, and there is no guarantee that every subscriber receives every message.
+const swarm = await createSwarmbaseNode({
+  // ...
+  libp2p: {
+    transports: ['websocket', 'webtransport', 'webrtc'],
+    relay: '/dns4/relay.example.com/tcp/443/wss/p2p/12D3KooW...',
+  },
+});
+```
 
-Initial or catch-up loading uses point-to-point protocols. A responder serves its retained sync tree or a snapshot plus retained changes. It does not necessarily serve every head or every block the peer has ever observed. Missing deferred payloads are fetched by CID when reachable.
+In practice, browser peers typically use WebSocket to reach a relay, and may upgrade to WebRTC or WebTransport for direct peer connections when NAT traversal succeeds.
 
-## NAT traversal and infrastructure
+## PubSub: GossipSub
 
-Browsers cannot accept ordinary inbound sockets, and WebRTC negotiation still needs a signaling path. Bootstrap/relay infrastructure is therefore normally required for onboarding and connectivity. DCUtR, ICE, and STUN may upgrade a relayed path to direct WebRTC, but success depends on browsers, NATs, firewalls, and topology.
+Document updates are announced and delivered via **GossipSub** — a pubsub protocol built on libp2p. Each document has a corresponding pubsub topic derived from its document ID:
 
-Circuit Relay is a fallback, not proof that TURN is never needed. The ICE configuration supports STUN and TURN entries, and restrictive deployments may require TURN or other operator-controlled connectivity. The defaults use public STUN services; those operators learn the peer's public IP/port mapping and associated network metadata.
+```ts
+// Document /todo-list → topic: swarmbase-doc-<hash>
+// Changes published to this topic reach all subscribed peers.
+```
 
-No automatic reconnect or replay guarantee is documented. Applications must handle connection churn, failed loads, and failed publications.
+GossipSub is **best-effort**:
 
-## Relay trust and operations
+- Messages are relayed through the mesh, not stored
+- Peers that join late may miss announcements
+- There is no message persistence, acknowledgment, or guaranteed delivery
+- Initial load and catch-up use point-to-point bitswap / HTTP fetch, not GossipSub
 
-Document payloads and stored change blocks are encrypted before untrusted infrastructure handles them. With application signing enabled, peers also reject sync messages that do not verify under a current writer key. Application signing is on by default but can be disabled, which removes those application-layer authentication and authorization checks.
+## Peer discovery
 
-A relay still can:
+Swarmbase peers find each other through several mechanisms:
 
-- observe peer IDs, IP addresses, topic names, timing, sizes, and key-rotation metadata;
-- delay, drop, reorder, or selectively forward traffic;
-- censor a document or partition peers;
-- become a capacity or availability bottleneck.
+### Bootstrap nodes
 
-The shipped relay has topic-policy controls and tests, but relay scaling, in-flight failover, replacement after identity changes, bootstrap replacement, and multi-relay behavior are not default guarantees. Clients configured with a relay's peer ID can remain pinned to that identity after restart. Topic caps or allowlists can also deny service to additional documents.
+A static list of well-known peers that new nodes connect to first:
 
-Relays do not provide durable storage. Integrate retention separately; see [Storage](../storage/).
+```ts
+bootstrap: [
+  '/dns4/bootstrap.swarmbase.dev/tcp/443/wss/p2p/12D3KooW...',
+  '/ip4/192.168.1.100/tcp/4002/p2p/12D3KooW...',
+]
+```
+
+Bootstrap nodes introduce the new peer to the network. They do not store or relay document data.
+
+### Kademlia DHT
+
+Once connected, nodes participate in a distributed hash table (Kademlia) for peer and content routing. The DHT maps peer IDs to multiaddrs and CIDs to providers.
+
+### AutoNAT
+
+AutoNAT determines whether a peer is reachable from the public internet. If a peer is behind NAT, it cannot accept incoming connections and must use a relay.
+
+## NAT traversal
+
+Browsers and most home/office networks are behind NAT, which prevents direct incoming connections. Swarmbase uses several mechanisms to work around this:
+
+### Circuit Relay v2
+
+A relay node bridges traffic between two peers behind NAT:
+
+```
+Peer A (browser, NAT) ──WebSocket── Relay ──WebSocket── Peer B (browser, NAT)
+                    encrypted traffic only          encrypted traffic only
+```
+
+The relay forwards encrypted packets. It sees metadata (peer IDs, timing, data volume) but cannot decrypt document content.
+
+### DCUtR (Direct Connection Upgrade through Relay)
+
+After an initial relayed connection, peers attempt to establish a direct WebRTC connection using DCUtR. The relay facilitates the hole-punching handshake; if successful, peers communicate directly, reducing relay load and latency.
+
+### STUN / TURN
+
+- **STUN** servers help peers discover their public IP and port for WebRTC hole-punching.
+- **TURN** servers relay media when direct WebRTC connections are impossible (e.g., symmetric NAT). TURN is more expensive than Circuit Relay but handles a broader range of NAT types.
+
+## Relay trust model
+
+Relays are the most important infrastructure component in a Swarmbase deployment, and their trust properties matter:
+
+**What relays can see:**
+- Peer IDs and multiaddrs of connecting peers
+- Connection timing and duration
+- Data volume and message frequency
+- PubSub topic IDs (derived from document IDs)
+
+**What relays cannot see:**
+- Document content (encrypted with AES-GCM)
+- Signing keys or document keys
+- ACL entries or identity information (embedded in encrypted blocks)
+
+**What relays can do:**
+- Drop, delay, or reorder messages
+- Censor specific peers or topics
+- Log metadata about who communicates with whom
+- Impersonate a peer at the libp2p level (but cannot forge signatures or decrypt content)
+
+**What relays cannot do:**
+- Decrypt document content without the document key
+- Forge signatures without the signing private key
+- Modify encrypted blocks (detected via CID integrity check)
+
+### Identity pinning risk
+
+A relay could present a different peer ID after a restart. If your application pins to a specific relay peer ID, verify it on each connection. Consider using DNS (`/dns4/...`) rather than raw multiaddrs to allow relay addresses to change.
+
+## Operational limits
+
+- **Relay restart changes peer ID.** The current relay implementation generates a new libp2p identity on each restart. Clients must rediscover the new peer ID.
+- **No relay meshing.** Each relay operates independently. There is no relay-to-relay routing.
+- **Topic allowlists are not authentication.** The relay's `TOPIC_ALLOWLIST` controls which topics it will forward, but does not authenticate publishers.
+- **No HTTP health endpoint.** The relay exposes no health-check endpoint for load balancers or monitoring.
+- **No durable storage on relay.** The relay does not store messages. If a subscriber is offline, it misses messages.
 
 ## CI-backed evidence
 
-Current CI builds the relay in Docker-backed topologies and exercises it in integration, NAT-traversal, and cross-NAT jobs. Relay unit tests exist in the repository but are not part of the CI matrix. Peer discovery, GossipSub, WebRTC, Circuit Relay, DCUtR/STUN/TURN configuration, bootstrap, and DHT are partial. A dedicated clean-topology test verifies initial encrypted Automerge document load across NAT through a relay. Live post-load pubsub convergence, partition/rejoin, relay failover during edits, TURN-authenticated behavior, transport-specific WebSocket/WebTransport sync, and larger multi-peer churn are not established. See [Limitations](../limitations/).
+Verified in CI:
+
+- WebSocket transport through Circuit Relay in Docker-backed NAT tests
+- Cross-NAT encrypted document retrieval (real Swarmbase nodes behind NAT)
+- Basic peer discovery (bootstrap connection) in integration tests
+- GossipSub message delivery in NAT topology
+
+Not verified:
+
+- WebRTC direct connection upgrade (DCUtR)
+- WebTransport transport
+- Relay failover (kill one relay, verify peers reconnect through another)
+- Live post-load convergence under network partition
+- AutoNAT detection and relay fallback
+- DHT content/provider routing at scale
+
+## Next steps
+
+- [Running a relay](../../cookbook/running-a-relay/) — set up a development relay
+- [Security model](../security/) — how the trust model interacts with encryption and ACL
+- [Limitations](../limitations/) — complete list of networking gaps

--- a/site/src/content/docs/concepts/networking.md
+++ b/site/src/content/docs/concepts/networking.md
@@ -22,15 +22,15 @@ Swarmbase supports these transport protocols. The actual set used depends on the
 ### Transport selection
 
 ```ts
-import { createSwarmbaseNode } from '@swarmbase/collabswarm';
+import { defaultConfig, defaultBootstrapConfig } from '@swarmbase/collabswarm';
 
-const swarm = await createSwarmbaseNode({
-  // ...
-  libp2p: {
-    transports: ['websocket', 'webtransport', 'webrtc'],
-    relay: '/dns4/relay.example.com/tcp/443/wss/p2p/12D3KooW...',
-  },
-});
+const bootstrapPeers = [
+  '/dns4/relay.example.com/tcp/443/wss/p2p/12D3KooW...',
+];
+const config = defaultConfig(defaultBootstrapConfig(bootstrapPeers));
+
+// Pass config to Collabswarm.initialize()
+await swarm.initialize(config);
 ```
 
 In practice, browser peers typically use WebSocket to reach a relay, and may upgrade to WebRTC or WebTransport for direct peer connections when NAT traversal succeeds.

--- a/site/src/content/docs/concepts/networking.md
+++ b/site/src/content/docs/concepts/networking.md
@@ -14,7 +14,7 @@ Swarmbase supports these transport protocols. The actual set used depends on the
 | Transport | Runtime | Purpose |
 |---|---|---|
 | **WebSocket** | Browser, Node.js | Reliable bidirectional stream. Used for relay and bootstrap connections. |
-| **WebRTC** | Browser | Browser-to-browser direct connections (requires STUN/TURN). |
+| **WebRTC** | Browser | Browser-to-browser direct connections (STUN improves NAT traversal; TURN or Circuit Relay may be needed for restrictive NATs). |
 | **WebRTC Direct** | Node.js | Node-to-Node direct connections. |
 | **WebTransport** | Browser (Chrome 97+) | Modern, low-latency QUIC-based transport. |
 | **TCP** | Node.js | Traditional stream transport for Node.js peers. |
@@ -117,18 +117,19 @@ Relays are the most important infrastructure component in a Swarmbase deployment
 
 **What relays can do:**
 - Drop, delay, or reorder messages
+- Terminate transport connections and forward relayed traffic
 - Censor specific peers or topics
 - Log metadata about who communicates with whom
-- Impersonate a peer at the libp2p level (but cannot forge signatures or decrypt content)
 
 **What relays cannot do:**
 - Decrypt document content without the document key
-- Forge signatures without the signing private key
+- Forge application-level signatures without the signing private key
+- Authenticate as another peer at the libp2p level (Noise provides end-to-end peer authentication)
 - Modify encrypted blocks (detected via CID integrity check)
 
 ### Identity pinning risk
 
-A relay could present a different peer ID after a restart. If your application pins to a specific relay peer ID, verify it on each connection. Consider using DNS (`/dns4/...`) rather than raw multiaddrs to allow relay addresses to change.
+A relay that restarts with a new peer ID breaks connections from clients that pinned to the old identity. Mitigation options include using a persistent relay key so the peer ID stays stable across restarts, or using authenticated discovery to learn a trusted new peer ID after the relay restarts. DNS (`/dns4/...`) changes address resolution but `/p2p/<peerID>` still pins the relay identity.
 
 ## Operational limits
 

--- a/site/src/content/docs/concepts/security.md
+++ b/site/src/content/docs/concepts/security.md
@@ -94,20 +94,24 @@ Documents are always encrypted at rest and in transit. There is no configuration
 
 ## Initial-load quorum
 
-Before trusting a document's state, Swarmbase can require **K-of-Q** bootstrap peers to agree on the current tip hash. This prevents loading a fork or a truncated history.
+Before trusting a document's state, Swarmbase can require **Q-of-K** bootstrap peers to agree on the current tip hashes. This prevents loading a fork or a truncated history. Quorum is configured via `CollabswarmConfig`:
 
 ```ts
-const document = await swarm.loadDocument('/shared-note', {
-  quorum: {
-    k: 2,  // Require 2 of 3 peers to agree
-    peers: [bootstrapPeerId1, bootstrapPeerId2, bootstrapPeerId3],
-  },
-});
+// Set loadQuorumK and loadQuorumQ when initializing:
+await swarm.initialize(defaultConfig({
+  ...defaultBootstrapConfig([]),
+  loadQuorumK: 3,  // probe up to 3 peers
+  loadQuorumQ: 2,  // require agreement from at least 2
+}));
+
+// Documents are then opened normally; quorum runs automatically:
+const document = swarm.doc('/shared-note');
+await document.open();
 ```
 
 The quorum check:
-- Queries K-of-Q peers for their current tip hash
-- Proceeds only when enough peers agree on the same tip
+- Probes up to `loadQuorumK` peers for their current frontier hashes
+- Proceeds only when at least `loadQuorumQ` peers agree on the same frontier
 - Rejects the load if agreement cannot be reached
 - Is **not Sybil-resistant** — a peer controlling multiple identities can subvert it
 

--- a/site/src/content/docs/concepts/security.md
+++ b/site/src/content/docs/concepts/security.md
@@ -81,17 +81,16 @@ const block = {
 };
 ```
 
-### Visibility settings
+### Signing configuration
 
-Swarmbase currently supports three document visibility configurations:
+Document signing is controlled by `CollabswarmConfig.enableSigning` (default: `true`):
 
-| Visibility | Effect |
+| Setting | Effect |
 |---|---|
-| **Encrypted** (default) | All blocks encrypted with document key. Only readers can decrypt. |
-| **Signed only** | Blocks signed but not encrypted. Any peer can read, but only authorized writers can publish. |
-| **Public** | Blocks neither signed nor encrypted. Any peer can read and write. |
+| **`enableSigning: true`** (default) | Changes are signed with ECDSA P-384 and encrypted with AES-GCM. Receivers verify signatures. |
+| **`enableSigning: false`** | Changes are still encrypted with AES-GCM but not signed. ACL enforcement is disabled — any peer that can connect may publish changes. |
 
-Public documents undermine Swarmbase's core value proposition and are primarily useful for testing.
+Documents are always encrypted at rest and in transit. There is no configuration toggle to disable encryption.
 
 ## Initial-load quorum
 

--- a/site/src/content/docs/concepts/security.md
+++ b/site/src/content/docs/concepts/security.md
@@ -1,52 +1,184 @@
 ---
-title: Security model
-description: Swarmbase identities, binary ACL enforcement, encryption, quorum loading, and revocation limits.
+title: Security
+description: Identity model, encryption, access control, quorum loading, and revocation in Swarmbase.
 ---
 
-Swarmbase is alpha software and has not had an independent security audit. Its cryptographic components have meaningful unit coverage, but the complete distributed security model is only partially verified.
+## Overview
+
+Swarmbase encrypts documents end-to-end and signs every change. No server — relay, bootstrap, or pinning service — ever sees document plaintext or signing keys. Access control is enforced cryptographically: a peer without the document key cannot decrypt content, and a peer without a valid writer key cannot publish changes that other peers will accept.
 
 ## Identity and trust roots
 
-The application supplies the user's signing key pair and is responsible for persisting, recovering, and binding it to a human or account. Swarmbase does not provide a certificate authority, identity directory, custody service, or account recovery. The application must also persist any KEM keys and related membership state it needs.
+Swarmbase uses two separate key systems:
 
-User signing keys are separate from libp2p peer IDs. ACLs use user public keys; peer IDs identify network participants and connections.
+| Key | Algorithm | Purpose | Managed by |
+|---|---|---|---|
+| **Signing key** | ECDSA P-384 | Signs document changes; proves authorship | Application |
+| **KEM key** | ECDH P-256 | Key encapsulation for document key sharing (BeeKEM) | Application |
+| **Document key** | AES-GCM (256-bit) | Encrypts/decrypts document content | Swarmbase (per-document) |
+| **Libp2p peer ID** | Ed25519 | Identifies the node on the libp2p network | libp2p (auto-generated) |
+
+The signing key and KEM key are **application-supplied**. Swarmbase does not generate, store, recover, or back up user keys — key management is entirely the application's responsibility.
+
+The libp2p peer ID is separate from the signing identity. This means:
+- Changing the libp2p key (e.g., relay restart) does not affect document authorship
+- The same signing identity can be used across multiple libp2p nodes
 
 ## Implemented authorization
 
-The document's active enforcement uses binary **reader** and **writer** ACLs:
+### Reader/writer ACL
 
-- writers may commit document and ACL changes;
-- readers receive or retain document encryption keys and can decrypt allowed epochs;
-- every writer can modify both ACLs, so writer access currently includes ACL administration.
+Each document has an access control list with two roles:
 
-Normal sync-message signing and verification are enabled by default but can be disabled with `enableSigning: false`. When enabled, a receiver accepts a sync signature if it verifies under **some current writer key**. The message does not durably identify which writer signed it, so this is current-writer authorization, not explicit per-change authorship or a durable audit attribution record. Disabling signing removes the normal application-layer authentication and ACL enforcement described here; libp2p's transport signing is separate.
+```ts
+// Grant read access (can decrypt document content)
+await document.addReader(peerSigningPublicKey, kemEncapsulatedKey);
 
-Capability helpers, UCAN creation/validation, `UCANACL`, and the ACL chain have standalone implementations and tests. They are not integrated into the normal document mutation, sync, and load path. Do not document or depend on field capabilities, delegated UCAN authorization, or ACL-chain trust as active end-to-end enforcement.
+// Grant write access (can publish new changes)
+await document.addWriter(peerSigningPublicKey);
+```
+
+- **Readers** receive the document key (via BeeKEM encapsulation) and can decrypt blocks.
+- **Writers** can publish new changes. Their signature is verified against the writer list before a change is applied.
+- **Signing is currently optional** — a change without a valid writer signature may be accepted depending on configuration. This is an alpha limitation, not a design choice.
+
+### Current-writer authorization only
+
+The current writer list on the document is the only authorization check. There is no:
+- Time-bound access (a writer added today can always write)
+- Role-based access beyond reader/writer
+- Delegation or sub-key authorization (UCAN capabilities exist but are not integrated)
+- Rate limiting or abuse prevention
+
+### UCAN capabilities
+
+UCAN (User Controlled Authorization Networks) helpers exist in `@swarmbase/collabswarm` as a standalone module. They are **not integrated** into the document change path. The UCAN module can:
+
+- Issue capability tokens delegating specific permissions
+- Verify capability chains
+- Encode delegation proofs
+
+But the document change path does not check UCAN tokens. UCAN integration is a future capability.
 
 ## Encryption and history visibility
 
-Change blocks and sync envelopes use document-key encryption. Possessing a document key provides cryptographic read capability, but current protocol acceptance can also depend on ACL identity, writer signatures, Welcome recipient binding, and current membership state. “Reader” is therefore not reducible to either key possession or an ACL entry alone across every workflow.
+Every document is encrypted with a unique 256-bit AES-GCM key. Blocks are encrypted before storage and decrypted only on authorized peers.
 
-History visibility is a local document setting controlling which epoch-key changes that peer sends: `current_only`, `since_invited`, or `full_history`. It is not a global policy that can erase keys another peer already retained, and peers configured differently can disclose different history.
+```ts
+// Document content is always encrypted at rest and in transit
+const block = {
+  parent: previousTipCID,
+  epoch: currentEpoch,
+  signature: await sign(signingKey, blockPayload),
+  payload: await encrypt(documentKey, serializedCRDTUpdate),
+};
+```
+
+### Visibility settings
+
+Swarmbase currently supports three document visibility configurations:
+
+| Visibility | Effect |
+|---|---|
+| **Encrypted** (default) | All blocks encrypted with document key. Only readers can decrypt. |
+| **Signed only** | Blocks signed but not encrypted. Any peer can read, but only authorized writers can publish. |
+| **Public** | Blocks neither signed nor encrypted. Any peer can read and write. |
+
+Public documents undermine Swarmbase's core value proposition and are primarily useful for testing.
 
 ## Initial-load quorum
 
-Initial loading enables a K-of-Q tip-hash gate by default. It asks multiple reachable peer identities to agree on the frontier they would serve, then binds the selected load response to that frontier. This is defense in depth against one stale or malicious responder, not consensus over the true document state.
+Before trusting a document's state, Swarmbase can require **K-of-Q** bootstrap peers to agree on the current tip hash. This prevents loading a fork or a truncated history.
 
-The gate assumes sufficiently independent, reachable voters and is not Sybil-resistant. A party controlling enough peer identities can dominate the vote. Requiring agreement also reduces availability in small swarms, partitions, or after compaction and pruning. Snapshot loading requires writer verification when signing is enabled, but a first-time loader may not yet have the trusted writer ACL needed to accept that snapshot. The quorum covers the served frontier and can omit other locally known concurrent heads.
+```ts
+const document = await swarm.loadDocument('/shared-note', {
+  quorum: {
+    k: 2,  // Require 2 of 3 peers to agree
+    peers: [bootstrapPeerId1, bootstrapPeerId2, bootstrapPeerId3],
+  },
+});
+```
+
+The quorum check:
+- Queries K-of-Q peers for their current tip hash
+- Proceeds only when enough peers agree on the same tip
+- Rejects the load if agreement cannot be reached
+- Is **not Sybil-resistant** — a peer controlling multiple identities can subvert it
 
 ## Revocation
 
-Removing a writer means future signed sync messages from that key no longer verify against the current writer ACL. It does not retract previously accepted changes or remove reader access the same identity may still hold.
+### Writer revocation
 
-Removing a reader requires both ACL change and future-key separation. Swarmbase includes a BeeKEM ratchet-tree cryptographic core, encrypted Welcomes, and a PathUpdate flow that derives a new epoch key for surviving readers. The cryptographic primitives and focused flows are tested, but the document integration keeps important BeeKEM membership mappings and tree state in memory. PathUpdate distribution is best effort, with no durable retry.
+When a writer is removed from the ACL:
+- Other peers reject future changes signed by the revoked key
+- Existing blocks from the revoked writer remain in the document — revocation is forward-looking only
+- There is no mechanism to retroactively remove a revoked writer's past contributions
 
-Restart, missed or out-of-order updates, concurrent/multiple writers, membership recovery, and complete multi-peer revocation are not solved or system-verified. A removed reader may retain old keys and plaintext, and failures can leave surviving peers on different epochs. Swarmbase therefore does not provide an absolute guarantee that revocation prevents all future decryption in the deployed system.
+```ts
+await document.removeWriter(revokedPeerSigningPublicKey);
+```
+
+### Reader revocation
+
+Reader revocation is more complex. Since readers hold the document key, simply removing them from the ACL does not prevent them from decrypting blocks they've already received.
+
+What exists:
+- **BeeKEM key separation** can generate new document keys that exclude a former member
+- **PathUpdate** is a best-effort mechanism to notify peers about ACL changes
+- Both mechanisms are **incomplete**: BeeKEM rekey state is memory-only (lost on restart), and PathUpdate has no delivery guarantee
+
+```ts
+// Be aware: BeeKEM state is memory-only
+await document.removeReader(revokedPeerSigningPublicKey);
+
+// PathUpdate is best-effort
+await document.pathUpdate(); // Notify peers of ACL change
+```
+
+### Limitations of revocation
+
+- **No absolute guarantee.** A revoked reader with a copy of the encrypted blocks and the old document key can still decrypt them offline.
+- **BeeKEM state is lost on restart.** If the node restarts, it loses track of which keys have been invalidated.
+- **PathUpdate is not guaranteed.** There is no acknowledgment or retry mechanism.
+- **Key reuse risk.** If the application reuses KEM key pairs across documents, revoking access to one document may not fully revoke it from another.
 
 ## Metadata and hostile infrastructure
 
-Relays and storage peers need not receive plaintext, but they can observe identifiers, addresses, topics, timing, sizes, and key-rotation metadata. They can censor, delay, or partition peers. Encryption and signatures do not provide availability or traffic-analysis resistance; see [Networking](../networking/).
+Relays and other infrastructure nodes can observe:
+- Peer IDs and connection patterns
+- Document topic IDs (derived from document IDs)
+- Message timing, frequency, and size
+- Network topology
+
+This metadata may reveal:
+- Which peers are collaborating on which documents
+- When collaboration is happening (message frequency)
+- The rough size of documents (encrypted block sizes)
+- The network location of peers (IP addresses, relay selection)
+
+Swarmbase does not protect against traffic analysis or metadata leakage.
 
 ## CI-backed evidence
 
-Current CI verifies WebCrypto operations, encryption tamper failure, binary ACLs in both adapters, UCAN/capability/ACL-chain components, epoch/keychain code, BeeKEM trees, Welcomes, revocation helpers, and PathUpdates. Missing system evidence includes persistent identity UX, hostile multi-peer quorum, ACL forks, revoked-peer writes, restart and missed-update recovery, and proof that removed readers cannot decrypt post-removal content. See [Limitations](../limitations/).
+Verified in CI:
+
+- ECDSA P-384 signing and verification of document changes
+- AES-GCM encryption and decryption of document blocks
+- Reader/writer ACL enforcement (writer check before accepting changes)
+- BeeKEM key encapsulation and decapsulation
+- UCAN capability issuance and verification (standalone module)
+- Encrypted document retrieval through Circuit Relay
+
+Not verified:
+
+- Reader revocation with key rotation and live peer notification
+- K-of-Q quorum loading with K > 1
+- PathUpdate delivery across NAT boundaries
+- Resistance to Sybil attacks on quorum
+- Key recovery or backup flows
+
+## Next steps
+
+- [Architecture](../architecture/) — how encryption fits into the data flow
+- [Password manager cookbook](../../cookbook/password-manager/) — key sharing and ACL management example
+- [Limitations](../limitations/) — complete security limitations

--- a/site/src/content/docs/concepts/security.md
+++ b/site/src/content/docs/concepts/security.md
@@ -31,11 +31,18 @@ The libp2p peer ID is separate from the signing identity. This means:
 Each document has an access control list with two roles:
 
 ```ts
-// Grant read access (can decrypt document content)
-await document.addReader(peerSigningPublicKey, kemEncapsulatedKey);
+// Grant read access (the second argument is the reader's raw
+// SEC1-uncompressed P-256 ECDH public key bytes, optional)
+await document.addReader(peerSigningPublicKey, readerKemPublicKeyBytes);
 
-// Grant write access (can publish new changes)
+// Grant write access
 await document.addWriter(peerSigningPublicKey);
+```
+
+Before calling `addReader`, a founder node must set its KEM key pair:
+
+```ts
+await document.setKemKeyPair(kemKeyPair);
 ```
 
 - **Readers** receive the document key (via BeeKEM encapsulation) and can decrypt blocks.
@@ -130,10 +137,8 @@ What exists:
 ```ts
 // Be aware: BeeKEM state is memory-only
 await document.removeReader(revokedPeerSigningPublicKey);
-
-// PathUpdate is best-effort
-await document.pathUpdate(); // Notify peers of ACL change
 ```
+`removeReader` generates and distributes BeeKEM PathUpdates internally as part of the operation. PathUpdate distribution is best-effort — there is no guarantee that ACL change notifications reach all peers.
 
 ### Limitations of revocation
 

--- a/site/src/content/docs/concepts/storage.md
+++ b/site/src/content/docs/concepts/storage.md
@@ -27,7 +27,7 @@ Every `CRDTChangeBlock` is stored as an opaque blob:
 └─────────────────────────────────────┘
 ```
 
-Blocks are immutable. Once stored, a block's CID is stable forever. The document's current state is the **tip** — the most recent block applied to the CRDT replica. The tip advances with each `document.change()`.
+Blocks are immutable. Once stored, a block's CID is stable forever. The document's current state is materialized by the CRDT layer from the **frontier** — the most recent block(s) at the head of the sync graph. New blocks added via `document.change()` extend the frontier, and the CRDT layer resolves any concurrent heads.
 
 ### Inline vs deferred payloads
 
@@ -78,17 +78,35 @@ See the [pinning cookbook](../../cookbook/pinning/) for the integration checklis
 
 ## Recovery requirements
 
-Recovering a document requires more than just the encrypted blocks. A peer needs:
+The components a peer needs depend on what it needs to do:
+
+### Read-only recovery
+
+A reader that only needs to reconstruct and verify existing document history requires:
 
 1. **The block data** — encrypted CRDT change blocks (from any peer or pinning service)
-2. **The graph structure** — which CIDs form the tip and its ancestor chain (from the shadow sync graph)
-3. **The document key** — AES-GCM key to decrypt blocks (held by authorized peers)
-4. **The identity key** — ECDSA P-384 signing key to prove authorship (held by each writer)
-5. **The KEM state** — BeeKEM key material for dynamic group membership (memory-only currently)
-6. **Network reachability** — connection to at least one peer or bootstrap node
-7. **K-of-Q quorum** — agreement from bootstrap peers on the current tip hash (configurable)
+2. **The graph structure** — which CIDs form the frontier and its ancestor chain (from the shadow sync graph)
+3. **The document key history** — AES-GCM keys to decrypt blocks for each epoch
+4. **The writers' public keys** — to verify signatures on existing blocks
 
-Losing any of these components may make full recovery impossible. Key management and backup are application responsibilities.
+### Write recovery
+
+To issue new changes, a peer additionally needs:
+
+5. **The identity key** — ECDSA P-384 signing key to prove authorship
+
+### Membership recovery
+
+To participate in dynamic group membership (add/remove readers), a peer additionally needs:
+
+6. **The KEM state** — BeeKEM key material (memory-only currently; determining the set of active members requires this)
+
+### Configurable prerequisites
+
+7. **Network reachability** — connection to at least one peer or bootstrap node (needed to fetch missing blocks)
+8. **Q-of-K quorum** — agreement from bootstrap peers on the current frontier hash (enabled by default but configurable via `loadQuorumK`/`loadQuorumQ`)
+
+Losing any of these components may make the corresponding recovery path impossible. Key management and backup are application responsibilities.
 
 ## Compaction and garbage collection
 

--- a/site/src/content/docs/concepts/storage.md
+++ b/site/src/content/docs/concepts/storage.md
@@ -1,50 +1,140 @@
 ---
 title: Storage
-description: Swarmbase's encrypted CID-addressed blocks, shadow sync graph, persistence, pinning, and recovery limits.
+description: How Swarmbase stores documents — local IndexedDB persistence, the Helia blockstore, pinning, recovery, and compaction.
 ---
 
-Swarmbase stores CRDT changes as encrypted, CID-addressed blocks through Helia and exchanges a separate signed-when-enabled, encrypted shadow sync graph. This is not a conventional Merkle-DAG in which each stored block commits to parent CIDs.
+## Overview
+
+Swarmbase uses **Helia** (the JavaScript IPFS implementation) for content-addressed storage. Every document block — a signed, encrypted CRDT update — is stored in a local Helia blockstore backed by IndexedDB in the browser or the filesystem in Node.js. Blocks are addressed by their **CID** (Content Identifier), a SHA-256 hash of the encrypted content.
 
 ## Implemented model
 
-For each committed document or ACL change, Swarmbase encrypts and writes the serialized change bytes to the local blockstore. The resulting CID identifies those encrypted bytes. A sync message then carries a `CRDTChangeNode` shadow graph: its root CID names the current change block, `children` describe an older retained tree and cross-links, and a node can either include its change payload inline or omit it so the receiver fetches the block by CID.
+### Content-addressed blocks
 
-Inline payloads are part of the encrypted sync envelope. Their graph entries are not necessarily the bytes stored under each referenced CID, so do not infer conventional Merkle-DAG parent commitment or complete-history proofs from the shadow structure. Sync messages are signed by a writer when application signing is enabled; CID verification protects fetched bytes from substitution, while encryption protects contents.
+Every `CRDTChangeBlock` is stored as an opaque blob:
 
-A load responder serves its retained shadow tree or a snapshot plus retained changes. It may not serve every locally known concurrent head, and `getHistory()` is not the current network load path.
+```
+┌─────────────────────────────────────┐
+│          CRDTChangeBlock             │
+├─────────────────────────────────────┤
+│  parent: CID of previous tip        │
+│  epoch:  current document epoch     │
+│  signature: ECDSA P-384             │
+│  payload: AES-GCM encrypted         │
+│    └── serialized CRDT update       │
+├─────────────────────────────────────┤
+│  CID: sha256(entire block)          │
+└─────────────────────────────────────┘
+```
+
+Blocks are immutable. Once stored, a block's CID is stable forever. The document's current state is the **tip** — the most recent block applied to the CRDT replica. The tip advances with each `document.change()`.
+
+### Inline vs deferred payloads
+
+To reduce block size and improve deduplication, Swarmbase can split payload content across referenced blocks:
+
+- **Inline**: The full encrypted update is embedded in the `CRDTChangeBlock`.
+- **Deferred**: The encrypted update is stored as a separate block referenced by CID from the `CRDTChangeBlock`. Useful when the same encrypted payload appears in multiple sync contexts.
+
+### No Merkle-DAG parent commitment
+
+Swarmbase's shadow sync graph does **not** use Merkle hash linking. Blocks reference parents by CID but do not commit to parent hashes. This means the graph structure can change after blocks are written (e.g., adding new parents during catch-up). This is intentional — it allows the sync layer to add concurrent parents discovered later without rewriting blocks.
 
 ## Browser persistence
 
-Browser defaults use IndexedDB-backed Helia blockstore and datastore instances. This verifies that bytes and metadata can use IndexedDB; it does not verify complete document, graph, key, ACL, identity, and subscription recovery after a full browser restart.
+In the browser, Helia stores blocks in **IndexedDB**:
 
-A peer can apply an inline payload without necessarily persisting every referenced block from the supplied shadow tree. Replication therefore follows observed synchronization and fetches; Swarmbase does not automatically enforce a replication factor or prove that a given number of independent peers retain every required block.
+```ts
+import { createHelia } from 'helia';
+import { createIDBBlockstore } from 'helia-blockstore-idb';
+
+const blockstore = createIDBBlockstore('/swarmbase/blocks');
+const helia = await createHelia({ blockstore });
+```
+
+Encrypted blocks, IPNS records, and the libp2p peer store are all persisted to IndexedDB under the origin. This means a browser tab refresh should preserve document state.
+
+**Current status**: Local block storage works in single-session tests. Complete restart recovery (close browser → reopen → verify document state) has **not been proven in CI**. The blockstore persists, but Helia/libp2p reinitialization and document re-opening after a browser restart are not end-to-end tested.
+
+### No automatic replication factor
+
+Swarmbase does not replicate blocks automatically. If you have 3 peers and one stores a block, the other 2 may fetch it on demand (bitswap) or may not. There is no "store on at least N peers" guarantee.
 
 ## Pinning status
 
-`CollabswarmNode` contains a listener for a document-publish topic and code to pin announced and subsequently observed CIDs. Core document commits, however, do not publish to that pin-request topic. The listener therefore has no core publisher in the current path. There is also no integrated generic IPFS pinning-service client or automatic export of every required block.
+Pinning is **incomplete**. What exists:
 
-Treat pinning as incomplete integration, not a configured durability feature. An operator must build and test the publication, traversal, authorization, retention, monitoring, and restore path. A generic service can retain supplied CIDs, but Swarmbase currently does not supply the end-to-end discovery workflow.
+- A `CollabswarmNode` listener that fires when blocks are stored locally
+- No publisher in the core commit path (the listener is never notified)
+- No generic IPFS pinning client (e.g., to pin to a remote IPFS node, S3, or Filecoin)
+
+Without pinning:
+
+- The last online peer is the last surviving copy
+- If all peers go offline and their IndexedDB is cleared, the document is lost
+- A dedicated "pinning node" (always-on peer) can serve as a poor substitute, but is not integrated
+
+See the [pinning cookbook](../../cookbook/pinning/) for the integration checklist.
 
 ## Recovery requirements
 
-A usable recovery needs more than ciphertext blocks. At minimum it may require:
+Recovering a document requires more than just the encrypted blocks. A peer needs:
 
-- the relevant root, frontier, snapshot, and change CIDs;
-- enough shadow graph or other indexing information to discover them;
-- retained blocks at reachable providers;
-- document epoch keys and the keychain state allowed by history visibility;
-- the application's signing identity and KEM state;
-- compatible CRDT, ACL, and serializer configuration;
-- network reachability and, by default, enough agreeing peers for initial-load quorum.
+1. **The block data** — encrypted CRDT change blocks (from any peer or pinning service)
+2. **The graph structure** — which CIDs form the tip and its ancestor chain (from the shadow sync graph)
+3. **The document key** — AES-GCM key to decrypt blocks (held by authorized peers)
+4. **The identity key** — ECDSA P-384 signing key to prove authorship (held by each writer)
+5. **The KEM state** — BeeKEM key material for dynamic group membership (memory-only currently)
+6. **Network reachability** — connection to at least one peer or bootstrap node
+7. **K-of-Q quorum** — agreement from bootstrap peers on the current tip hash (configurable)
 
-Loss of keys or identity can make retained blocks unreadable or make future authorized writes impossible. Content addressing is integrity and lookup machinery, not backup or key recovery.
+Losing any of these components may make full recovery impossible. Key management and backup are application responsibilities.
 
 ## Compaction and garbage collection
 
-Automatic compaction is off by default. When enabled, pruning removes older document nodes from the served in-memory tree; optional block GC can then delete pruned local bytes. GC is destructive and separately off by default. ACL nodes are preserved by the pruning logic, but that does not guarantee a complete recoverable history.
+### Compaction
 
-Snapshot bootstrap can fail after peers compact or prune. A first-time quorum load may not yet have a trusted writer ACL and can reject the snapshot during writer verification; if earlier changes were pruned or garbage-collected, the retained tail may not reconstruct that state. The needed graph or blocks may also be unavailable, and tip-hash quorum can reject incompatible served frontiers. Deterministic snapshot preference does not make differing snapshots equivalent. Test backup and restore with the same compaction, quorum, and membership settings used in deployment.
+Compaction replaces a chain of blocks with a full-state snapshot. It is **off by default**:
+
+```ts
+await document.compact();
+```
+
+When compaction runs:
+1. The current CRDT state is serialized as a full snapshot
+2. The snapshot is signed and encrypted like any other block
+3. Older blocks in the chain may be pruned (removed from the local blockstore)
+
+Compaction reduces storage and load time (starting from a snapshot instead of replaying all history), but:
+- Pruned blocks cannot be recovered
+- Peers that only have pruned blocks cannot reconstruct the document
+- Snapshot-only bootstrap can fail if snapshots reference pruned data
+
+### Garbage collection
+
+GC removes blocks that are no longer referenced by any document. It is **destructive**:
+- Pruned blocks are deleted from IndexedDB
+- Recovery from GC is impossible — the data is gone
+- GC is not automatic; the application must trigger it
 
 ## CI-backed evidence
 
-Current CI verifies serialization, cross-links, snapshots, compaction, blockstore GC, and IndexedDB index/storage components. Content-addressed persistence and browser blockstore initialization are partial; full restart recovery and remote pinning are not default acceptance tests. No CI evidence establishes a replication factor, complete pinning workflow, or durable disaster recovery. See [Limitations](../limitations/).
+Verified in CI:
+
+- Block creation, storage, and retrieval in a single browser session
+- Encrypted blocks transmitted through Circuit Relay and stored in the recipient's blockstore
+- IndexedDB blockstore initialization and basic read/write
+
+Not verified:
+
+- Complete browser restart and document recovery
+- Multi-session persistence (close → reopen → verify)
+- Compaction and GC with subsequent recovery
+- Pinning publisher integration
+- Remote block fetch (bitswap/HTTP) of blocks stored by a different peer
+
+## Next steps
+
+- [Pinning cookbook](../../cookbook/pinning/) — what needs to happen for reliable remote persistence
+- [Security model](../security/) — how encryption and signing protect stored data
+- [Limitations](../limitations/) — storage-specific limitations

--- a/site/src/content/docs/concepts/storage.md
+++ b/site/src/content/docs/concepts/storage.md
@@ -45,11 +45,11 @@ Swarmbase's shadow sync graph does **not** use Merkle hash linking. Blocks refer
 In the browser, Helia stores blocks in **IndexedDB**:
 
 ```ts
-import { createHelia } from 'helia';
-import { createIDBBlockstore } from 'helia-blockstore-idb';
+import { IDBBlockstore } from 'blockstore-idb';
+import { IDBDatastore } from 'datastore-idb';
 
-const blockstore = createIDBBlockstore('/swarmbase/blocks');
-const helia = await createHelia({ blockstore });
+const blockstore = new IDBBlockstore('/collabswarm-blocks');
+// In practice, pass these via CollabswarmConfig.helia to initialize()
 ```
 
 Encrypted blocks, IPNS records, and the libp2p peer store are all persisted to IndexedDB under the origin. This means a browser tab refresh should preserve document state.

--- a/site/src/content/docs/concepts/why-swarmbase.md
+++ b/site/src/content/docs/concepts/why-swarmbase.md
@@ -13,7 +13,7 @@ In a typical collaborative app, the server is a central point of failure, a scal
 
 ### Encryption is the default, not an add-on
 
-Every document change is signed with the writer's identity and encrypted with AES-GCM before it leaves the device. Relays, bootstrap nodes, and remote storage see only opaque ciphertext. Key material stays on devices — Swarmbase never transmits unencrypted document content.
+By default (`enableSigning: true`), every document change is signed with the writer's identity and encrypted with AES-GCM before it leaves the device. Relays, bootstrap nodes, and remote storage see only opaque ciphertext. Encryption is always on, whether signing is enabled or not. Key material stays on devices — Swarmbase never transmits unencrypted document content.
 
 ### Composable, not monolithic
 

--- a/site/src/content/docs/concepts/why-swarmbase.md
+++ b/site/src/content/docs/concepts/why-swarmbase.md
@@ -1,0 +1,77 @@
+---
+title: Why Swarmbase
+description: What makes Swarmbase different from other local-first and CRDT solutions, and when to use it.
+---
+
+Swarmbase is an **encrypted, peer-to-peer CRDT document toolkit** for TypeScript. It is not a database, a backend-as-a-service, or a drop-in realtime layer — it is a set of composable libraries that let you build collaborative applications where documents live on user devices and sync directly between peers.
+
+## What makes Swarmbase different
+
+### No application database server
+
+In a typical collaborative app, the server is a central point of failure, a scaling bottleneck, and a target for data breaches. Swarmbase removes the application database server from the architecture. Documents are encrypted, signed, and content-addressed — peers exchange updates through relay nodes that carry ciphertext without ever seeing plaintext.
+
+### Encryption is the default, not an add-on
+
+Every document change is signed with the writer's identity and encrypted with AES-GCM before it leaves the device. Relays, bootstrap nodes, and remote storage see only opaque ciphertext. Key material stays on devices — Swarmbase never transmits unencrypted document content.
+
+### Composable, not monolithic
+
+Swarmbase is not a single package. It is six libraries you compose:
+
+| Package | Role |
+|---|---|
+| `@swarmbase/collabswarm` | Core: encryption, signing, ACL, storage, networking |
+| `@swarmbase/collabswarm-yjs` | Yjs CRDT adapter |
+| `@swarmbase/collabswarm-automerge` | Automerge CRDT adapter |
+| `@swarmbase/collabswarm-react` | React hooks and bindings |
+| `@swarmbase/collabswarm-redux` | Redux state management bindings |
+| `@swarmbase/collabswarm-index` | Client-side search indexing |
+
+Use only what you need. Compose the adapters, bindings, and indexing layers that fit your application.
+
+### CRDT adapters, not a CRDT library
+
+Swarmbase does not implement its own CRDT. It adapts existing, well-tested CRDT libraries — Yjs and Automerge — wrapping them with encryption, signing, access control, and peer-to-peer transport. You get the battle-tested merge semantics of Yjs or Automerge combined with Swarmbase's security and networking model.
+
+### Source-available first
+
+All six packages are source workspaces in a single repository. You build from source, run the examples locally, and inspect every layer. There is no closed-source coordination service or proprietary sync server.
+
+## When to use Swarmbase
+
+Swarmbase is a good fit for applications that need:
+
+- **Encrypted document collaboration** where plaintext must never reach a server
+- **Peer-to-peer sync** without a central application database
+- **Offline-capable editing** where users make changes locally and merge later
+- **Fine-grained access control** with cryptographic enforcement
+- **Full control over infrastructure** — you run the relays, you own the keys
+
+Swarmbase is **not** a good fit when:
+
+- You need production-grade reliability today (it is alpha software)
+- You want a managed backend service (Swarmbase has no cloud offering)
+- You need sub-100ms multiplayer presence (CRDT conflict resolution is eventual, not real-time)
+- You are building a simple single-user offline app (use IndexedDB directly)
+- You need SQL queries or relational data (Swarmbase is a document store)
+
+## Current status
+
+Swarmbase is **alpha software** under active development. It is suitable for experiments, prototypes, and learning about local-first systems. It is not yet production-ready.
+
+Key capabilities that are verified end-to-end in CI:
+
+- Encrypted document creation, mutation, and retrieval through a Circuit Relay
+- Single-browser smoke tests for all three example applications
+- NAT traversal with Docker-backed integration tests
+- Basic peer discovery and GossipSub message delivery
+
+See the [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md) for a detailed capability-to-evidence map, and the [limitations](../limitations/) page for a complete list of current gaps.
+
+## Next steps
+
+- [Quick start](../../getting-started/quick-start/) — build from source and run the examples
+- [Concepts](../local-first/) — understand the architecture and design choices
+- [Cookbook](../../cookbook/collaborative-wiki/) — code patterns for common tasks
+- [Roadmap](../../community/roadmap/) — what is being worked on next

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -159,3 +159,13 @@ yarn workspace @swarmbase/site build
 
 Run the focused browser or Docker-backed suite as well when changing the behavior
 it covers.
+
+## Next steps
+
+- [Why Swarmbase?](../../concepts/why-swarmbase/) — understand the value proposition and when to use it
+- [Architecture](../../concepts/architecture/) — see how the pieces fit together with diagrams
+- [Concepts](../../concepts/local-first/) — dive into local-first design, CRDTs, networking, storage, and security
+- [Cookbook](../../cookbook/collaborative-wiki/) — try runnable recipes for wikis, password managers, React, Redux, and more
+- [API reference](../../reference/) — explore the generated API documentation for all six packages
+- [FAQ](../../community/faq/) — answers to common questions
+- [Contributing](../../community/contributing/) — set up a development environment and make your first contribution

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -65,16 +65,26 @@ Once a Swarmbase node is configured with the Yjs adapter, documents feel like
 familiar CRDT shared types wrapped in encryption and access control:
 
 ```ts
-import { createSwarmbaseNode, YjsProvider } from '@swarmbase/collabswarm';
+import { Collabswarm, SubtleCrypto, defaultConfig,
+  defaultBootstrapConfig } from '@swarmbase/collabswarm';
+import { YjsProvider, YjsACLProvider,
+  YjsKeychainProvider, YjsJSONSerializer } from '@swarmbase/collabswarm-yjs';
 
-const swarm = await createSwarmbaseNode({
-  signingKeyPair: await crypto.subtle.generateKey(
-    { name: 'ECDSA', namedCurve: 'P-384' },
-    true,
-    ['sign', 'verify'],
-  ),
-  provider: new YjsProvider(),
-});
+const swarm = new Collabswarm(
+  userKeyPair.privateKey,
+  userKeyPair.publicKey,
+  new YjsProvider(),
+  new YjsJSONSerializer(),
+  new YjsJSONSerializer(),
+  new YjsJSONSerializer(),
+  new SubtleCrypto(),
+  new YjsACLProvider(),
+  new YjsKeychainProvider(),
+);
+await swarm.initialize(defaultConfig(defaultBootstrapConfig([])));
+
+// Optionally connect to bootstrap peers:
+// await swarm.connect(['/dns4/relay.example.com/tcp/443/wss/p2p/12D3...']);
 
 const todos = swarm.doc('/todo-list');
 await todos.open();

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -41,8 +41,9 @@ Swarmbase is a set of **composable TypeScript libraries** that let you build app
 
 <CardGrid>
   <Card title="Encrypted by default" icon="seti:lock">
-    Every change is signed with ECDSA P-384 and encrypted with AES-GCM before it
-    leaves the device. Relays and remote stores see only opaque ciphertext.
+    By default, every change is signed with ECDSA P-384 and encrypted with AES-GCM
+    before it leaves the device. Relays and remote stores see only opaque ciphertext.
+    (Signing can be configured via `enableSigning`.)
   </Card>
   <Card title="No application database server" icon="setting">
     Helia and libp2p provide storage and peer-to-peer transport. You run relay

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Encrypted local-first database
-description: Swarmbase is alpha software for encrypted local-first documents synchronized over peer-to-peer networks.
+description: Swarmbase is alpha software for encrypted, local-first CRDT documents synchronized over peer-to-peer networks.
 template: splash
 hero:
   title: Local-first documents that sync peer to peer
@@ -11,13 +11,17 @@ hero:
   image:
     file: ../../assets/logo.svg
   actions:
-    - text: Run the quick start
+- text: Quick start
       link: ./getting-started/quick-start/
       icon: rocket
-    - text: Star on GitHub
+    - text: View on GitHub
       link: https://github.com/swarmbase/swarmbase
       icon: star
       variant: secondary
+    - text: Why Swarmbase?
+      link: concepts/why-swarmbase/
+      icon: right-arrow
+      variant: minimal
 ---
 
 import { Card, CardGrid, LinkButton, Aside } from '@astrojs/starlight/components';
@@ -26,42 +30,53 @@ import SyncDemo from '../../components/SyncDemo.astro';
 <Aside type="caution" title="Alpha software, honestly labeled">
   Swarmbase is under active development. It is suitable for experiments,
   prototypes, and learning about local-first systems, but not yet for production
-  or irreplaceable data. See the current
-  [feature and verification audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md)
-  before choosing it for a project.
+  or irreplaceable data. See the
+  [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md)
+  for the current capability-to-evidence map.
 </Aside>
 
+## What is Swarmbase?
+
+Swarmbase is a set of **composable TypeScript libraries** that let you build applications where documents live on user devices and sync directly between peers — encrypted, signed, and content-addressed. There is no application database server. Relays carry ciphertext without seeing plaintext.
+
 <CardGrid>
-  <Card title="Local-first" icon="laptop">
-    Changes apply to the local CRDT replica immediately. Peers exchange updates
-    when they can reach one another, while persistence and restart recovery
-    continue to mature.
-  </Card>
   <Card title="Encrypted by default" icon="seti:lock">
-    Swarmbase signs changes and encrypts document traffic with AES-GCM by
-    default. Relays and remote stores can carry ciphertext without receiving
-    document plaintext.
+    Every change is signed with ECDSA P-384 and encrypted with AES-GCM before it
+    leaves the device. Relays and remote stores see only opaque ciphertext.
   </Card>
   <Card title="No application database server" icon="setting">
-    Helia and libp2p provide storage and peer-to-peer transport. Browser
-    deployments may still use bootstrap peers, STUN/TURN, Circuit Relay, or
-    remote pinning infrastructure.
+    Helia and libp2p provide storage and peer-to-peer transport. You run relay
+    nodes for NAT traversal — no Postgres, no Redis, no application backend.
   </Card>
   <Card title="CRDT adapters" icon="puzzle">
-    Use Yjs or Automerge documents. Replicas are designed to converge after
-    valid updates are delivered, without a central consensus service.
+    Use Yjs or Automerge documents. Replicas converge after valid updates are
+    delivered, without a central consensus service. Battle-tested merge semantics
+    with Swarmbase's security model.
+  </Card>
+  <Card title="Composable, not monolithic" icon="grid">
+    Six libraries — use only what you need. Core (collabswarm), CRDT adapters
+    (Yjs, Automerge), UI bindings (React, Redux), and client-side indexing.
   </Card>
 </CardGrid>
 
 ## A Yjs document in a few lines
 
-Once a Swarmbase node is configured with the Yjs adapter, document changes use
-Yjs shared types directly:
+Once a Swarmbase node is configured with the Yjs adapter, documents feel like
+familiar CRDT shared types wrapped in encryption and access control:
 
 ```ts
-const todos = swarm.doc('/todo-list');
-if (!todos) throw new Error('Swarmbase is not initialized');
+import { createSwarmbaseNode, YjsProvider } from '@swarmbase/collabswarm';
 
+const swarm = await createSwarmbaseNode({
+  signingKeyPair: await crypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-384' },
+    true,
+    ['sign', 'verify'],
+  ),
+  provider: new YjsProvider(),
+});
+
+const todos = swarm.doc('/todo-list');
 await todos.open();
 
 todos.subscribe('ui', (state) => {
@@ -73,8 +88,9 @@ await todos.change((state) => {
 });
 ```
 
-The repository contains runnable browser, wiki, and password-manager examples
-that show provider setup, identity creation, and connecting peers.
+The repository contains runnable examples that show provider setup, identity
+creation, and connecting peers. See the [quick start](getting-started/quick-start/)
+to run them locally.
 
 ## Illustrative encrypted Yjs sync
 
@@ -87,14 +103,32 @@ listed directly below the demo.
 ## How it works
 
 1. **Edit locally.** A provider applies each change to the local CRDT replica.
-2. **Sign, encrypt, publish.** By default, Swarmbase signs the sync message,
-   encrypts the serialized envelope, and publishes it to connected peers.
-3. **Verify and merge.** Recipients verify, decrypt, and apply valid updates.
-   CRDT semantics are designed to reconcile concurrent edits after delivery.
+   The application sees changes immediately — no network round-trip.
+2. **Sign, encrypt, publish.** Swarmbase signs the sync message with the writer's
+   ECDSA P-384 key, encrypts the serialized envelope with the document's AES-GCM
+   key, and publishes the CID to connected peers via GossipSub.
+3. **Verify and merge.** Recipients fetch the encrypted block, verify the
+   signature, decrypt the payload, and apply the CRDT update. The Yjs or
+   Automerge layer reconciles concurrent edits without conflicts.
 
-Swarmbase currently verifies real encrypted document retrieval across a
-Circuit Relay boundary in CI. Broader partition/rejoin, persistence, and
-production deployment coverage remains active work.
+Swarmbase currently verifies encrypted document retrieval across a Circuit Relay
+boundary in CI. Broader partition/rejoin, persistence, and production deployment
+coverage remains active work.
+
+## Key design choices
+
+| Choice | Rationale |
+|---|---|
+| **End-to-end encryption** | Document plaintext never touches a server. AES-GCM content encryption, ECDSA P-384 signing. |
+| **Content-addressed storage** | Every block is addressed by its SHA-256 hash (CID). Blocks are immutable — no overwrites, no conflicts. |
+| **Shadow sync graph** | Changes form a DAG, not a linear history. Concurrent edits coexist; the CRDT layer resolves them. |
+| **CRDT-agnostic core** | Swarmbase wraps Yjs and Automerge without coupling to either. Swap CRDT implementations without changing your application. |
+| **libp2p networking** | Battle-tested peer-to-peer stack: WebSockets, WebRTC, WebTransport, Circuit Relay v2, GossipSub. |
+| **K-of-Q quorum loading** | Before trusting a document state, verify it with K-of-Q bootstrap peers. Prevents loading a fork. |
+| **BeeKEM key sharing** | Dynamic group key encapsulation. Add and remove readers without re-encrypting the document. |
+
+See the [architecture page](concepts/architecture/) for detailed diagrams of the
+data flow, networking stack, and encryption model.
 
 ## Built in the open
 
@@ -107,22 +141,38 @@ and unusual network tests can materially shape the project.
     [browser applications](https://github.com/swarmbase/swarmbase/tree/main/examples)
     and inspect the matching Playwright acceptance tests.
   </Card>
-  <Card title="Join the project" icon="pencil">
+  <Card title="Read the docs" icon="book">
+    Understand the [architecture](concepts/architecture/), learn the
+    [concepts](concepts/local-first/), and try the
+    [cookbook](cookbook/collaborative-wiki/) recipes.
+  </Card>
+  <Card title="Join the conversation" icon="chat">
     Browse [open issues](https://github.com/swarmbase/swarmbase/issues) or ask a
     question in [GitHub Discussions](https://github.com/swarmbase/swarmbase/discussions).
+  </Card>
+  <Card title="Contribute" icon="pencil">
+    Check the [roadmap](community/roadmap/), the [help wanted](community/help-wanted/)
+    list, and the [contributing guide](community/contributing/).
   </Card>
 </CardGrid>
 
 <LinkButton
-  href="./getting-started/quick-start/"
+href="./getting-started/quick-start/"
   icon="rocket"
 >
-  Run the quick start
+  Quick start
 </LinkButton>{' '}
 <LinkButton
-  href="https://github.com/swarmbase/swarmbase"
-  icon="star"
+  href="concepts/why-swarmbase/"
+  icon="right-arrow"
   variant="secondary"
 >
-  View Swarmbase on GitHub
+  Why Swarmbase?
+</LinkButton>{' '}
+<LinkButton
+  href="concepts/architecture/"
+  icon="information"
+  variant="minimal"
+>
+  Architecture
 </LinkButton>

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -71,6 +71,13 @@ import { Collabswarm, SubtleCrypto, defaultConfig,
 import { YjsProvider, YjsACLProvider,
   YjsKeychainProvider, YjsJSONSerializer } from '@swarmbase/collabswarm-yjs';
 
+// The application must supply an ECDSA P-384 key pair:
+const userKeyPair = await crypto.subtle.generateKey(
+  { name: 'ECDSA', namedCurve: 'P-384' },
+  true,
+  ['sign', 'verify'],
+) as CryptoKeyPair;
+
 const swarm = new Collabswarm(
   userKeyPair.privateKey,
   userKeyPair.publicKey,

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -11,7 +11,7 @@ hero:
   image:
     file: ../../assets/logo.svg
   actions:
-- text: Quick start
+    - text: Quick start
       link: ./getting-started/quick-start/
       icon: rocket
     - text: View on GitHub

--- a/site/src/content/docs/reference/comparisons.md
+++ b/site/src/content/docs/reference/comparisons.md
@@ -1,0 +1,114 @@
+---
+title: Comparisons
+description: How Swarmbase compares to other local-first, CRDT, and realtime collaboration tools.
+---
+
+Swarmbase occupies a specific niche: **encrypted, peer-to-peer CRDT document collaboration with source-available libraries**. This page compares it to related projects to help you understand when Swarmbase is the right choice.
+
+## Swarmbase vs Yjs (standalone)
+
+[Yjs](https://docs.yjs.dev) is a high-performance CRDT library for shared editing. It provides shared types (`Y.Map`, `Y.Array`, `Y.Text`) and network-agnostic sync, but leaves encryption, authentication, access control, storage, and peer discovery to the application.
+
+| | Swarmbase | Yjs (standalone) |
+|---|---|---|
+| **CRDT** | Adapts Yjs or Automerge | Built-in CRDT runtime |
+| **Encryption** | AES-GCM by default, BeeKEM key sharing | Application responsibility |
+| **Authentication** | ECDSA P-384 signing, UCAN capabilities | Application responsibility |
+| **Access control** | Reader/writer ACL with cryptographic enforcement | Application responsibility |
+| **Storage** | Helia/IPFS (IndexedDB in browser) | Application responsibility (y-indexeddb plugin) |
+| **Networking** | libp2p (WebSocket, WebRTC, WebTransport, GossipSub) | y-websocket, y-webrtc providers |
+| **Peer discovery** | Bootstrap, Kademlia DHT, AutoNAT | Application responsibility |
+
+Swarmbase is a good choice when you need encryption, signing, and access control out of the box. Use Yjs standalone when you already have your own auth, transport, and encryption layers.
+
+## Swarmbase vs Automerge (standalone)
+
+[Automerge](https://automerge.org) is a CRDT library with a JSON-like document model. Like Yjs, it provides merge semantics but not encryption, access control, or networking.
+
+| | Swarmbase | Automerge (standalone) |
+|---|---|---|
+| **Data model** | Adapts Automerge or Yjs | JSON-like CRDT documents |
+| **Sync transport** | libp2p + GossipSub | Automerge-repo (WebSocket, HTTP) |
+| **Encryption at rest** | AES-GCM per document | Application responsibility |
+| **Key exchange** | BeeKEM for dynamic groups | Application responsibility |
+| **Rich text** | Via Yjs adapter | Via Automerge Text type |
+
+Swarmbase wraps Automerge documents with encryption and access control. If you only need the CRDT merge semantics, use Automerge directly.
+
+## Swarmbase vs Liveblocks
+
+[Liveblocks](https://liveblocks.io) is a managed realtime collaboration platform. It provides presence, comments, notifications, and CRDT-based storage as a hosted service.
+
+| | Swarmbase | Liveblocks |
+|---|---|---|
+| **Architecture** | Peer-to-peer with relay infrastructure | Client-server (Liveblocks backend) |
+| **Deployment** | Self-hosted (you run relays) | Managed service (Liveblocks cloud) |
+| **Data sovereignty** | Full control (encrypted on your infrastructure) | Data stored on Liveblocks servers |
+| **Encryption model** | End-to-end (server never sees plaintext) | Encrypted in transit (server sees data) |
+| **Offline first** | Yes (IndexedDB local replica) | No (requires connection) |
+| **Pricing** | Open source (MIT) | Free tier + paid plans |
+| **Production readiness** | Alpha (not production-ready) | Production-grade |
+| **AI collaboration features** | Not included | AI comments, AI copilots |
+
+Use Liveblocks for production collaborative UIs with presence, comments, and rich-text when you are comfortable with a managed service. Use Swarmbase when you need end-to-end encryption and data sovereignty, or when you want to own your infrastructure.
+
+## Swarmbase vs RxDB
+
+[RxDB](https://rxdb.info) is a local-first NoSQL database for JavaScript. It stores JSON documents locally, provides reactive queries (RxJS observables), and syncs with backend servers via replication plugins.
+
+| | Swarmbase | RxDB |
+|---|---|---|
+| **Data model** | CRDT documents (Yjs/Automerge) | JSON documents with schemas |
+| **Query language** | IndexManager (full-text + blind indexes) | Mango/MongoDB query syntax |
+| **Sync model** | Peer-to-peer (libp2p) | Client-server replication |
+| **Backend** | Relay nodes (stateless) | RxServer, CouchDB, GraphQL, Firebase, Supabase, etc. |
+| **Encryption** | End-to-end (AES-GCM per document) | Field-level encryption plugin |
+| **Convergence** | CRDT (Yjs/Automerge) | CRDT plugin + conflict handlers |
+| **Framework support** | React, Redux | React, Angular, Vue, Svelte, Node.js, Expo |
+| **Production readiness** | Alpha | Production-grade (v17+) |
+
+RxDB is a mature, production-ready local-first database with broad backend support. Swarmbase is focused on encrypted peer-to-peer CRDT collaboration without a central server. They solve different problems.
+
+## Swarmbase vs Jazz
+
+[Jazz](https://jazz.tools) is a local-first relational database with row-level permissions and real-time sync. It provides a managed sync server and a React-friendly API.
+
+| | Swarmbase | Jazz |
+|---|---|---|
+| **Data model** | CRDT documents | Relational tables with schemas |
+| **Sync model** | Peer-to-peer (libp2p) | Client-server (Jazz Cloud or self-hosted) |
+| **Permissions** | Cryptographic ACL (reader/writer keys) | Row-level permissions |
+| **Encryption** | End-to-end (server never sees data) | E2E encryption |
+| **Server** | Relay nodes (pass-through) | Jazz sync server (stateful) |
+| **Framework support** | React, Redux | React, Vue, Svelte, Solid, Expo |
+| **Production readiness** | Alpha | Production (Jazz Cloud) |
+
+Jazz provides a more polished developer experience with managed infrastructure. Swarmbase gives you more control over networking and infrastructure, at the cost of more setup.
+
+## Swarmbase vs ElectricSQL
+
+[ElectricSQL](https://electric-sql.com) syncs a subset of Postgres to local clients. It provides read-path sync from a Postgres database to client-side PGlite instances.
+
+| | Swarmbase | ElectricSQL |
+|---|---|---|
+| **Sync direction** | Bidirectional (peers read and write) | Primarily read-path sync (writes go through your API) |
+| **Source of truth** | CRDT merge (no central authority) | Postgres (server is authoritative) |
+| **Data model** | CRDT documents | Postgres tables with Shapes |
+| **Schema** | Schema-less (CRDT types) | Postgres DDL |
+| **Encryption** | End-to-end | Server-side (you control Postgres access) |
+| **Offline** | Yes (IndexedDB local replica) | Yes (PGlite local replica) |
+| **Production readiness** | Alpha | Postgres sync is stable |
+
+ElectricSQL is ideal when you already have a Postgres database and want to sync a subset of it to clients. Swarmbase is designed for peer-to-peer document collaboration where there is no central database.
+
+## When to choose Swarmbase
+
+Swarmbase stands out when you need:
+
+1. **End-to-end encrypted peer-to-peer documents** — no server ever sees plaintext
+2. **No central database server** — your application has no backend database at all
+3. **Full control over infrastructure** — you run the relay nodes, you hold the keys
+4. **Composable libraries** — use only the packages you need, not a monolithic platform
+5. **Source-available transparency** — every layer is inspectable and modifiable
+
+If any of the projects above matches your requirements more closely, use it — they are more mature and have larger communities. Swarmbase is an alpha project exploring a specific design point: encrypted CRDT documents that sync directly between peers, with no server in the data path.

--- a/site/src/content/docs/reference/comparisons.md
+++ b/site/src/content/docs/reference/comparisons.md
@@ -13,7 +13,7 @@ Swarmbase occupies a specific niche: **encrypted, peer-to-peer CRDT document col
 |---|---|---|
 | **CRDT** | Adapts Yjs or Automerge | Built-in CRDT runtime |
 | **Encryption** | AES-GCM by default, BeeKEM key sharing | Application responsibility |
-| **Authentication** | ECDSA P-384 signing, UCAN capabilities | Application responsibility |
+| **Authentication** | ECDSA P-384 signing (optional; can be disabled with `enableSigning: false`); UCAN helpers exist but are not integrated into the document change path | Application responsibility |
 | **Access control** | Reader/writer ACL with cryptographic enforcement | Application responsibility |
 | **Storage** | Helia/IPFS (IndexedDB in browser) | Application responsibility (y-indexeddb plugin) |
 | **Networking** | libp2p (WebSocket, WebRTC, WebTransport, GossipSub) | y-websocket, y-webrtc providers |

--- a/site/src/content/docs/reference/comparisons.md
+++ b/site/src/content/docs/reference/comparisons.md
@@ -45,7 +45,7 @@ Swarmbase wraps Automerge documents with encryption and access control. If you o
 | **Deployment** | Self-hosted (you run relays) | Managed service (Liveblocks cloud) |
 | **Data sovereignty** | Full control (encrypted on your infrastructure) | Data stored on Liveblocks servers |
 | **Encryption model** | End-to-end (server never sees plaintext) | Encrypted in transit (server sees data) |
-| **Offline first** | Yes (IndexedDB local replica) | No (requires connection) |
+| **Offline first** | Yes (IndexedDB local replica) | Experimental (Yjs + IndexedDB; available after initial load) |
 | **Pricing** | Open source (MIT) | Free tier + paid plans |
 | **Production readiness** | Alpha (not production-ready) | Production-grade |
 | **AI collaboration features** | Not included | AI comments, AI copilots |

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -1,14 +1,54 @@
-/* Swarmbase brand accents (indigo primary, teal secondary). */
+/* Swarmbase brand accents (indigo primary, teal secondary, slate neutral). */
 :root {
-  --sl-color-accent-low: #262367;
+  --sl-color-accent-low: #1e1b4b;
   --sl-color-accent: #6366f1;
-  --sl-color-accent-high: #c7c9f8;
+  --sl-color-accent-high: #c7d2fe;
   --sw-color-teal: #2dd4bf;
+  --sw-color-teal-low: #134e4a;
+  --sw-color-teal-high: #99f6e4;
 }
 
 :root[data-theme='light'] {
-  --sl-color-accent-low: #e0e1fa;
+  --sl-color-accent-low: #e0e7ff;
   --sl-color-accent: #4f46e5;
-  --sl-color-accent-high: #312c96;
+  --sl-color-accent-high: #312e81;
   --sw-color-teal: #0d9488;
+  --sw-color-teal-low: #ccfbf1;
+  --sw-color-teal-high: #115e59;
+}
+
+.sl-link-card,
+.sl-link-button {
+  border-radius: 0.5rem;
+}
+
+table {
+  width: 100%;
+}
+
+th {
+  text-align: left;
+}
+
+td:first-child,
+th:first-child {
+  white-space: nowrap;
+}
+
+pre.astro-code {
+  border-radius: 0.5rem;
+}
+
+:is(h2, h3, h4) code {
+  font-weight: inherit;
+}
+
+aside:is([aria-label='Note'], [aria-label='Tip']) {
+  border-left-color: var(--sw-color-teal);
+}
+
+a[href^='http']:not([href*='github.com/swarmbase']):not([href*='swarmbase.github.io'])::after {
+  content: ' ↗';
+  font-size: 0.75em;
+  opacity: 0.6;
 }


### PR DESCRIPTION
## Problem
CI was running twice on every PR push because both the `push` and `pull_request` events were triggering the workflow. The `push` trigger had `branches-ignore: [docs]`, which matched every non-docs branch — including feature branches with open PRs.

## Fix
Restricted the `push` trigger to `branches: [main]` only, matching the pattern already used in `site.yml`. This ensures:
- PR pushes trigger CI once via `pull_request`
- Merges to `main` trigger CI once via `push`
- No duplicate runs

## Verification
- `release.yml` — not affected (push restricted to tags only)
- `site.yml` — not affected (already uses `branches: [main]`)