### PR TITLE
Add robots.txt, OG image, and social preview metadata

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -79,6 +79,12 @@ export default defineConfig({
         baseUrl: 'https://github.com/swarmbase/swarmbase/edit/main/site/',
       },
       customCss: ['./src/styles/custom.css'],
+      head: [
+        {
+          tag: 'meta',
+          attrs: { property: 'og:image', content: '/swarmbase/og-image.svg' },
+        },
+      ],
       sidebar: [
         {
           label: 'Getting started',

--- a/site/public/og-image.svg
+++ b/site/public/og-image.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#0f0e1a"/>
+  <circle cx="600" cy="240" r="80" fill="#6366f1" opacity="0.8"/>
+  <circle cx="460" cy="200" r="24" fill="#2dd4bf"/>
+  <circle cx="740" cy="200" r="24" fill="#2dd4bf"/>
+  <circle cx="460" cy="280" r="24" fill="#2dd4bf"/>
+  <circle cx="740" cy="280" r="24" fill="#2dd4bf"/>
+  <circle cx="600" cy="160" r="24" fill="#2dd4bf"/>
+  <circle cx="600" cy="320" r="24" fill="#2dd4bf"/>
+  <text x="600" y="420" text-anchor="middle" fill="#c7d2fe" font-family="system-ui, sans-serif" font-size="52" font-weight="700">Swarmbase</text>
+  <text x="600" y="480" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="28">Encrypted, local-first CRDT documents</text>
+  <text x="600" y="520" text-anchor="middle" fill="#94a3b8" font-family="system-ui, sans-serif" font-size="24">that sync peer to peer</text>
+</svg>

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://swarmbase.github.io/swarmbase/sitemap-index.xml


### PR DESCRIPTION
## Summary

Small SEO and social-sharing improvements for the documentation site.

### Changes

- **robots.txt** — Allow all crawlers with a reference to the sitemap index
- **og-image.svg** — 1200x630 social preview image with the Swarmbase logo pattern and tagline, used when the site is shared on Discord, Slack, LinkedIn, etc.
- **og:image meta tag** — Added to the Starlight site head so every page gets the social preview image

### Verification

- `yarn workspace @swarmbase/site build`: 250 pages, zero warnings
- og:image tag confirmed present in built HTML output
- robots.txt accessible at site root