### PR TITLE
Add structured issue intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Swarmbase is alpha software and is not production-ready. For questions and design exploration, use [GitHub Discussions](https://github.com/swarmbase/swarmbase/discussions).
+        Swarmbase is under active development. For questions and design exploration, use [GitHub Discussions](https://github.com/swarmbase/swarmbase/discussions).
 
         Report suspected vulnerabilities through [private vulnerability reporting](https://github.com/swarmbase/swarmbase/security/advisories/new), not this form. Never include credentials, signing keys, KEM keys, document keys, private payloads, or sensitive user data.
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Report a reproducible defect in Swarmbase or its development tooling.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Swarmbase is alpha software and is not production-ready. For questions and design exploration, use [GitHub Discussions](https://github.com/swarmbase/swarmbase/discussions).
+
+        Report suspected vulnerabilities through [private vulnerability reporting](https://github.com/swarmbase/swarmbase/security/advisories/new), not this form. Never include credentials, signing keys, KEM keys, document keys, private payloads, or sensitive user data.
+  - type: input
+    id: revision
+    attributes:
+      label: Version or commit
+      description: Give the commit SHA, branch, or package version where you reproduced the problem.
+      placeholder: e.g. main at 0123abcd
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Core document or runtime APIs
+        - Automerge adapter
+        - Yjs adapter
+        - React bindings
+        - Redux bindings
+        - Indexing and search
+        - Relay or peer-to-peer networking
+        - Browser examples
+        - Build, tests, or release tooling
+        - Documentation site
+        - Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the operating system, Node.js version, browser and version when relevant, and the command or example used.
+      placeholder: macOS 15; Node.js 22.19.0; Chromium 140; yarn test:e2e:browser-test
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest deterministic sequence that reproduces the problem.
+      placeholder: |
+        1. Install from a clean checkout...
+        2. Run...
+        3. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized log output
+      description: Remove all secrets and private data. Include only the lines needed to understand the failure.
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add sanitized screenshots, supporting links, or other details that help explain the problem.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and discussions for this problem.
+          required: true
+        - label: I removed credentials, keys, private payloads, and sensitive user data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions, use cases, and design ideas
+    url: https://github.com/swarmbase/swarmbase/discussions
+    about: Start a discussion before turning an exploratory idea into actionable work.
+  - name: Security reports
+    url: https://github.com/swarmbase/swarmbase/security/advisories/new
+    about: Report suspected vulnerabilities privately. Do not disclose them in a public issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -9,7 +9,7 @@ body:
       value: |
         Use this form for actionable documentation changes. Ask open-ended questions and discuss new ideas in [GitHub Discussions](https://github.com/swarmbase/swarmbase/discussions).
 
-        Swarmbase is alpha software. Capability and security claims must match the [feature and verification audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md).
+        Capability and security claims must match the [feature and verification audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md).
   - type: input
     id: location
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,57 @@
+name: Documentation issue
+description: Report missing, inaccurate, or unclear Swarmbase documentation.
+title: "[Docs]: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for actionable documentation changes. Ask open-ended questions and discuss new ideas in [GitHub Discussions](https://github.com/swarmbase/swarmbase/discussions).
+
+        Swarmbase is alpha software. Capability and security claims must match the [feature and verification audit](https://github.com/swarmbase/swarmbase/blob/main/docs/feature-audit.md).
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link the page or give the repository path and section.
+      placeholder: https://swarmbase.github.io/swarmbase/concepts/security/
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is missing, inaccurate, or unclear?
+      description: Quote only the minimum text needed and explain the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: Suggested correction
+      description: Describe the result you expect. Include supporting source or test links for capability claims.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Documentation area
+      options:
+        - Getting started
+        - Concepts or architecture
+        - Security or limitations
+        - Cookbook
+        - API reference or source comments
+        - Examples
+        - Contributor documentation
+        - Agent index (llms.txt)
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and discussions for this problem.
+          required: true
+        - label: I did not include credentials, keys, private payloads, or sensitive user data.
+          required: true


### PR DESCRIPTION
## Summary

- add structured bug and documentation issue forms
- apply the existing `bug` and `documentation` labels automatically
- route questions and design exploration to Discussions
- route suspected vulnerabilities to private reporting

## Why

Visitors currently land on an unstructured blank issue flow. These forms collect the revision, affected area, environment, reproduction, and evidence needed to make reports actionable while keeping secrets and security reports out of public issues.

## Validation

- parsed all three YAML files locally
- validated required form fields, unique IDs, dropdown and checkbox options, and contact links
- confirmed both configured labels exist in the repository
- confirmed private vulnerability reporting is enabled
- `git diff --check`

The local schema validation was not added to the repository.

## Stack

Depends on #353. The focused change in this pull request is commit `93c20975`.
