### PR TITLE
Restore alpha safety boundaries

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Swarmbase is under active development. For questions and design exploration, use [GitHub Discussions](https://github.com/swarmbase/swarmbase/discussions).
+        Swarmbase is alpha software and is not production-ready. For questions and design exploration, use [GitHub Discussions](https://github.com/swarmbase/swarmbase/discussions).
 
         Report suspected vulnerabilities through [private vulnerability reporting](https://github.com/swarmbase/swarmbase/security/advisories/new), not this form. Never include credentials, signing keys, KEM keys, document keys, private payloads, or sensitive user data.
   - type: input

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Swarmbase
 
-Swarmbase is under active development. Contributions should distinguish implemented primitives from behavior verified end to end.
+Swarmbase is alpha software and is not production-ready. Contributions should distinguish implemented primitives from behavior verified end to end.
 
 Read the [full contributing guide](https://swarmbase.github.io/swarmbase/community/contributing/) before starting. It contains the repository map, exact setup commands, Docker readiness sequence, generated-documentation boundaries, and pull request expectations. The repository's [AGENTS.md](AGENTS.md) provides the same operational baseline for coding tools.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://swarmbase.github.io/swarmbase/community/contributing/)
 [![Docs](https://img.shields.io/badge/docs-swarmbase.github.io-4f46e5)](https://swarmbase.github.io/swarmbase/)
 
-Open-source TypeScript toolkit for encrypted, local-first CRDT documents that sync peer to peer. Build collaborative browser applications without a server seeing your data in plaintext.
+Open-source TypeScript toolkit for encrypted, local-first CRDT documents that sync peer to peer. Build collaborative browser applications without relay infrastructure seeing document plaintext.
 
+> **Alpha:** Swarmbase is not production-ready and may lose data or change APIs. The `@swarmbase/*` packages are not published to npm; use the source workspaces.
 
 **Documentation:** https://swarmbase.github.io/swarmbase/
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-Swarmbase is under active development. APIs and persisted formats may change. Security fixes are developed on the default branch; no release line currently receives backported fixes.
+Swarmbase is alpha software with no production-supported release. APIs and persisted formats may change, and the software must not be used for irreplaceable data. Security fixes are developed on the default branch; no release line currently receives backported fixes.
 
 ## Reporting a vulnerability
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,6 +2,8 @@
 
 > TypeScript toolkit for encrypted, local-first CRDT documents synchronized over peer-to-peer networks. Composes Yjs/Automerge CRDT libraries with libp2p networking, Helia content-addressed storage, ECDSA P-384 signing, and AES-GCM encryption.
 
+Swarmbase is alpha software and is not production-ready. The six `@swarmbase/*` libraries are source workspaces and are not published to npm.
+
 Use the feature audit and concept documentation as the authority for capability claims. A primitive test does not establish complete multi-peer behavior. Every capability must be verified by CI evidence.
 
 ## Start

--- a/site/scripts/generate-llms-full.mjs
+++ b/site/scripts/generate-llms-full.mjs
@@ -422,7 +422,7 @@ export function generateLlmsFull() {
     '# Swarmbase documentation site — full handwritten corpus',
     '',
     '> Concatenated hand-authored documentation pages plus the feature audit. Generated API detail and repository/package READMEs are indexed separately in llms.txt.',
-    '> Swarmbase is under active development. Check capability claims against the feature audit and documented limitations.',
+    '> Swarmbase is alpha software and is not production-ready. Check capability claims against the feature audit and documented limitations.',
     '',
     ...sections.flatMap((section) => [section, '', '---', '']),
   ].join('\n');

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -32,7 +32,10 @@ hero:
 import { Card, CardGrid, LinkButton } from '@astrojs/starlight/components';
 import SyncDemo from '../../components/SyncDemo.astro';
 
-
+:::caution[Alpha software]
+Swarmbase is not production-ready and may lose data or change APIs. The
+`@swarmbase/*` packages are source workspaces and are not published to npm.
+:::
 
 ## What is Swarmbase?
 


### PR DESCRIPTION
## Summary

- restore the visible alpha, production-readiness, data-loss, and unpublished-package boundaries in the README, contributing guide, and documentation landing page
- align the security policy and bug intake with the absence of a production-supported release
- expose the same boundary to coding tools through `llms.txt` and the generated full corpus
- narrow the README value proposition to document plaintext rather than the broader “your data”

## Why

Recent documentation updates left the repository entry points saying only that Swarmbase was under active development, while the project remains alpha software, is not production-ready, may lose data, and has no published `@swarmbase/*` packages. These limitations need to remain explicit wherever people or coding tools first evaluate the project.

## Validation

- `yarn workspace @swarmbase/site build` (250 pages and a 26-source agent corpus)
- `node site/scripts/check-links.mjs site/dist .` (28,759 HTML links, 34 index links, and 151 corpus links; zero issues)
- `node --test site/scripts/check-links.test.mjs site/scripts/generate-llms-full.test.mjs` (22 passing tests)
- parsed `.github/ISSUE_TEMPLATE/bug.yml` as YAML
- `git diff --check`

The focused change in this pull request is commit `4f84eb18`.
