### PR TITLE
ESM migration: switch tsconfig to NodeNext module resolution

### DIFF
--- a/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
+++ b/packages/collabswarm-automerge/src/collabswarm-automerge.test.ts
@@ -8,7 +8,7 @@ import {
   AutomergeJSONSerializer,
   serializeKey,
   deserializeKey,
-} from './collabswarm-automerge';
+} from './collabswarm-automerge.js';
 
 // ECDSA P-384 JWK test keys (public only - ACL uses raw export which requires public keys)
 const publicKeyData1 = {

--- a/packages/collabswarm-automerge/tsconfig.json
+++ b/packages/collabswarm-automerge/tsconfig.json
@@ -18,7 +18,8 @@
   },
   "exclude": [
     "node_modules",
-    "extras"
+    "extras",
+    "src/**/*.test.ts"
   ],
   "include": [
     "src",

--- a/packages/collabswarm-automerge/tsconfig.json
+++ b/packages/collabswarm-automerge/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,
     "downlevelIteration": true,

--- a/packages/collabswarm-index/src/blind-index-query.test.ts
+++ b/packages/collabswarm-index/src/blind-index-query.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeAll } from '@jest/globals';
-import { SubtleBlindIndexProvider } from './subtle-blind-index-provider';
-import { BlindIndexQuery, BlindIndexEntry } from './blind-index-query';
+import { SubtleBlindIndexProvider } from './subtle-blind-index-provider.js';
+import { BlindIndexQuery, BlindIndexEntry } from './blind-index-query.js';
 
 describe('BlindIndexQuery', () => {
   let provider: SubtleBlindIndexProvider;

--- a/packages/collabswarm-index/src/bloom-filter-crdt.test.ts
+++ b/packages/collabswarm-index/src/bloom-filter-crdt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { BloomFilterCRDT } from './bloom-filter-crdt';
+import { BloomFilterCRDT } from './bloom-filter-crdt.js';
 
 describe('BloomFilterCRDT', () => {
   describe('add and has', () => {

--- a/packages/collabswarm-index/src/bloom-filter-gossip.test.ts
+++ b/packages/collabswarm-index/src/bloom-filter-gossip.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, jest as jestFn } from '@jest/globals';
-import { BloomFilterGossip } from './bloom-filter-gossip';
+import { BloomFilterGossip } from './bloom-filter-gossip.js';
 import { bloomFilterUpdateV1 } from '@swarmbase/collabswarm';
 
 type MockFn = ReturnType<typeof jestFn.fn>;

--- a/packages/collabswarm-index/src/collabswarm-index-integration.test.ts
+++ b/packages/collabswarm-index/src/collabswarm-index-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, beforeEach } from '@jest/globals';
-import { CollabswarmIndexIntegration, SubscribableDocument } from './collabswarm-index-integration';
-import { IndexManager } from './index-manager';
-import { MemoryIndexStorage } from './memory-index-storage';
+import { CollabswarmIndexIntegration, SubscribableDocument } from './collabswarm-index-integration.js';
+import { IndexManager } from './index-manager.js';
+import { MemoryIndexStorage } from './memory-index-storage.js';
 
 interface MockDoc {
   title: string;

--- a/packages/collabswarm-index/src/field-extractor.test.ts
+++ b/packages/collabswarm-index/src/field-extractor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { extractField } from './field-extractor';
+import { extractField } from './field-extractor.js';
 
 describe('extractField', () => {
   test.each([

--- a/packages/collabswarm-index/src/idb-index-storage.test.ts
+++ b/packages/collabswarm-index/src/idb-index-storage.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, beforeEach, afterEach } from '@jest/globals';
 import 'fake-indexeddb/auto';
 import { openDB } from 'idb';
-import { IDBIndexStorage } from './idb-index-storage';
+import { IDBIndexStorage } from './idb-index-storage.js';
 
 describe('IDBIndexStorage', () => {
   let storage: IDBIndexStorage;

--- a/packages/collabswarm-index/src/index-manager.test.ts
+++ b/packages/collabswarm-index/src/index-manager.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, beforeEach } from '@jest/globals';
-import { IndexManager } from './index-manager';
-import { MemoryIndexStorage } from './memory-index-storage';
-import { IndexDefinition } from './types';
+import { IndexManager } from './index-manager.js';
+import { MemoryIndexStorage } from './memory-index-storage.js';
+import { IndexDefinition } from './types.js';
 
 async function waitFor(condition: () => Promise<boolean>, timeoutMs: number = 2000): Promise<void> {
   const start = Date.now();

--- a/packages/collabswarm-index/src/memory-index-storage.test.ts
+++ b/packages/collabswarm-index/src/memory-index-storage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeEach } from '@jest/globals';
-import { MemoryIndexStorage } from './memory-index-storage';
-import { FieldFilter } from './types';
+import { MemoryIndexStorage } from './memory-index-storage.js';
+import { FieldFilter } from './types.js';
 
 describe('MemoryIndexStorage', () => {
   let storage: MemoryIndexStorage;

--- a/packages/collabswarm-index/src/react.test.ts
+++ b/packages/collabswarm-index/src/react.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, beforeEach } from '@jest/globals';
-import { IndexManager } from './index-manager';
-import { MemoryIndexStorage } from './memory-index-storage';
-import { QueryResult } from './types';
+import { IndexManager } from './index-manager.js';
+import { MemoryIndexStorage } from './memory-index-storage.js';
+import { QueryResult } from './types.js';
 
 // We test the hooks' backing logic by directly exercising IndexManager's
 // subscribe()/defineIndex()/removeIndex() — the same primitives the hooks
@@ -74,12 +74,12 @@ function subscribeAndWait<T extends Record<string, unknown>>(
 
 describe('React hooks (module surface)', () => {
   test('useIndexQuery should be exported as a function', async () => {
-    const mod = await import('./react');
+    const mod = await import('./react.js');
     expect(typeof mod.useIndexQuery).toBe('function');
   });
 
   test('useDefineIndexes should be exported as a function', async () => {
-    const mod = await import('./react');
+    const mod = await import('./react.js');
     expect(typeof mod.useDefineIndexes).toBe('function');
   });
 });

--- a/packages/collabswarm-index/src/subtle-blind-index-provider.test.ts
+++ b/packages/collabswarm-index/src/subtle-blind-index-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeAll } from '@jest/globals';
-import { SubtleBlindIndexProvider } from './subtle-blind-index-provider';
+import { SubtleBlindIndexProvider } from './subtle-blind-index-provider.js';
 
 describe('SubtleBlindIndexProvider', () => {
   let provider: SubtleBlindIndexProvider;

--- a/packages/collabswarm-index/tsconfig.json
+++ b/packages/collabswarm-index/tsconfig.json
@@ -19,7 +19,8 @@
   "exclude": [
     "node_modules",
     "examples",
-    "extras"
+    "extras",
+    "src/**/*.test.ts"
   ],
   "include": [
     "src",

--- a/packages/collabswarm-index/tsconfig.json
+++ b/packages/collabswarm-index/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,
     "downlevelIteration": true,

--- a/packages/collabswarm-react/src/hooks-advanced.test.ts
+++ b/packages/collabswarm-react/src/hooks-advanced.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, jest, afterEach } from '@jest/globals';
 import React, { useState } from 'react';
 import { render, act, cleanup, waitFor } from '@testing-library/react';
-import { openTaskResults, subscriberCounts } from './hooks-cache';
+import { openTaskResults, subscriberCounts } from './hooks-cache.js';
 import {
   resetCaches,
   createMockDocument,
@@ -9,7 +9,7 @@ import {
   createMockCollabswarmMultiDoc,
   TestProvider,
   TestConsumer,
-} from './test-utils';
+} from './test-utils.js';
 
 // ---------------------------------------------------------------------------
 // Tests: Subscription callback behavior

--- a/packages/collabswarm-react/src/hooks-cache.test.ts
+++ b/packages/collabswarm-react/src/hooks-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from '@jest/globals';
-import { openTasks, openTaskResults, subscriberCounts } from './hooks-cache';
+import { openTasks, openTaskResults, subscriberCounts } from './hooks-cache.js';
 
 function resetCaches() {
   openTasks.clear();

--- a/packages/collabswarm-react/src/hooks-lifecycle.test.ts
+++ b/packages/collabswarm-react/src/hooks-lifecycle.test.ts
@@ -8,7 +8,7 @@ import {
   createMockCollabswarm,
   TestProvider,
   TestConsumer,
-} from './test-utils';
+} from './test-utils.js';
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/packages/collabswarm-react/src/hooks.test.ts
+++ b/packages/collabswarm-react/src/hooks.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import React from 'react';
 import { render, act, waitFor } from '@testing-library/react';
-import { CollabswarmContext, useCollabswarm } from './hooks';
+import { CollabswarmContext, useCollabswarm } from './hooks.js';
 
 // ---------------------------------------------------------------------------
 // CollabswarmContext defaults

--- a/packages/collabswarm-react/tsconfig.json
+++ b/packages/collabswarm-react/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,
     "downlevelIteration": true,

--- a/packages/collabswarm-redux/src/reducers.test.ts
+++ b/packages/collabswarm-redux/src/reducers.test.ts
@@ -16,8 +16,8 @@ import {
   CHANGE_DOCUMENT,
   PEER_CONNECT,
   PEER_DISCONNECT,
-} from './actions';
-import { collabswarmReducer, CollabswarmState } from './reducers';
+} from './actions.js';
+import { collabswarmReducer, CollabswarmState } from './reducers.js';
 
 // Mock state with `as any` casts since the reducer only stores references.
 function createMockState(): CollabswarmState<any, any, any, any, any, any> {

--- a/packages/collabswarm-redux/tsconfig.json
+++ b/packages/collabswarm-redux/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,
     "downlevelIteration": true,

--- a/packages/collabswarm-yjs/src/collabswarm-yjs.test.ts
+++ b/packages/collabswarm-yjs/src/collabswarm-yjs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from '@jest/globals';
 import { Doc } from 'yjs';
 import { Base64 } from 'js-base64';
-import { YjsJSONSerializer } from './collabswarm-yjs';
+import { YjsJSONSerializer } from './collabswarm-yjs.js';
 
 // Test the core Yjs functionality that YjsProvider wraps
 describe('Yjs Core Functionality', () => {

--- a/packages/collabswarm-yjs/src/yjs-provider.test.ts
+++ b/packages/collabswarm-yjs/src/yjs-provider.test.ts
@@ -7,7 +7,7 @@ import {
   YjsKeychain,
   YjsKeychainProvider,
   YjsJSONSerializer,
-} from './collabswarm-yjs';
+} from './collabswarm-yjs.js';
 
 // ECDSA P-384 test keys (extractable, verify-only)
 const publicKeyData1 = {

--- a/packages/collabswarm-yjs/tsconfig.json
+++ b/packages/collabswarm-yjs/tsconfig.json
@@ -19,7 +19,8 @@
   "exclude": [
     "node_modules",
     "examples",
-    "extras"
+    "extras",
+    "src/**/*.test.ts"
   ],
   "include": [
     "src",

--- a/packages/collabswarm-yjs/tsconfig.json
+++ b/packages/collabswarm-yjs/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,
     "downlevelIteration": true,

--- a/packages/collabswarm/src/acl-chain.test.ts
+++ b/packages/collabswarm/src/acl-chain.test.ts
@@ -7,8 +7,8 @@ import {
   ACLState,
   canonicalEntryPayload,
   computeEntryHash,
-} from './acl-chain';
-import { SubtleCrypto } from './auth-subtlecrypto';
+} from './acl-chain.js';
+import { SubtleCrypto } from './auth-subtlecrypto.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures and helpers

--- a/packages/collabswarm/src/auth-subtlecrypto.test.ts
+++ b/packages/collabswarm/src/auth-subtlecrypto.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from '@jest/globals';
-import { SubtleCrypto } from './auth-subtlecrypto';
-import type { AesAlgorithmName } from './auth-provider';
-import { importSymmetricKey } from './utils';
+import { SubtleCrypto } from './auth-subtlecrypto.js';
+import type { AesAlgorithmName } from './auth-provider.js';
+import { importSymmetricKey } from './utils.js';
 
 const auth = new SubtleCrypto();
 

--- a/packages/collabswarm/src/beekem-pending-welcomes.test.ts
+++ b/packages/collabswarm/src/beekem-pending-welcomes.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from '@jest/globals';
-import { CRDTSyncMessage } from './crdt-sync-message';
+import { CRDTSyncMessage } from './crdt-sync-message.js';
 import {
   evaluateBeeKEMWelcome,
   WelcomeValidationDeps,
-} from './beekem-welcome-handler';
-import { SyncMessageSerializer } from './sync-message-serializer';
+} from './beekem-welcome-handler.js';
+import { SyncMessageSerializer } from './sync-message-serializer.js';
 
 /**
  * Unit-level coverage for the pending-welcomes buffer + drain semantics

--- a/packages/collabswarm/src/beekem-revocation-wire.test.ts
+++ b/packages/collabswarm/src/beekem-revocation-wire.test.ts
@@ -39,8 +39,8 @@
  */
 
 import { describe, expect, test } from '@jest/globals';
-import { BeeKEM } from './beekem/beekem';
-import { eciesOpen, eciesSeal, generateEciesKeyPair } from './ecies';
+import { BeeKEM } from './beekem/beekem.js';
+import { eciesOpen, eciesSeal, generateEciesKeyPair } from './ecies.js';
 
 /**
  * Re-import a raw SEC1 P-256 public key with `extractable=true` so
@@ -61,15 +61,15 @@ async function importExtractableKemPublicKey(
 import {
   deriveDocumentKeyFromRootSecret,
   deriveEpochIdFromRootSecret,
-} from './derive-doc-key';
+} from './derive-doc-key.js';
 import {
   deserializePathUpdateFromWire,
   serializePathUpdateForWire,
-} from './path-update-wire';
+} from './path-update-wire.js';
 import {
   decodeWelcomeSealedPayload,
   encodeWelcomeSealedPayload,
-} from './welcome-sealed-payload';
+} from './welcome-sealed-payload.js';
 
 function toBuffer(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
   const out = new Uint8Array(bytes.byteLength);

--- a/packages/collabswarm/src/beekem-revocation.test.ts
+++ b/packages/collabswarm/src/beekem-revocation.test.ts
@@ -17,15 +17,15 @@
  */
 
 import { describe, expect, test } from '@jest/globals';
-import { BeeKEM } from './beekem/beekem';
+import { BeeKEM } from './beekem/beekem.js';
 import {
   deriveDocumentKeyFromRootSecret,
   deriveEpochIdFromRootSecret,
-} from './derive-doc-key';
+} from './derive-doc-key.js';
 import {
   deserializePathUpdateFromWire,
   serializePathUpdateForWire,
-} from './path-update-wire';
+} from './path-update-wire.js';
 
 const ECDH_ALGO = { name: 'ECDH', namedCurve: 'P-256' };
 

--- a/packages/collabswarm/src/beekem-welcome-encryption.test.ts
+++ b/packages/collabswarm/src/beekem-welcome-encryption.test.ts
@@ -5,7 +5,7 @@ import {
   generateEciesKeyPair,
   importEciesPublicKey,
   exportEciesPublicKey,
-} from './ecies';
+} from './ecies.js';
 
 /**
  * Wire-level coverage of the BeeKEM Welcome payload encryption flow.

--- a/packages/collabswarm/src/beekem-welcome-handler.test.ts
+++ b/packages/collabswarm/src/beekem-welcome-handler.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from '@jest/globals';
-import { CRDTSyncMessage } from './crdt-sync-message';
-import { SyncMessageSerializer } from './sync-message-serializer';
+import { CRDTSyncMessage } from './crdt-sync-message.js';
+import { SyncMessageSerializer } from './sync-message-serializer.js';
 import {
   evaluateBeeKEMWelcome,
   WelcomeValidationDeps,
-} from './beekem-welcome-handler';
+} from './beekem-welcome-handler.js';
 
 /**
  * Direct unit-test coverage for the security-critical gates of the

--- a/packages/collabswarm/src/beekem-welcome-wire.test.ts
+++ b/packages/collabswarm/src/beekem-welcome-wire.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from '@jest/globals';
-import { BeeKEM } from './beekem/beekem';
+import { BeeKEM } from './beekem/beekem.js';
 import {
   deserializeBeeKEMWelcomeFromWire,
   serializeBeeKEMWelcomeForWire,
-} from './beekem-welcome-wire';
+} from './beekem-welcome-wire.js';
 import {
   decodeWelcomeSealedPayload,
   encodeWelcomeSealedPayload,
-} from './welcome-sealed-payload';
+} from './welcome-sealed-payload.js';
 
 /**
  * Wire round-trip coverage for the BeeKEM Welcome wire shape and the

--- a/packages/collabswarm/src/beekem-welcome.test.ts
+++ b/packages/collabswarm/src/beekem-welcome.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { CRDTSyncMessage } from './crdt-sync-message';
+import { CRDTSyncMessage } from './crdt-sync-message.js';
 
 /**
  * Unit-level coverage for the BeeKEM Welcome receive flow.

--- a/packages/collabswarm/src/beekem/beekem.test.ts
+++ b/packages/collabswarm/src/beekem/beekem.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { BeeKEM } from './beekem';
+import { BeeKEM } from './beekem.js';
 
 const ECDH_ALGO = { name: 'ECDH', namedCurve: 'P-256' };
 

--- a/packages/collabswarm/src/beekem/tree-math.test.ts
+++ b/packages/collabswarm/src/beekem/tree-math.test.ts
@@ -12,7 +12,7 @@ import {
   leafToNodeIndex,
   nodeToLeafIndex,
   copath,
-} from './tree-math';
+} from './tree-math.js';
 
 describe('isLeaf / isInternal', () => {
   test.each([

--- a/packages/collabswarm/src/blockstore-gc.test.ts
+++ b/packages/collabswarm/src/blockstore-gc.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from '@jest/globals';
-import { collectTreeCIDs, filterDeletableCIDs } from './blockstore-gc';
+import { collectTreeCIDs, filterDeletableCIDs } from './blockstore-gc.js';
 import {
   CRDTChangeNode,
   crdtDocumentChangeNode,
   crdtReaderChangeNode,
   crdtWriterChangeNode,
   crdtChangeNodeDeferred,
-} from './crdt-change-node';
+} from './crdt-change-node.js';
 
 type Changes = Uint8Array;
 

--- a/packages/collabswarm/src/capabilities.test.ts
+++ b/packages/collabswarm/src/capabilities.test.ts
@@ -7,7 +7,7 @@ import {
   capabilityImplies,
   isFieldCapability,
   getFieldPath,
-} from './capabilities';
+} from './capabilities.js';
 
 describe('capabilityImplies', () => {
   test.each([

--- a/packages/collabswarm/src/collabswarm.test.ts
+++ b/packages/collabswarm/src/collabswarm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { SubtleCrypto } from './auth-subtlecrypto';
+import { SubtleCrypto } from './auth-subtlecrypto.js';
 
 describe('Collabswarm crypto key generation', () => {
   const auth = new SubtleCrypto();

--- a/packages/collabswarm/src/compaction.test.ts
+++ b/packages/collabswarm/src/compaction.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, jest, test } from '@jest/globals';
 import {
   CompactionConfig,
   defaultCompactionConfig,
-} from './compaction-config';
-import { CRDTSnapshotNode } from './snapshot-node';
+} from './compaction-config.js';
+import { CRDTSnapshotNode } from './snapshot-node.js';
 import {
   isBlockNotFoundError,
   loadChangeBlock,
-} from './blockstore-gc';
+} from './blockstore-gc.js';
 
 describe('CompactionConfig', () => {
   test('default config has compaction disabled', () => {

--- a/packages/collabswarm/src/derive-doc-key.test.ts
+++ b/packages/collabswarm/src/derive-doc-key.test.ts
@@ -3,7 +3,7 @@ import {
   DOC_KEY_INFO,
   deriveDocumentKeyFromRootSecret,
   deriveEpochIdFromRootSecret,
-} from './derive-doc-key';
+} from './derive-doc-key.js';
 
 const ALGO = { name: 'AES-GCM' };
 

--- a/packages/collabswarm/src/document-topic.test.ts
+++ b/packages/collabswarm/src/document-topic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { documentTopic, DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic';
+import { documentTopic, DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic.js';
 
 describe('documentTopic', () => {
   test('uses /document/ prefix by default', () => {

--- a/packages/collabswarm/src/ecies.test.ts
+++ b/packages/collabswarm/src/ecies.test.ts
@@ -6,7 +6,7 @@ import {
   importEciesPublicKey,
   exportEciesPublicKey,
   ECIES_P256_PUBLIC_KEY_LENGTH,
-} from './ecies';
+} from './ecies.js';
 
 /**
  * Direct-unit tests for the ECIES sealed-box primitive.

--- a/packages/collabswarm/src/epoch.test.ts
+++ b/packages/collabswarm/src/epoch.test.ts
@@ -8,7 +8,7 @@ import {
   createEpoch,
   EpochManager,
   toHex,
-} from './epoch';
+} from './epoch.js';
 
 /** Helper: create a deterministic Uint8Array of the given length from a seed byte. */
 function makeBytes(length: number, seed: number): Uint8Array {

--- a/packages/collabswarm/src/json-serializer.test.ts
+++ b/packages/collabswarm/src/json-serializer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
-import { JSONSerializer } from './json-serializer';
-import { CRDTChangeBlock } from './crdt-change-block';
+import { JSONSerializer } from './json-serializer.js';
+import { CRDTChangeBlock } from './crdt-change-block.js';
 
 const jsonSerializer = new JSONSerializer<any>();
 

--- a/packages/collabswarm/src/load-quorum-orchestrator.test.ts
+++ b/packages/collabswarm/src/load-quorum-orchestrator.test.ts
@@ -35,9 +35,9 @@ import {
   beforeEach,
   afterEach,
 } from '@jest/globals';
-import { runLoadQuorum } from './load-quorum-orchestrator';
-import { dedupePeersByPeerId, LoadQuorumFailedError } from './load-quorum';
-import { tipsHashToHex } from './tips-hash';
+import { runLoadQuorum } from './load-quorum-orchestrator.js';
+import { dedupePeersByPeerId, LoadQuorumFailedError } from './load-quorum.js';
+import { tipsHashToHex } from './tips-hash.js';
 
 /**
  * Fixture hashes. Each is a 32-byte fixed-byte buffer so the hex form is

--- a/packages/collabswarm/src/load-quorum.test.ts
+++ b/packages/collabswarm/src/load-quorum.test.ts
@@ -10,7 +10,7 @@ import {
   LOAD_QUORUM_TIMEOUT_MS_MAX,
   LoadQuorumFailedError,
   validateLoadQuorumConfig,
-} from './load-quorum';
+} from './load-quorum.js';
 
 function bytes(hex: string): Uint8Array {
   if (hex.length % 2 !== 0) {

--- a/packages/collabswarm/src/lru-cache.test.ts
+++ b/packages/collabswarm/src/lru-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { LRUCache } from './lru-cache';
+import { LRUCache } from './lru-cache.js';
 
 describe('LRUCache', () => {
   test('get/set basic operations', () => {

--- a/packages/collabswarm/src/merkle-cross-links.test.ts
+++ b/packages/collabswarm/src/merkle-cross-links.test.ts
@@ -10,14 +10,14 @@ import {
   stripInlineChanges,
   trackTipInList,
   treeContainsCid,
-} from './merkle-cross-links';
+} from './merkle-cross-links.js';
 import {
   CRDTChangeNode,
   CRDTChangeNodeKind,
   crdtChangeNodeDeferred,
   crdtDocumentChangeNode,
   crdtWriterChangeNode,
-} from './crdt-change-node';
+} from './crdt-change-node.js';
 
 /**
  * Tests for the Merkle-CRDT cross-link selection helpers introduced in

--- a/packages/collabswarm/src/merkle-dag-serialization.test.ts
+++ b/packages/collabswarm/src/merkle-dag-serialization.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test } from '@jest/globals';
 import {
   CRDTChangeNode,
   crdtChangeNodeDeferred,
-} from './crdt-change-node';
+} from './crdt-change-node.js';
 import {
   CRDTChangeNodeWire,
   deserializeChangeNodeFromJSON,
   serializeChangeNodeForJSON,
-} from './merkle-dag-serialization';
+} from './merkle-dag-serialization.js';
 
 // --- Test encoders -------------------------------------------------------
 

--- a/packages/collabswarm/src/network-stats.test.ts
+++ b/packages/collabswarm/src/network-stats.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { NetworkStats } from './network-stats';
+import { NetworkStats } from './network-stats.js';
 
 describe('NetworkStats', () => {
   test('initial snapshot has all zero counters', () => {

--- a/packages/collabswarm/src/path-update-wire.test.ts
+++ b/packages/collabswarm/src/path-update-wire.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
-import { BeeKEM } from './beekem/beekem';
+import { BeeKEM } from './beekem/beekem.js';
 import {
   deserializePathUpdateFromWire,
   serializePathUpdateForWire,
-} from './path-update-wire';
+} from './path-update-wire.js';
 
 const ECDH_ALGO = { name: 'ECDH', namedCurve: 'P-256' };
 

--- a/packages/collabswarm/src/set-kem-key-pair.test.ts
+++ b/packages/collabswarm/src/set-kem-key-pair.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { validateAndExportKemKeyPair } from './kem-key-pair';
+import { validateAndExportKemKeyPair } from './kem-key-pair.js';
 
 /**
  * Validation coverage for the helper backing

--- a/packages/collabswarm/src/snapshot-node.test.ts
+++ b/packages/collabswarm/src/snapshot-node.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { CRDTSnapshotNode } from './snapshot-node';
+import { CRDTSnapshotNode } from './snapshot-node.js';
 
 describe('CRDTSnapshotNode', () => {
   test('can create a valid snapshot node', () => {

--- a/packages/collabswarm/src/tips-hash.test.ts
+++ b/packages/collabswarm/src/tips-hash.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
-import { tipsHash, tipsHashToHex, TIPS_HASH_LENGTH } from './tips-hash';
-import { constantTimeHexEquals } from './load-quorum';
+import { tipsHash, tipsHashToHex, TIPS_HASH_LENGTH } from './tips-hash.js';
+import { constantTimeHexEquals } from './load-quorum.js';
 
 describe('tipsHash (initial-load quorum, #189 §5.4.2)', () => {
   test('returns a 32-byte SHA-256 digest', async () => {

--- a/packages/collabswarm/src/ucan.test.ts
+++ b/packages/collabswarm/src/ucan.test.ts
@@ -6,7 +6,7 @@ import {
   deserializeUCAN,
   validateUCANChain,
   UCAN,
-} from './ucan';
+} from './ucan.js';
 
 /** Generate an ECDSA P-384 key pair for testing. */
 async function generateKeyPair(): Promise<CryptoKeyPair> {

--- a/packages/collabswarm/src/utils.test.ts
+++ b/packages/collabswarm/src/utils.test.ts
@@ -11,7 +11,7 @@ import {
   generateAndExportSymmetricKey,
   importHmacKey,
   importSymmetricKey,
-} from './utils';
+} from './utils.js';
 
 /**
  * Minimal Uint8ArrayList stand-in for testing. The real package is ESM-only

--- a/packages/collabswarm/tsconfig.json
+++ b/packages/collabswarm/tsconfig.json
@@ -15,7 +15,11 @@
     "outDir": "dist",
     "composite": true
   },
-  "exclude": ["node_modules", "examples", "extras",
-    "src/**/*.test.ts"],
+  "exclude": [
+    "node_modules",
+    "examples",
+    "extras",
+    "src/**/*.test.ts"
+  ],
   "include": ["src", "types", "bin"]
 }

--- a/packages/collabswarm/tsconfig.json
+++ b/packages/collabswarm/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,
     "downlevelIteration": true,
@@ -15,6 +15,7 @@
     "outDir": "dist",
     "composite": true
   },
-  "exclude": ["node_modules", "examples", "extras"],
+  "exclude": ["node_modules", "examples", "extras",
+    "src/**/*.test.ts"],
   "include": ["src", "types", "bin"]
 }


### PR DESCRIPTION
## Summary

Switches all six `@swarmbase/*` packages from `ESNext`/`Bundler` to `NodeNext`/`NodeNext` module resolution. This produces correct ESM-compatible `dist/**` output so that ESM-only dependencies (e.g. `uuid@^14`) work at runtime instead of triggering `ERR_REQUIRE_ESM`.

## Changes

### Commit 1: `.js` extensions on test imports (mechanical)
- Adds explicit `.js` extensions to 50 test files' relative import paths
- Required by NodeNext module resolution
- No-op with the current ESNext/Bundler configuration

### Commit 2: tsconfig switch
- Changes `module`/`moduleResolution` from `ESNext`/`Bundler` to `NodeNext`/`NodeNext` in all 6 packages
- Excludes `src/**/*.test.ts` from tsc compile in 4 packages that were emitting test fixtures into `dist/` (React and Redux already excluded theirs)

## Verification

| Command | Result |
|---|---|
| `yarn build` | Passes |
| `yarn test` (all 6 packages) | 1208 tests pass |
| `yarn test:relay` | 57 tests pass |
| `yarn build:examples` | All 3 example apps build |
| `yarn workspace @swarmbase/site build` | 250 pages built |
| `git diff --check` | Clean |

Fixes #286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated module resolution for improved compatibility with modern Node.js environments.
  * Standardized module imports across packages for more reliable compilation and execution.
  * Improved consistency across package builds without changing public functionality.

* **Tests**
  * Updated test imports to align with the standardized module resolution approach.
  * Existing test coverage, assertions, and behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->