### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/swarmbase/swarmbase/security/code-scanning/8](https://github.com/swarmbase/swarmbase/security/code-scanning/8)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults unless overridden. The safest minimal fix here is:

```yml
permissions:
  contents: read
```

This matches CodeQL guidance and preserves existing behavior for checkout/build/test workflows. Keep the existing job-level `integration.permissions` block; it is already aligned and does not conflict.

**Where to change:** `.github/workflows/ci.yml`, near the top-level keys (`name`, `on`, `jobs`), inserting `permissions` between `on` and `jobs` (or anywhere at root level).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
