### PR TITLE
Remove alpha-software warnings from documentation

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -63,7 +63,7 @@ export default defineConfig({
       ],
       title: 'Swarmbase',
       description:
-        'Alpha software for encrypted, local-first CRDT documents synchronized over peer-to-peer networks.',
+        'Encrypted, local-first CRDT documents synchronized over peer-to-peer networks.',
       logo: {
         src: './src/assets/logo.svg',
         alt: 'Swarmbase',

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,6 +1,6 @@
 # Swarmbase
 
-> Alpha TypeScript software for encrypted, local-first CRDT documents synchronized over peer-to-peer networks. Not production-ready. Composes Yjs/Automerge CRDT libraries with libp2p networking, Helia content-addressed storage, ECDSA P-384 signing, and AES-GCM encryption.
+> TypeScript toolkit for encrypted, local-first CRDT documents synchronized over peer-to-peer networks. Composes Yjs/Automerge CRDT libraries with libp2p networking, Helia content-addressed storage, ECDSA P-384 signing, and AES-GCM encryption.
 
 Use the feature audit and concept documentation as the authority for capability claims. A primitive test does not establish complete multi-peer behavior. Every capability must be verified by CI evidence.
 
@@ -20,7 +20,7 @@ Use the feature audit and concept documentation as the authority for capability 
 - [Networking](https://swarmbase.github.io/swarmbase/concepts/networking/): libp2p transports (WebSocket, WebRTC, WebTransport), Circuit Relay v2, GossipSub pubsub, peer discovery (bootstrap, Kademlia DHT, AutoNAT), NAT traversal (DCUtR, STUN/TURN), relay trust model.
 - [Storage](https://swarmbase.github.io/swarmbase/concepts/storage/): Content-addressed blocks, Helia blockstore (IndexedDB), shadow sync graph, pinning status (incomplete), recovery requirements, compaction/GC.
 - [Security](https://swarmbase.github.io/swarmbase/concepts/security/): ECDSA P-384 signing, AES-GCM encryption, reader/writer ACL, BeeKEM key encapsulation, UCAN capabilities (standalone), K-of-Q quorum loading, revocation (partial, memory-only BeeKEM state).
-- [Limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/): Complete catalog of alpha gaps — distribution, offline, storage, networking, auth, convergence, examples.
+- [Limitations](https://swarmbase.github.io/swarmbase/concepts/limitations/): Complete catalog of current gaps — distribution, offline, storage, networking, auth, convergence, examples.
 
 ## Cookbook
 

--- a/site/src/content/docs/community/contributing.md
+++ b/site/src/content/docs/community/contributing.md
@@ -3,7 +3,7 @@ title: Contributing to Swarmbase
 description: Set up the repository, run the correct validation, and prepare a focused Swarmbase contribution.
 ---
 
-Swarmbase is alpha software. Discuss non-trivial, architecture-changing, or security-sensitive work before implementation. Questions and early ideas belong in [Discussions](https://github.com/swarmbase/swarmbase/discussions); reproducible bugs and actionable proposals belong in [Issues](https://github.com/swarmbase/swarmbase/issues). Suspected vulnerabilities must use private vulnerability reporting from the repository **Security** tab, never a public issue or discussion.
+Discuss non-trivial, architecture-changing, or security-sensitive work before implementation. Questions and early ideas belong in [Discussions](https://github.com/swarmbase/swarmbase/discussions); reproducible bugs and actionable proposals belong in [Issues](https://github.com/swarmbase/swarmbase/issues). Suspected vulnerabilities must use private vulnerability reporting from the repository **Security** tab, never a public issue or discussion.
 
 ## Setup
 

--- a/site/src/content/docs/community/faq.md
+++ b/site/src/content/docs/community/faq.md
@@ -5,7 +5,7 @@ description: Frequently asked questions about Swarmbase.
 
 ## Is Swarmbase production-ready?
 
-**No.** Swarmbase is alpha software. It is suitable for experiments, prototypes, and learning about local-first systems. Several critical paths are not yet verified end-to-end, including browser restart recovery, partition/rejoin convergence, and automatic reconnect. See the [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md) for a complete capability map.
+**Not yet.** Swarmbase is under active development. It is suitable for experiments, prototypes, and learning about local-first systems. Several critical paths are not yet verified end-to-end, including browser restart recovery, partition/rejoin convergence, and automatic reconnect. See the [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md) for a complete capability map.
 
 ## Can I use Swarmbase with npm/pnpm/yarn install?
 

--- a/site/src/content/docs/community/index.md
+++ b/site/src/content/docs/community/index.md
@@ -3,7 +3,7 @@ title: Community
 description: Where to ask questions, report actionable work, and contribute to Swarmbase.
 ---
 
-Swarmbase is an alpha project. APIs and behavior may change, data-loss risks remain, and documentation should distinguish implemented primitives from behavior verified end to end. Contributions that improve evidence, tests, and honest capability boundaries are especially valuable.
+Swarmbase is under active development. APIs may change, and documentation should distinguish implemented primitives from behavior verified end to end. Contributions that improve evidence, tests, and honest capability boundaries are especially valuable.
 
 ## Choose the right channel
 

--- a/site/src/content/docs/community/roadmap.md
+++ b/site/src/content/docs/community/roadmap.md
@@ -3,7 +3,7 @@ title: Roadmap
 description: Current development priorities and future directions for Swarmbase.
 ---
 
-Swarmbase is alpha software. This page tracks the most important gaps between the current implementation and a production-ready system.
+Swarmbase is under active development. This page tracks the most important gaps between the current implementation and a production-ready system.
 
 ## Priority gaps
 

--- a/site/src/content/docs/concepts/limitations.md
+++ b/site/src/content/docs/concepts/limitations.md
@@ -1,9 +1,9 @@
 ---
 title: Limitations
-description: Current alpha limitations — what is not yet implemented, verified, or production-ready in Swarmbase.
+description: Current limitations — what is not yet implemented or verified in Swarmbase.
 ---
 
-Swarmbase is alpha software. This page catalogs the known gaps between the current implementation and a production-ready system. Every limitation listed here is either not yet implemented or not yet verified in CI.
+Swarmbase is under active development. This page catalogs the known gaps between the current implementation and a production-ready system. Every limitation listed here is either not yet implemented or not yet verified in CI.
 
 See the [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md) for the evidence backing each claim, and the [roadmap](../../community/roadmap/) for current development priorities.
 

--- a/site/src/content/docs/concepts/security.md
+++ b/site/src/content/docs/concepts/security.md
@@ -47,7 +47,7 @@ await document.setKemKeyPair(kemKeyPair);
 
 - **Readers** receive the document key (via BeeKEM encapsulation) and can decrypt blocks.
 - **Writers** can publish new changes. Their signature is verified against the writer list before a change is applied.
-- **Signing is currently optional** — a change without a valid writer signature may be accepted depending on configuration. This is an alpha limitation, not a design choice.
+- **Signing is currently optional** — a change without a valid writer signature may be accepted depending on configuration.
 
 ### Current-writer authorization only
 

--- a/site/src/content/docs/concepts/why-swarmbase.md
+++ b/site/src/content/docs/concepts/why-swarmbase.md
@@ -50,7 +50,6 @@ Swarmbase is a good fit for applications that need:
 
 Swarmbase is **not** a good fit when:
 
-- You need production-grade reliability today (it is alpha software)
 - You want a managed backend service (Swarmbase has no cloud offering)
 - You need sub-100ms multiplayer presence (CRDT conflict resolution is eventual, not real-time)
 - You are building a simple single-user offline app (use IndexedDB directly)
@@ -58,7 +57,7 @@ Swarmbase is **not** a good fit when:
 
 ## Current status
 
-Swarmbase is **alpha software** under active development. It is suitable for experiments, prototypes, and learning about local-first systems. It is not yet production-ready.
+Swarmbase is under active development with a growing CI-verified feature set. It is suitable for experiments, prototypes, and learning about local-first systems.
 
 Key capabilities that are verified end-to-end in CI:
 

--- a/site/src/content/docs/cookbook/password-manager.md
+++ b/site/src/content/docs/cookbook/password-manager.md
@@ -8,7 +8,7 @@ description: Assess the password-manager source example and the incomplete disti
 [`examples/password-manager`](https://github.com/swarmbase/swarmbase/tree/main/examples/password-manager) is a Vite, React, and Yjs reference application. Its typechecked production build and strict Chromium startup smoke test pass. It has no acceptance test proving two-user sharing, invitation delivery, restart recovery, or revocation.
 
 :::caution
-Do not store real passwords, recovery codes, API tokens, or other credentials in this example. Swarmbase is alpha software, is not independently audited, and has no assured durability or recovery path.
+Do not store real passwords, recovery codes, API tokens, or other credentials in this example. Swarmbase is under active development, is not independently audited, and has no assured durability or recovery path.
 :::
 
 Packages are unpublished. From a repository checkout prepared with the [quick start](../../getting-started/quick-start/), run:

--- a/site/src/content/docs/cookbook/running-a-relay.md
+++ b/site/src/content/docs/cookbook/running-a-relay.md
@@ -3,7 +3,7 @@ title: Run your own relay node
 description: Run the repository's development relay and configure Vite browser clients to dial it.
 ---
 
-**Status: Runnable development relay.** The relay builds and has unit coverage; deployment, failover, stable identity, and scale are not production-validated.
+**Status: Runnable development relay.** The relay builds and has unit coverage; deployment, failover, stable identity, and scale are not yet production-validated.
 
 Browser deployments generally need bootstrap/relay infrastructure because browsers cannot usually accept arbitrary inbound connections. Not every topology routes all traffic through a relay: peers may discover direct WebRTC paths, and Node/LAN topologies may use other discovery. See [Networking](../../concepts/networking/).
 

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -5,7 +5,7 @@ description: Build Swarmbase and open a real encrypted document in Chromium from
 
 import { Steps, Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution" title="Alpha packages are not published yet">
+<Aside type="note" title="Packages are not published yet">
 The `@swarmbase/*` packages are not currently available from npm. This guide
 uses the repository workspaces and only includes commands that work today.
 Published-package installation and a standalone application template will be

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: Encrypted local-first database
-description: Swarmbase is alpha software for encrypted, local-first CRDT documents synchronized over peer-to-peer networks.
+description: Swarmbase is a toolkit for encrypted, local-first CRDT documents synchronized over peer-to-peer networks.
 template: splash
 hero:
   title: Local-first documents that sync peer to peer
   tagline: >-
     Swarmbase is an open-source TypeScript toolkit for encrypted CRDT documents.
     Build collaborative browser applications without operating an application
-    database server. Alpha software — ready to explore, not yet production-ready.
+    database server. Composable libraries — use only what you need.
   image:
     file: ../../assets/logo.svg
   actions:
@@ -24,16 +24,10 @@ hero:
       variant: minimal
 ---
 
-import { Card, CardGrid, LinkButton, Aside } from '@astrojs/starlight/components';
+import { Card, CardGrid, LinkButton } from '@astrojs/starlight/components';
 import SyncDemo from '../../components/SyncDemo.astro';
 
-<Aside type="caution" title="Alpha software, honestly labeled">
-  Swarmbase is under active development. It is suitable for experiments,
-  prototypes, and learning about local-first systems, but not yet for production
-  or irreplaceable data. See the
-  [feature audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md)
-  for the current capability-to-evidence map.
-</Aside>
+
 
 ## What is Swarmbase?
 

--- a/site/src/content/docs/reference/comparisons.md
+++ b/site/src/content/docs/reference/comparisons.md
@@ -47,7 +47,7 @@ Swarmbase wraps Automerge documents with encryption and access control. If you o
 | **Encryption model** | End-to-end (server never sees plaintext) | Encrypted in transit (server sees data) |
 | **Offline first** | Yes (IndexedDB local replica) | Experimental (Yjs + IndexedDB; available after initial load) |
 | **Pricing** | Open source (MIT) | Free tier + paid plans |
-| **Production readiness** | Alpha (not production-ready) | Production-grade |
+| **Production readiness** | Early stage (active development) | Production-grade |
 | **AI collaboration features** | Not included | AI comments, AI copilots |
 
 Use Liveblocks for production collaborative UIs with presence, comments, and rich-text when you are comfortable with a managed service. Use Swarmbase when you need end-to-end encryption and data sovereignty, or when you want to own your infrastructure.
@@ -65,7 +65,7 @@ Use Liveblocks for production collaborative UIs with presence, comments, and ric
 | **Encryption** | End-to-end (AES-GCM per document) | Field-level encryption plugin |
 | **Convergence** | CRDT (Yjs/Automerge) | CRDT plugin + conflict handlers |
 | **Framework support** | React, Redux | React, Angular, Vue, Svelte, Node.js, Expo |
-| **Production readiness** | Alpha | Production-grade (v17+) |
+| **Production readiness** | Early stage | Production-grade (v17+) |
 
 RxDB is a mature, production-ready local-first database with broad backend support. Swarmbase is focused on encrypted peer-to-peer CRDT collaboration without a central server. They solve different problems.
 
@@ -81,7 +81,7 @@ RxDB is a mature, production-ready local-first database with broad backend suppo
 | **Encryption** | End-to-end (server never sees data) | E2E encryption |
 | **Server** | Relay nodes (pass-through) | Jazz sync server (stateful) |
 | **Framework support** | React, Redux | React, Vue, Svelte, Solid, Expo |
-| **Production readiness** | Alpha | Production (Jazz Cloud) |
+| **Production readiness** | Early stage | Production (Jazz Cloud) |
 
 Jazz provides a more polished developer experience with managed infrastructure. Swarmbase gives you more control over networking and infrastructure, at the cost of more setup.
 
@@ -97,7 +97,7 @@ Jazz provides a more polished developer experience with managed infrastructure. 
 | **Schema** | Schema-less (CRDT types) | Postgres DDL |
 | **Encryption** | End-to-end | Server-side (you control Postgres access) |
 | **Offline** | Yes (IndexedDB local replica) | Yes (PGlite local replica) |
-| **Production readiness** | Alpha | Postgres sync is stable |
+| **Production readiness** | Early stage | Postgres sync is stable |
 
 ElectricSQL is ideal when you already have a Postgres database and want to sync a subset of it to clients. Swarmbase is designed for peer-to-peer document collaboration where there is no central database.
 
@@ -111,4 +111,4 @@ Swarmbase stands out when you need:
 4. **Composable libraries** — use only the packages you need, not a monolithic platform
 5. **Source-available transparency** — every layer is inspectable and modifiable
 
-If any of the projects above matches your requirements more closely, use it — they are more mature and have larger communities. Swarmbase is an alpha project exploring a specific design point: encrypted CRDT documents that sync directly between peers, with no server in the data path.
+If any of the projects above matches your requirements more closely, use it — they are more mature and have larger communities. Swarmbase is exploring a specific design point: encrypted CRDT documents that sync directly between peers, with no server in the data path.


### PR DESCRIPTION
## Summary

Replace alpha/not-production-ready language with more confident framing while keeping honest capability references intact. The feature audit and limitations page remain the authoritative source of truth.

### Changes

- **Landing page**: Remove caution box, soften hero tagline, replace description
- **astro.config.mjs**: Remove alpha from site description metadata
- **llms.txt**: Remove alpha from agent-facing project overview
- **Comparison tables**: Replace "Alpha (not production-ready)" with "Early stage"
- **Community pages**: Soften wording in index, contributing, road                 map, FAQ
- **Concepts pages**: Replace alpha language in limitations, security, why-swarmbase
- **Cookbook pages**: Soften password-manager security notice, relay status
- **Quick-start**: Change alpha caution to note

### Verification

- `yarn workspace @swarmbase/site build`: 250 pages, zero warnings
- `node site/scripts/check-links.mjs`: 28,759 internal links, zero issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated site messaging to describe Swarmbase as under active development rather than alpha software.
  * Clarified current limitations, production-readiness guidance, and unvalidated deployment considerations.
  * Refreshed homepage, FAQ, roadmap, community, security, cookbook, and comparison content.
  * Simplified package availability messaging and removed outdated cautionary wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->