### PR TITLE
Add llms-full.txt for AI agent consumption

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -58,8 +58,8 @@ jobs:
         run: yarn install --immutable
       - name: Build site
         run: yarn workspace @swarmbase/site build
-      - name: Test site link checker
-        run: node --test site/scripts/check-links.test.mjs
+      - name: Test site tooling
+        run: node --test site/scripts/check-links.test.mjs site/scripts/generate-llms-full.test.mjs
       - name: Check site and agent index links
         run: node site/scripts/check-links.mjs
       - uses: actions/configure-pages@v5

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build:dependencies": "yarn workspace @swarmbase/collabswarm tsc && yarn workspace @swarmbase/collabswarm-yjs tsc",
     "dev": "yarn run build:dependencies && astro dev",
-    "build": "yarn run build:dependencies && astro build",
+    "build": "yarn run build:dependencies && astro build && node scripts/generate-llms-full.mjs",
     "preview": "astro preview"
   },
   "dependencies": {

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -6,6 +6,7 @@ Use the feature audit and concept documentation as the authority for capability 
 
 ## Start
 
+- [Full handwritten documentation corpus](https://swarmbase.github.io/swarmbase/llms-full.txt): Every hand-authored site page plus the feature and verification audit in one generated file.
 - [Quick start](https://swarmbase.github.io/swarmbase/getting-started/quick-start/): Build Swarmbase from source and exercise the verified browser path.
 - [Why Swarmbase](https://swarmbase.github.io/swarmbase/concepts/why-swarmbase/): Value proposition, when to use/not use.
 - [Architecture](https://swarmbase.github.io/swarmbase/concepts/architecture/): System overview, data flow, networking stack, encryption model with ASCII diagrams.

--- a/site/scripts/check-links.mjs
+++ b/site/scripts/check-links.mjs
@@ -114,7 +114,45 @@ function* tagsIn(html) {
   }
 }
 
-function linksInMarkdown(markdown) {
+function markdownOutsideFences(markdown, sourceName) {
+  let fence;
+
+  const searchable = markdown
+    .split('\n')
+    .map((line, index) => {
+      if (!fence) {
+        const opening = /^([ \t]*)(`{3,}|~{3,})/.exec(line);
+        if (!opening) return line;
+        fence = {
+          character: opening[2][0],
+          length: opening[2].length,
+          startLine: index + 1,
+        };
+        return ' '.repeat(line.length);
+      }
+
+      const closing = /^([ \t]*)(`+|~+)\s*$/.exec(line);
+      if (
+        closing &&
+        closing[2][0] === fence.character &&
+        closing[2].length >= fence.length
+      ) {
+        fence = undefined;
+      }
+      return ' '.repeat(line.length);
+    })
+    .join('\n');
+
+  if (fence) {
+    throw new Error(
+      `${sourceName}:${fence.startLine}: unclosed ${fence.character.repeat(fence.length)} fence`,
+    );
+  }
+  return searchable;
+}
+
+function linksInMarkdown(markdown, sourceName) {
+  const searchableMarkdown = markdownOutsideFences(markdown, sourceName);
   const inlineLinkPattern =
     /\[[^\]\n]+\]\(\s*(?:<([^>\n]+)>|([^\s)\n]+))(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^\n)]*\)))?\s*\)/g;
   const inlineLinkOpeningPattern = /\[[^\]\n]+\]\(/g;
@@ -127,26 +165,26 @@ function linksInMarkdown(markdown) {
   const undefinedReferences = [];
   const malformedInlineLinks = [];
 
-  for (const match of markdown.matchAll(inlineLinkPattern)) {
+  for (const match of searchableMarkdown.matchAll(inlineLinkPattern)) {
     validInlineStarts.add(match.index);
     links.push(match[1] ?? match[2]);
   }
-  for (const match of markdown.matchAll(referenceLinkPattern)) {
+  for (const match of searchableMarkdown.matchAll(referenceLinkPattern)) {
     const label = normalizeReferenceLabel(match[1]);
     if (!definitions.has(label)) {
       definitions.set(label, match[2] ?? match[3]);
     }
   }
-  for (const match of markdown.matchAll(referenceUsePattern)) {
+  for (const match of searchableMarkdown.matchAll(referenceUsePattern)) {
     const label = normalizeReferenceLabel(match[2] || match[1]);
     const href = definitions.get(label);
     if (href) links.push(href);
     else undefinedReferences.push(match[2] || match[1]);
   }
-  for (const match of markdown.matchAll(inlineLinkOpeningPattern)) {
+  for (const match of searchableMarkdown.matchAll(inlineLinkOpeningPattern)) {
     if (!validInlineStarts.has(match.index)) {
       malformedInlineLinks.push(
-        markdown.slice(0, match.index).split('\n').length,
+        searchableMarkdown.slice(0, match.index).split('\n').length,
       );
     }
   }
@@ -374,26 +412,26 @@ function checkSiteLink({
   return { internal: true, url };
 }
 
-function checkRepositoryLink(href, url, diagnostics) {
+function checkRepositoryLink({ href, url, sourceName, diagnostics }) {
   let target;
   try {
     target = repositoryTargetFor(url);
   } catch {
     diagnostics.push(
-      `llms.txt: href="${href}" has invalid repository path encoding`,
+      `${sourceName}: href="${href}" has invalid repository path encoding`,
     );
     return true;
   }
   if (!target) return false;
   if (target.error) {
-    diagnostics.push(`llms.txt: href="${href}" -> ${target.error}`);
+    diagnostics.push(`${sourceName}: href="${href}" -> ${target.error}`);
     return true;
   }
 
   const targetPath = resolve(repositoryDirectory, target.relativePath);
   if (pathEscapesDirectory(repositoryDirectory, targetPath)) {
     diagnostics.push(
-      `llms.txt: href="${href}" -> escapes the repository checkout`,
+      `${sourceName}: href="${href}" -> escapes the repository checkout`,
     );
     return true;
   }
@@ -405,13 +443,13 @@ function checkRepositoryLink(href, url, diagnostics) {
     realTargetPath = realpathSync(targetPath);
   } catch {
     diagnostics.push(
-      `llms.txt: href="${href}" -> missing repository target "${target.relativePath || '.'}"`,
+      `${sourceName}: href="${href}" -> missing repository target "${target.relativePath || '.'}"`,
     );
     return true;
   }
   if (pathEscapesDirectory(realRepositoryPath, realTargetPath)) {
     diagnostics.push(
-      `llms.txt: href="${href}" -> repository target escapes the checkout through a symbolic link`,
+      `${sourceName}: href="${href}" -> repository target escapes the checkout through a symbolic link`,
     );
     return true;
   }
@@ -420,7 +458,7 @@ function checkRepositoryLink(href, url, diagnostics) {
     stats = statSync(realTargetPath);
   } catch {
     diagnostics.push(
-      `llms.txt: href="${href}" -> missing repository target "${target.relativePath || '.'}"`,
+      `${sourceName}: href="${href}" -> missing repository target "${target.relativePath || '.'}"`,
     );
     return true;
   }
@@ -430,10 +468,77 @@ function checkRepositoryLink(href, url, diagnostics) {
   if (!hasExpectedType) {
     const expectedType = target.kind === 'blob' ? 'file' : 'directory';
     diagnostics.push(
-      `llms.txt: href="${href}" -> repository target "${target.relativePath || '.'}" is not a ${expectedType}`,
+      `${sourceName}: href="${href}" -> repository target "${target.relativePath || '.'}" is not a ${expectedType}`,
     );
   }
   return true;
+}
+
+function checkMarkdownArtifact({
+  relativePath,
+  files,
+  siteRoot,
+  basePath,
+  anchorsByFile,
+  diagnostics,
+}) {
+  let markdown;
+  try {
+    markdown = readFileSync(resolve(distDirectory, relativePath), 'utf8');
+  } catch (error) {
+    throw new Error(`${distDirectory}/${relativePath} does not exist`, {
+      cause: error,
+    });
+  }
+
+  const { links, malformedInlineLinks, undefinedReferences } =
+    linksInMarkdown(markdown, relativePath);
+  if (links.length === 0) {
+    diagnostics.push(`${relativePath}: contains no Markdown links`);
+  }
+  for (const line of malformedInlineLinks) {
+    diagnostics.push(`${relativePath}:${line}: malformed inline Markdown link`);
+  }
+  for (const label of undefinedReferences) {
+    diagnostics.push(`${relativePath}: undefined link reference "${label}"`);
+  }
+
+  const sourceUrl = new URL(relativePath, siteRoot);
+  let siteLinkCount = 0;
+  let repositoryLinkCount = 0;
+  for (const href of links) {
+    const result = checkSiteLink({
+      href,
+      sourceUrl,
+      sourceName: relativePath,
+      siteRoot,
+      files,
+      basePath,
+      anchorsByFile,
+      diagnostics,
+    });
+    if (result.internal) {
+      siteLinkCount += 1;
+    } else if (
+      result.url &&
+      checkRepositoryLink({
+        href,
+        url: result.url,
+        sourceName: relativePath,
+        diagnostics,
+      })
+    ) {
+      repositoryLinkCount += 1;
+    }
+  }
+
+  return {
+    externalLinkCount: links.length - siteLinkCount - repositoryLinkCount,
+    linkCount: links.length,
+    relativePath,
+    repositoryLinkCount,
+    siteLinkCount,
+  };
 }
 
 function run() {
@@ -469,28 +574,6 @@ function run() {
       anchorsFor(htmlByFile.get(relativePath), relativePath, diagnostics),
     ]),
   );
-  let agentIndex;
-  try {
-    agentIndex = readFileSync(resolve(distDirectory, 'llms.txt'), 'utf8');
-  } catch (error) {
-    throw new Error(`${distDirectory}/llms.txt does not exist`, {
-      cause: error,
-    });
-  }
-  const {
-    links: agentIndexLinks,
-    malformedInlineLinks,
-    undefinedReferences,
-  } = linksInMarkdown(agentIndex);
-  if (agentIndexLinks.length === 0) {
-    diagnostics.push('llms.txt: contains no Markdown links');
-  }
-  for (const line of malformedInlineLinks) {
-    diagnostics.push(`llms.txt:${line}: malformed inline Markdown link`);
-  }
-  for (const label of undefinedReferences) {
-    diagnostics.push(`llms.txt: undefined link reference "${label}"`);
-  }
   let internalLinkCount = 0;
 
   for (const relativePath of htmlFiles) {
@@ -516,33 +599,16 @@ function run() {
     }
   }
 
-  const agentIndexUrl = new URL('llms.txt', siteRoot);
-  let agentIndexSiteLinkCount = 0;
-  let agentIndexRepositoryLinkCount = 0;
-  for (const href of agentIndexLinks) {
-    const result = checkSiteLink({
-      href,
-      sourceUrl: agentIndexUrl,
-      sourceName: 'llms.txt',
-      siteRoot,
+  const markdownResults = ['llms.txt', 'llms-full.txt'].map((relativePath) =>
+    checkMarkdownArtifact({
+      relativePath,
       files,
+      siteRoot,
       basePath,
       anchorsByFile,
       diagnostics,
-    });
-    if (result.internal) {
-      agentIndexSiteLinkCount += 1;
-    } else if (
-      result.url &&
-      checkRepositoryLink(href, result.url, diagnostics)
-    ) {
-      agentIndexRepositoryLinkCount += 1;
-    }
-  }
-  const agentIndexExternalLinkCount =
-    agentIndexLinks.length -
-    agentIndexSiteLinkCount -
-    agentIndexRepositoryLinkCount;
+    }),
+  );
 
   diagnostics.sort();
   if (diagnostics.length > 0) {
@@ -559,8 +625,14 @@ function run() {
     return;
   }
 
+  const markdownSummary = markdownResults
+    .map(
+      (result) =>
+        `${result.linkCount} links in ${result.relativePath} (${result.siteLinkCount} site, ${result.repositoryLinkCount} repository, ${result.externalLinkCount} external)`,
+    )
+    .join(' and ');
   console.log(
-    `Checked ${internalLinkCount} internal links in ${htmlFiles.length} HTML files and ${agentIndexLinks.length} links in llms.txt (${agentIndexSiteLinkCount} site, ${agentIndexRepositoryLinkCount} repository, ${agentIndexExternalLinkCount} external); 0 issues.`,
+    `Checked ${internalLinkCount} internal links in ${htmlFiles.length} HTML files and ${markdownSummary}; 0 issues.`,
   );
 }
 

--- a/site/scripts/check-links.test.mjs
+++ b/site/scripts/check-links.test.mjs
@@ -26,6 +26,7 @@ after(() => {
 function createFixture({
   indexBody = '',
   llms = '[Home](https://swarmbase.github.io/swarmbase/)',
+  llmsFull = '[Home](https://swarmbase.github.io/swarmbase/)',
   pages = {},
   repositoryDirectories = [],
   repositoryFiles = {},
@@ -58,6 +59,9 @@ function createFixture({
   }
 
   if (llms !== null) writeFileSync(join(directory, 'llms.txt'), llms);
+  if (llmsFull !== null) {
+    writeFileSync(join(directory, 'llms-full.txt'), llmsFull);
+  }
   return { directory, repositoryDirectory, root };
 }
 
@@ -272,4 +276,44 @@ test('requires llms.txt in the built site', () => {
 
   assert.equal(result.status, 1, outputFor(result));
   assert.match(outputFor(result), /llms\.txt does not exist/);
+});
+
+test('resumes llms-full.txt validation after fenced examples', () => {
+  const result = check(
+    createFixture({
+      llmsFull: [
+        '[Guide](https://swarmbase.github.io/swarmbase/guide/#topic)',
+        '```md',
+        '[Example only](https://swarmbase.github.io/swarmbase/ignored/)',
+        '```',
+        '[Missing](https://swarmbase.github.io/swarmbase/missing/)',
+      ].join('\n'),
+      pages: { 'guide/index.html': '<h2 id="topic">Topic</h2>' },
+    }),
+  );
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /llms-full\.txt:.*missing target/);
+});
+
+test('rejects an unclosed fence in llms-full.txt', () => {
+  const result = check(
+    createFixture({
+      llmsFull: [
+        '[Home](https://swarmbase.github.io/swarmbase/)',
+        '```md',
+        '[Masked](https://swarmbase.github.io/swarmbase/missing/)',
+      ].join('\n'),
+    }),
+  );
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /llms-full\.txt:2: unclosed ``` fence/);
+});
+
+test('requires llms-full.txt in the built site', () => {
+  const result = check(createFixture({ llmsFull: null }));
+
+  assert.equal(result.status, 1, outputFor(result));
+  assert.match(outputFor(result), /llms-full\.txt does not exist/);
 });

--- a/site/scripts/generate-llms-full.mjs
+++ b/site/scripts/generate-llms-full.mjs
@@ -422,7 +422,7 @@ export function generateLlmsFull() {
     '# Swarmbase documentation site — full handwritten corpus',
     '',
     '> Concatenated hand-authored documentation pages plus the feature audit. Generated API detail and repository/package READMEs are indexed separately in llms.txt.',
-    '> Swarmbase is alpha software. Check capability claims against the feature audit and documented limitations.',
+    '> Swarmbase is under active development. Check capability claims against the feature audit and documented limitations.',
     '',
     ...sections.flatMap((section) => [section, '', '---', '']),
   ].join('\n');

--- a/site/scripts/generate-llms-full.mjs
+++ b/site/scripts/generate-llms-full.mjs
@@ -1,0 +1,439 @@
+#!/usr/bin/env node
+
+import {
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(import.meta.url);
+const root = resolve(dirname(scriptPath), '..', '..');
+const docsRoot = resolve(root, 'site/src/content/docs');
+const outputPath = resolve(root, 'site/dist/llms-full.txt');
+const siteRoot = new URL('https://swarmbase.github.io/swarmbase/');
+const repositoryRoot = new URL('https://github.com/swarmbase/swarmbase/');
+
+function repositoryPath(path) {
+  return relative(root, path).split(sep).join('/');
+}
+
+function pathIsInside(parent, path) {
+  const child = relative(parent, path);
+  return child !== '..' && !child.startsWith(`..${sep}`);
+}
+
+function collectMarkdown(directory) {
+  const files = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) files.push(...collectMarkdown(path));
+    else if (entry.isFile() && /\.mdx?$/.test(entry.name)) files.push(path);
+  }
+
+  return files;
+}
+
+function documentationOrder(path) {
+  const relativePath = relative(docsRoot, path).split(sep).join('/');
+  const sections = [
+    'index.',
+    'getting-started/',
+    'concepts/',
+    'cookbook/',
+    'reference/',
+    'community/',
+  ];
+  const section = sections.findIndex((prefix) =>
+    relativePath.startsWith(prefix),
+  );
+  const rank = section === -1 ? sections.length : section;
+  return `${String(rank).padStart(2, '0')}:${relativePath}`;
+}
+
+function splitFrontmatter(markdown) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(markdown);
+  if (!match) return { content: markdown, frontmatter: '' };
+  return {
+    content: markdown.slice(match[0].length),
+    frontmatter: match[1],
+  };
+}
+
+function unquote(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function titleFor(path, frontmatter, content) {
+  const frontmatterTitle = /^title:\s*(.+)$/m.exec(frontmatter)?.[1];
+  if (frontmatterTitle) return unquote(frontmatterTitle);
+
+  const heading = /^#\s+(.+)$/m.exec(content)?.[1];
+  return heading?.trim() ?? repositoryPath(path);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function protectFences(markdown, sourceName) {
+  const output = [];
+  const fences = [];
+  let active;
+
+  for (const [index, line] of markdown.split('\n').entries()) {
+    if (!active) {
+      const opening = /^([ \t]*)(`{3,}|~{3,})/.exec(line);
+      if (!opening) {
+        output.push(line);
+        continue;
+      }
+
+      const token = `\0SWARMBASE_FENCE_${fences.length}\0`;
+      if (markdown.includes(token)) {
+        throw new Error(`${sourceName}: fence placeholder collision`);
+      }
+      active = {
+        character: opening[2][0],
+        indent: opening[1],
+        length: opening[2].length,
+        lines: [line],
+        startLine: index + 1,
+        token,
+      };
+      output.push(`${active.indent}${token}`);
+      continue;
+    }
+
+    active.lines.push(line);
+    const closing = /^([ \t]*)(`+|~+)\s*$/.exec(line);
+    if (
+      closing &&
+      closing[2][0] === active.character &&
+      closing[2].length >= active.length
+    ) {
+      fences.push(active);
+      active = undefined;
+    }
+  }
+
+  if (active) {
+    throw new Error(
+      `${sourceName}:${active.startLine}: unclosed ${active.character.repeat(active.length)} fence`,
+    );
+  }
+
+  return { fences, markdown: output.join('\n') };
+}
+
+function restoreFences(markdown, fences, sourceName) {
+  let restored = markdown;
+
+  for (const fence of fences) {
+    let replacements = 0;
+    const placeholder = new RegExp(
+      `^([ \\t]*)${escapeRegExp(fence.token)}[ \\t]*$`,
+      'gm',
+    );
+    restored = restored.replace(placeholder, (_match, indent) => {
+      replacements += 1;
+      return fence.lines
+        .map((line) => {
+          if (!line) return '';
+          const content = line.startsWith(fence.indent)
+            ? line.slice(fence.indent.length)
+            : line;
+          return `${indent}${content}`;
+        })
+        .join('\n');
+    });
+    if (replacements !== 1) {
+      throw new Error(`${sourceName}: lost fenced code placeholder`);
+    }
+  }
+
+  if (restored.includes('\0SWARMBASE_FENCE_')) {
+    throw new Error(`${sourceName}: unrestored fenced code placeholder`);
+  }
+  return restored;
+}
+
+export function mapOutsideFences(
+  markdown,
+  transform,
+  sourceName = 'Markdown',
+) {
+  const protectedMarkdown = protectFences(markdown, sourceName);
+  const transformed = transform(protectedMarkdown.markdown);
+  return restoreFences(transformed, protectedMarkdown.fences, sourceName);
+}
+
+function attributeValue(attributes, name) {
+  const match = new RegExp(
+    `\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`,
+  ).exec(attributes);
+  return match?.[1] ?? match?.[2];
+}
+
+function dedent(markdown) {
+  const lines = markdown.replace(/^\s*\n|\n\s*$/g, '').split('\n');
+  const indents = lines
+    .filter((line) => line.trim())
+    .map((line) => /^ */.exec(line)?.[0].length ?? 0);
+  const indent = indents.length > 0 ? Math.min(...indents) : 0;
+  return lines.map((line) => line.slice(indent)).join('\n');
+}
+
+function removeMdxImports(markdown, sourceName) {
+  const output = [];
+  let importLine;
+
+  for (const [index, line] of markdown.split('\n').entries()) {
+    if (importLine === undefined && !/^\s*import\b/.test(line)) {
+      output.push(line);
+      continue;
+    }
+    if (importLine === undefined) importLine = index + 1;
+
+    if (/(?:from\s+)?['"][^'"]+['"]\s*;?\s*$/.test(line)) {
+      importLine = undefined;
+    }
+  }
+
+  if (importLine !== undefined) {
+    throw new Error(`${sourceName}:${importLine}: unclosed MDX import`);
+  }
+  return output.join('\n');
+}
+
+export function cleanMdx(markdown, sourceName = 'MDX') {
+  return mapOutsideFences(markdown, (chunk) => {
+    let clean = removeMdxImports(chunk, sourceName);
+
+    clean = clean.replace(
+      /^[ \t]*<Card\b([^>]*)>([\s\S]*?)^[ \t]*<\/Card>[ \t]*$/gm,
+      (_match, attributes, body) => {
+        const title = attributeValue(attributes, 'title');
+        return `${title ? `**${title}**\n\n` : ''}${dedent(body)}\n\n`;
+      },
+    );
+    clean = clean.replace(
+      /^[ \t]*<Aside\b([^>]*)>([\s\S]*?)^[ \t]*<\/Aside>[ \t]*$/gm,
+      (_match, attributes, body) => {
+        const title = attributeValue(attributes, 'title');
+        return `${title ? `**${title}**\n\n` : ''}${dedent(body)}\n\n`;
+      },
+    );
+    clean = clean.replace(
+      /<LinkButton\b([^>]*)>([\s\S]*?)<\/LinkButton>/g,
+      (_match, attributes, label) => {
+        const href = attributeValue(attributes, 'href');
+        const text = label.replace(/\s+/g, ' ').trim();
+        return href ? `- [${text}](${href})` : text;
+      },
+    );
+    clean = clean.replace(
+      /<\/?(?:Steps|CardGrid|SyncDemo)\b[^>]*>/g,
+      '',
+    );
+    clean = clean.replace(/\{\s*(['"])\s+\1\s*\}/g, '');
+
+    const component = /<\/?[A-Z][A-Za-z0-9.]*(?:\s|\/?>)/.exec(clean);
+    if (component) {
+      throw new Error(`unsupported MDX component ${component[0].trim()}`);
+    }
+
+    return clean;
+  }, sourceName);
+}
+
+function siteUrlFor(path) {
+  let route = relative(docsRoot, path).split(sep).join('/');
+  route = route.replace(/\.mdx?$/, '');
+  if (route === 'index') route = '';
+  else route = route.replace(/\/index$/, '');
+  return new URL(route ? `${route}/` : '', siteRoot);
+}
+
+function encodedRepositoryPath(path) {
+  return path.split('/').map(encodeURIComponent).join('/');
+}
+
+function repositoryUrlForPath(path, search = '', hash = '') {
+  const relativePath = repositoryPath(path);
+  if (relativePath === '..' || relativePath.startsWith('../')) {
+    throw new Error(`repository link escapes the checkout: ${path}`);
+  }
+
+  const kind = statSync(path).isDirectory() ? 'tree' : 'blob';
+  const url = new URL(
+    `${kind}/main/${encodedRepositoryPath(relativePath)}`,
+    repositoryRoot,
+  );
+  url.search = search;
+  url.hash = hash;
+  return url;
+}
+
+function sourceUrlFor(path) {
+  return pathIsInside(docsRoot, path)
+    ? siteUrlFor(path)
+    : repositoryUrlForPath(path);
+}
+
+function relativeTarget(sourcePath, href) {
+  if (href.startsWith('/') || href.startsWith('#') || href.startsWith('?')) {
+    return;
+  }
+
+  const pathPart = href.split(/[?#]/, 1)[0];
+  if (!pathPart) return;
+
+  try {
+    return resolve(dirname(sourcePath), decodeURIComponent(pathPart));
+  } catch {
+    throw new Error(`${repositoryPath(sourcePath)} has an invalid link: ${href}`);
+  }
+}
+
+function rewriteHref(href, sourcePath) {
+  if (/^[a-z][a-z\d+.-]*:/i.test(href) || href.startsWith('//')) return href;
+
+  if (!pathIsInside(docsRoot, sourcePath)) {
+    const base = new URL(
+      repositoryPath(sourcePath),
+      'https://repository.invalid/',
+    );
+    const parsed = new URL(href, base);
+    const targetPath = resolve(root, decodeURIComponent(parsed.pathname.slice(1)));
+    return repositoryUrlForPath(targetPath, parsed.search, parsed.hash).href;
+  }
+
+  const target = relativeTarget(sourcePath, href);
+  if (target && pathIsInside(docsRoot, target) && /\.mdx?$/.test(target)) {
+    const parsed = new URL(href, siteUrlFor(sourcePath));
+    const url = siteUrlFor(target);
+    url.search = parsed.search;
+    url.hash = parsed.hash;
+    return url.href;
+  }
+  if (target) {
+    try {
+      const stats = statSync(target);
+      if (stats.isFile() || stats.isDirectory()) {
+        const parsed = new URL(href, siteUrlFor(sourcePath));
+        return repositoryUrlForPath(target, parsed.search, parsed.hash).href;
+      }
+    } catch {
+      // Route-style documentation links do not map directly to source paths.
+    }
+  }
+
+  return new URL(href, siteUrlFor(sourcePath)).href;
+}
+
+export function rewriteMarkdownLinks(markdown, sourcePath) {
+  return mapOutsideFences(
+    markdown,
+    (chunk) => {
+      const inline =
+        /(!?\[[^\]\n]+\]\(\s*)(?:<([^>\n]+)>|([^\s)\n]+))((?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^\n)]*\)))?\s*\))/g;
+      const references =
+        /(^\s*\[[^\]\n]+\]:\s*)(?:<([^>\n]+)>|([^\s\n]+))/gm;
+
+      let rewritten = chunk.replace(
+        inline,
+        (_match, prefix, angled, plain, suffix) => {
+          const replacement = rewriteHref(angled ?? plain, sourcePath);
+          return `${prefix}${angled ? `<${replacement}>` : replacement}${suffix}`;
+        },
+      );
+      rewritten = rewritten.replace(
+        references,
+        (_match, prefix, angled, plain) => {
+          const replacement = rewriteHref(angled ?? plain, sourcePath);
+          return `${prefix}${angled ? `<${replacement}>` : replacement}`;
+        },
+      );
+      return rewritten;
+    },
+    repositoryPath(sourcePath),
+  );
+}
+
+function cleanContent(path) {
+  const raw = readFileSync(path, 'utf8');
+  const { content: withoutFrontmatter, frontmatter } = splitFrontmatter(raw);
+  const title = titleFor(path, frontmatter, withoutFrontmatter);
+  const sourceName = repositoryPath(path);
+  let content = withoutFrontmatter.replace(/^#\s+[^\n]+\n+/, '');
+
+  if (path.endsWith('.mdx')) content = cleanMdx(content, sourceName);
+  content = mapOutsideFences(
+    content,
+    (chunk) => chunk.replace(/^(#{1,5})(?=\s)/gm, '#$1'),
+    sourceName,
+  );
+  content = rewriteMarkdownLinks(content, path);
+  content = mapOutsideFences(
+    content,
+    (chunk) => chunk.replace(/\n{3,}/g, '\n\n'),
+    sourceName,
+  ).trim();
+
+  return { content, title };
+}
+
+export function generateLlmsFull() {
+  const siteSources = collectMarkdown(docsRoot)
+    .filter((path) => {
+      const relativePath = relative(docsRoot, path).split(sep).join('/');
+      return !relativePath.startsWith('reference/api/');
+    })
+    .sort((left, right) =>
+      documentationOrder(left).localeCompare(documentationOrder(right)),
+    );
+  const sources = [...siteSources, resolve(root, 'docs/feature-audit.md')];
+  const sections = sources.map((path) => {
+    const { content, title } = cleanContent(path);
+    const sourceLabel = pathIsInside(docsRoot, path)
+      ? 'Documentation page'
+      : 'Feature and verification audit';
+    return [
+      `## ${title}`,
+      '',
+      `Source: [${sourceLabel}](${sourceUrlFor(path).href})`,
+      '',
+      content,
+    ].join('\n');
+  });
+
+  const output = [
+    '# Swarmbase documentation site — full handwritten corpus',
+    '',
+    '> Concatenated hand-authored documentation pages plus the feature audit. Generated API detail and repository/package READMEs are indexed separately in llms.txt.',
+    '> Swarmbase is alpha software. Check capability claims against the feature audit and documented limitations.',
+    '',
+    ...sections.flatMap((section) => [section, '', '---', '']),
+  ].join('\n');
+
+  writeFileSync(outputPath, `${output.trimEnd()}\n`);
+  const lineCount = output.trimEnd().split('\n').length;
+  console.log(
+    `Generated ${outputPath} (${lineCount} lines from ${sources.length} sources)`,
+  );
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+  generateLlmsFull();
+}

--- a/site/scripts/generate-llms-full.test.mjs
+++ b/site/scripts/generate-llms-full.test.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  cleanMdx,
+  mapOutsideFences,
+  rewriteMarkdownLinks,
+} from './generate-llms-full.mjs';
+
+const repository = fileURLToPath(new URL('../..', import.meta.url));
+
+test('rejects an unclosed fenced block', () => {
+  assert.throws(
+    () =>
+      mapOutsideFences(
+        ['Before', '```ts', 'const value = true;'].join('\n'),
+        (markdown) => markdown,
+        'fixture.mdx',
+      ),
+    /fixture\.mdx:2: unclosed ``` fence/,
+  );
+});
+
+test('cleans MDX wrappers while preserving fenced content', () => {
+  const input = [
+    'import {',
+    '  Card,',
+    '  CardGrid,',
+    '  LinkButton,',
+    "} from '@astrojs/starlight/components';",
+    '',
+    '<CardGrid>',
+    '  <Card title="Example">',
+    '    Before.',
+    '',
+    '    ```ts',
+    "    import value from './value';",
+    "    const spacer = \"{' '}\";",
+    '    [Relative example](../inside-code/)',
+    '    ```',
+    '',
+    '    After.',
+    '  </Card>',
+    '</CardGrid>',
+    '',
+    '<LinkButton',
+    '  href="../guide/"',
+    '>',
+    '  Guide',
+    "</LinkButton>{' '}",
+  ].join('\n');
+
+  const output = cleanMdx(input, 'fixture.mdx');
+  const prose = output.replace(/```[\s\S]*?```/g, '');
+
+  assert.doesNotMatch(prose, /^import \{/m);
+  assert.doesNotMatch(prose, /<\/?(?:Card|CardGrid|LinkButton)\b/);
+  assert.doesNotMatch(prose, /\{\s*(['"])\s+\1\s*\}/);
+  assert.match(output, /\*\*Example\*\*\n\nBefore\./);
+  assert.match(
+    output,
+    /```ts\nimport value from '\.\/value';\nconst spacer = "\{' '\}";\n\[Relative example\]\(\.\.\/inside-code\/\)\n```/,
+  );
+  assert.match(output, /After\./);
+  assert.match(output, /- \[Guide\]\(\.\.\/guide\/\)/);
+});
+
+test('rewrites site links without changing fenced examples', () => {
+  const source = resolve(
+    repository,
+    'site/src/content/docs/concepts/architecture.md',
+  );
+  const output = rewriteMarkdownLinks(
+    [
+      '[Limitations](../limitations/)',
+      '[Audit](../../../../../docs/feature-audit.md)',
+      '```md',
+      '[Example](../kept-relative/)',
+      '```',
+    ].join('\n'),
+    source,
+  );
+
+  assert.match(
+    output,
+    /\[Limitations\]\(https:\/\/swarmbase\.github\.io\/swarmbase\/concepts\/limitations\/\)/,
+  );
+  assert.match(
+    output,
+    /\[Audit\]\(https:\/\/github\.com\/swarmbase\/swarmbase\/blob\/main\/docs\/feature-audit\.md\)/,
+  );
+  assert.match(output, /\[Example\]\(\.\.\/kept-relative\/\)/);
+});
+
+test('rewrites repository file, directory, and fragment links', () => {
+  const source = resolve(repository, 'docs/feature-audit.md');
+  const output = rewriteMarkdownLinks(
+    [
+      '[README](../README.md)',
+      '[Examples](../examples/)',
+      '[Section](#evidence)',
+    ].join('\n'),
+    source,
+  );
+
+  assert.match(
+    output,
+    /\[README\]\(https:\/\/github\.com\/swarmbase\/swarmbase\/blob\/main\/README\.md\)/,
+  );
+  assert.match(
+    output,
+    /\[Examples\]\(https:\/\/github\.com\/swarmbase\/swarmbase\/tree\/main\/examples\)/,
+  );
+  assert.match(
+    output,
+    /\[Section\]\(https:\/\/github\.com\/swarmbase\/swarmbase\/blob\/main\/docs\/feature-audit\.md#evidence\)/,
+  );
+});


### PR DESCRIPTION
## Summary

- generate `llms-full.txt` after every documentation-site build
- include every hand-authored site page plus the feature and verification audit
- preserve fenced code while converting Starlight MDX wrappers into readable Markdown
- rewrite page-relative links to canonical site or repository URLs
- validate links in both `llms.txt` and the generated full corpus

## Why

`llms.txt` is intentionally a concise index. Some coding tools benefit from a single, deeper documentation fetch, but a checked-in concatenation drifts whenever source documentation changes. Generating the corpus into `site/dist` keeps the deployed artifact synchronized without committing generated output.

The corpus is a practical machine-readable bundle, not a claim that generated API detail or every repository file is included. Those remain discoverable through `llms.txt`.

## Validation

- `node --test site/scripts/check-links.test.mjs site/scripts/generate-llms-full.test.mjs` (22 passing tests)
- `yarn workspace @swarmbase/site build` (250 pages and a 26-source corpus)
- `node site/scripts/check-links.mjs` (28,759 HTML links, 34 index links, and 151 corpus links; zero issues)
- local assertions across all 26 sources and 68 fenced code blocks
- deterministic regeneration check
- `git diff --check`

The focused change in this pull request is commit `16443622`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a generated `llms-full.txt` resource containing the site’s complete hand-authored documentation and feature audit.
  - The full documentation corpus is now produced automatically during site builds.

- **Documentation**
  - Added a link to the complete documentation corpus from `llms.txt`.
  - Improved documentation link validation, including support for code examples and clearer source-specific diagnostics.

- **Bug Fixes**
  - Documentation checks now validate both published Markdown resources and detect malformed fenced examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->