### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/swarmbase/swarmbase/security/code-scanning/3](https://github.com/swarmbase/swarmbase/security/code-scanning/3)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/ci.yml` so all jobs default to least privilege. The recommended minimal baseline is:

```yml
permissions:
  contents: read
```

This preserves existing functionality for checkout and read operations while removing reliance on mutable repository/org defaults. Since `integration` already has `permissions: contents: read`, it remains valid and does not need to change.  
Edit region: immediately after `on:` triggers (after line 7 in the provided snippet), before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
