### PR TITLE
Improve agent corpus generator diagnostics

### DIFF
--- a/site/scripts/generate-llms-full.mjs
+++ b/site/scripts/generate-llms-full.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import {
+  mkdirSync,
   readFileSync,
   readdirSync,
   statSync,
@@ -248,9 +249,11 @@ export function cleanMdx(markdown, sourceName = 'MDX') {
     );
     clean = clean.replace(/\{\s*(['"])\s+\1\s*\}/g, '');
 
-    const component = /<\/?[A-Z][A-Za-z0-9.]*(?:\s|\/?>)/.exec(clean);
+    const component = /<\/?([A-Z][A-Za-z0-9.]*)(?:\s|\/?>)/.exec(clean);
     if (component) {
-      throw new Error(`unsupported MDX component ${component[0].trim()}`);
+      throw new Error(
+        `${sourceName}: unsupported MDX component ${component[1]}`,
+      );
     }
 
     return clean;
@@ -301,8 +304,12 @@ function relativeTarget(sourcePath, href) {
 
   try {
     return resolve(dirname(sourcePath), decodeURIComponent(pathPart));
-  } catch {
-    throw new Error(`${repositoryPath(sourcePath)} has an invalid link: ${href}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `${repositoryPath(sourcePath)} has an invalid link ${href}: ${message}`,
+      { cause: error },
+    );
   }
 }
 
@@ -310,13 +317,24 @@ function rewriteHref(href, sourcePath) {
   if (/^[a-z][a-z\d+.-]*:/i.test(href) || href.startsWith('//')) return href;
 
   if (!pathIsInside(docsRoot, sourcePath)) {
-    const base = new URL(
-      repositoryPath(sourcePath),
-      'https://repository.invalid/',
-    );
-    const parsed = new URL(href, base);
-    const targetPath = resolve(root, decodeURIComponent(parsed.pathname.slice(1)));
-    return repositoryUrlForPath(targetPath, parsed.search, parsed.hash).href;
+    try {
+      const base = new URL(
+        repositoryPath(sourcePath),
+        'https://repository.invalid/',
+      );
+      const parsed = new URL(href, base);
+      const targetPath = resolve(
+        root,
+        decodeURIComponent(parsed.pathname.slice(1)),
+      );
+      return repositoryUrlForPath(targetPath, parsed.search, parsed.hash).href;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `${repositoryPath(sourcePath)} has an invalid repository link ${href}: ${message}`,
+        { cause: error },
+      );
+    }
   }
 
   const target = relativeTarget(sourcePath, href);
@@ -400,9 +418,11 @@ export function generateLlmsFull() {
       const relativePath = relative(docsRoot, path).split(sep).join('/');
       return !relativePath.startsWith('reference/api/');
     })
-    .sort((left, right) =>
-      documentationOrder(left).localeCompare(documentationOrder(right)),
-    );
+    .sort((left, right) => {
+      const leftOrder = documentationOrder(left);
+      const rightOrder = documentationOrder(right);
+      return leftOrder < rightOrder ? -1 : leftOrder > rightOrder ? 1 : 0;
+    });
   const sources = [...siteSources, resolve(root, 'docs/feature-audit.md')];
   const sections = sources.map((path) => {
     const { content, title } = cleanContent(path);
@@ -427,6 +447,7 @@ export function generateLlmsFull() {
     ...sections.flatMap((section) => [section, '', '---', '']),
   ].join('\n');
 
+  mkdirSync(dirname(outputPath), { recursive: true });
   writeFileSync(outputPath, `${output.trimEnd()}\n`);
   const lineCount = output.trimEnd().split('\n').length;
   console.log(

--- a/site/scripts/generate-llms-full.test.mjs
+++ b/site/scripts/generate-llms-full.test.mjs
@@ -66,6 +66,17 @@ test('cleans MDX wrappers while preserving fenced content', () => {
   assert.match(output, /- \[Guide\]\(\.\.\/guide\/\)/);
 });
 
+test('names the source containing an unsupported MDX component', () => {
+  assert.throws(
+    () => cleanMdx('<Unsupported />', 'docs/example.mdx'),
+    /docs\/example\.mdx: unsupported MDX component Unsupported/,
+  );
+  assert.throws(
+    () => cleanMdx('<Unsupported>content</Unsupported>', 'docs/example.mdx'),
+    /docs\/example\.mdx: unsupported MDX component Unsupported/,
+  );
+});
+
 test('rewrites site links without changing fenced examples', () => {
   const source = resolve(
     repository,
@@ -115,5 +126,35 @@ test('rewrites repository file, directory, and fragment links', () => {
   assert.match(
     output,
     /\[Section\]\(https:\/\/github\.com\/swarmbase\/swarmbase\/blob\/main\/docs\/feature-audit\.md#evidence\)/,
+  );
+});
+
+test('names the source and href for a missing repository link', () => {
+  const source = resolve(repository, 'docs/feature-audit.md');
+
+  assert.throws(
+    () => rewriteMarkdownLinks('[Missing](../not-here.md)', source),
+    /docs\/feature-audit\.md has an invalid repository link \.\.\/not-here\.md:.*not-here\.md/,
+  );
+});
+
+test('names the source and href for malformed repository encoding', () => {
+  const source = resolve(repository, 'docs/feature-audit.md');
+
+  assert.throws(
+    () => rewriteMarkdownLinks('[Bad](../bad%ZZ.md)', source),
+    /docs\/feature-audit\.md has an invalid repository link \.\.\/bad%ZZ\.md: URI malformed/,
+  );
+});
+
+test('names the source and href for malformed documentation encoding', () => {
+  const source = resolve(
+    repository,
+    'site/src/content/docs/concepts/architecture.md',
+  );
+
+  assert.throws(
+    () => rewriteMarkdownLinks('[Bad](../bad%ZZ.md)', source),
+    /site\/src\/content\/docs\/concepts\/architecture\.md has an invalid link \.\.\/bad%ZZ\.md: URI malformed/,
   );
 });


### PR DESCRIPTION
## Summary

- include the source document and original target in corpus-generation failures, including malformed URL encoding
- use locale-independent ordering and create the output directory for direct runs
- cover the new diagnostics with focused tests

## Validation

- `node --check site/scripts/generate-llms-full.mjs`
- `node --test site/scripts/check-links.test.mjs site/scripts/generate-llms-full.test.mjs` (26 tests)
- `yarn workspace @swarmbase/site build` (250 pages; 26-source corpus)
- `node site/scripts/check-links.mjs` (28,759 HTML links; 34 agent-index links; 151 corpus links)
- `git diff --check`

Commit: `64518819`
