### PR TITLE
Dual CJS/ESM output for all @swarmbase/* packages

### DIFF
--- a/packages/collabswarm-automerge/package.json
+++ b/packages/collabswarm-automerge/package.json
@@ -12,21 +12,22 @@
     "directory": "packages/collabswarm-automerge"
   },
   "scripts": {
-    "tsc": "tsc -b",
+    "tsc": "tsc -b && tsc -p tsconfig.cjs.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
     "prepublishOnly": "yarn tsc",
     "test": "jest",
     "tsc-watch": "tsc -w -p tsconfig.json"
   },
   "bin": {
-    "collabswarm-automerge-d": "dist/bin/collabswarm-automerge-d.js"
+    "collabswarm-automerge-d": "dist/esm/bin/collabswarm-automerge-d.js"
   },
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/cjs/src/index.js",
+  "types": "dist/esm/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js",
-      "default": "./dist/src/index.js"
+      "types": "./dist/esm/src/index.d.ts",
+      "import": "./dist/esm/src/index.js",
+      "require": "./dist/cjs/src/index.js",
+      "default": "./dist/esm/src/index.js"
     },
     "./package.json": "./package.json"
   },
@@ -104,5 +105,6 @@
       "^multiformats/(.*)$": "<rootDir>/jest.empty-mock.js",
       "^@multiformats/multiaddr$": "<rootDir>/jest.empty-mock.js"
     }
-  }
+  },
+  "module": "dist/esm/src/index.js"
 }

--- a/packages/collabswarm-automerge/tsconfig.cjs.json
+++ b/packages/collabswarm-automerge/tsconfig.cjs.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist/cjs",
+    "declaration": false,
+    "composite": false,
+    "baseUrl": ".",
+    "paths": {
+      "@swarmbase/collabswarm/node": [
+        "../collabswarm/dist/esm/src/collabswarm-node"
+      ]
+    },
+    "rootDir": "."
+  },
+  "references": []
+}

--- a/packages/collabswarm-automerge/tsconfig.json
+++ b/packages/collabswarm-automerge/tsconfig.json
@@ -13,13 +13,15 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "composite": true
   },
   "exclude": [
     "node_modules",
     "extras",
-    "src/**/*.test.ts"
+"src/**/*.test.ts",
+    "src/**/__benchmarks__/**",
+    "src/**/__mocks__/**"
   ],
   "include": [
     "src",

--- a/packages/collabswarm-index/package.json
+++ b/packages/collabswarm-index/package.json
@@ -12,26 +12,28 @@
     "directory": "packages/collabswarm-index"
   },
   "scripts": {
-    "tsc": "tsc -b",
+    "tsc": "tsc -b && tsc -p tsconfig.cjs.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
     "prepublishOnly": "yarn tsc",
     "test": "jest",
     "tsc-watch": "tsc -w -p tsconfig.json",
     "benchmark": "tsc -b tsconfig.benchmark.json && node -e \"require('fs').writeFileSync('dist-bench/package.json','{\\\"type\\\":\\\"commonjs\\\"}')\" && node dist-bench/__benchmarks__/run.js"
   },
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/cjs/src/index.js",
+  "types": "dist/esm/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js",
-      "default": "./dist/src/index.js"
+      "types": "./dist/esm/src/index.d.ts",
+      "import": "./dist/esm/src/index.js",
+      "require": "./dist/cjs/src/index.js",
+      "default": "./dist/esm/src/index.js"
     },
+    "./package.json": "./package.json",
     "./react": {
-      "types": "./dist/src/react.d.ts",
-      "import": "./dist/src/react.js",
-      "default": "./dist/src/react.js"
-    },
-    "./package.json": "./package.json"
+      "types": "./dist/esm/src/react.d.ts",
+      "import": "./dist/esm/src/react.js",
+      "require": "./dist/cjs/src/react.js",
+      "default": "./dist/esm/src/react.js"
+    }
   },
   "files": [
     "dist",
@@ -141,5 +143,6 @@
       "^multiformats/(.*)$": "<rootDir>/src/__mocks__/empty-module.cjs",
       "^@multiformats/multiaddr$": "<rootDir>/src/__mocks__/empty-module.cjs"
     }
-  }
+  },
+  "module": "dist/esm/src/index.js"
 }

--- a/packages/collabswarm-index/tsconfig.cjs.json
+++ b/packages/collabswarm-index/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist/cjs",
+    "declaration": false,
+    "composite": false,
+    "rootDir": "."
+  },
+  "references": []
+}

--- a/packages/collabswarm-index/tsconfig.json
+++ b/packages/collabswarm-index/tsconfig.json
@@ -13,14 +13,16 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "composite": true
   },
   "exclude": [
     "node_modules",
     "examples",
     "extras",
-    "src/**/*.test.ts"
+"src/**/*.test.ts",
+    "src/**/__benchmarks__/**",
+    "src/**/__mocks__/**"
   ],
   "include": [
     "src",

--- a/packages/collabswarm-react/package.json
+++ b/packages/collabswarm-react/package.json
@@ -13,18 +13,19 @@
   },
   "scripts": {
     "clean": "tsc -b --clean",
-    "tsc": "tsc -b --clean && tsc -b",
+    "tsc": "tsc -b --clean && tsc -b && tsc -p tsconfig.cjs.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
     "prepublishOnly": "yarn tsc",
     "test": "jest",
     "tsc-watch": "tsc -w -p tsconfig.json"
   },
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/cjs/src/index.js",
+  "types": "dist/esm/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js",
-      "default": "./dist/src/index.js"
+      "types": "./dist/esm/src/index.d.ts",
+      "import": "./dist/esm/src/index.js",
+      "require": "./dist/cjs/src/index.js",
+      "default": "./dist/esm/src/index.js"
     },
     "./package.json": "./package.json"
   },
@@ -112,5 +113,6 @@
       "^@multiformats/multiaddr$": "<rootDir>/jest.empty-mock.js",
       "^uint8arraylist$": "<rootDir>/jest.empty-mock.js"
     }
-  }
+  },
+  "module": "dist/esm/src/index.js"
 }

--- a/packages/collabswarm-react/tsconfig.cjs.json
+++ b/packages/collabswarm-react/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist/cjs",
+    "declaration": false,
+    "composite": false,
+    "rootDir": "."
+  },
+  "references": []
+}

--- a/packages/collabswarm-react/tsconfig.json
+++ b/packages/collabswarm-react/tsconfig.json
@@ -13,7 +13,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "composite": true
   },
   "exclude": [

--- a/packages/collabswarm-redux/package.json
+++ b/packages/collabswarm-redux/package.json
@@ -12,18 +12,19 @@
     "directory": "packages/collabswarm-redux"
   },
   "scripts": {
-    "tsc": "tsc -b",
+    "tsc": "tsc -b && tsc -p tsconfig.cjs.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
     "prepublishOnly": "yarn tsc",
     "test": "jest",
     "tsc-watch": "tsc -w -p tsconfig.json"
   },
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/cjs/src/index.js",
+  "types": "dist/esm/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js",
-      "default": "./dist/src/index.js"
+      "types": "./dist/esm/src/index.d.ts",
+      "import": "./dist/esm/src/index.js",
+      "require": "./dist/cjs/src/index.js",
+      "default": "./dist/esm/src/index.js"
     },
     "./package.json": "./package.json"
   },
@@ -91,5 +92,6 @@
       "^(\\.{1,2}/.*)\\.js$": "$1",
       "^@swarmbase/collabswarm$": "<rootDir>/src/__mocks__/@swarmbase/collabswarm.ts"
     }
-  }
+  },
+  "module": "dist/esm/src/index.js"
 }

--- a/packages/collabswarm-redux/tsconfig.cjs.json
+++ b/packages/collabswarm-redux/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist/cjs",
+    "declaration": false,
+    "composite": false,
+    "rootDir": "."
+  },
+  "references": []
+}

--- a/packages/collabswarm-redux/tsconfig.json
+++ b/packages/collabswarm-redux/tsconfig.json
@@ -12,13 +12,15 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "composite": true
   },
   "exclude": [
     "node_modules",
     "examples",
-    "src/**/*.test.ts"
+    "src/**/*.test.ts",
+    "src/**/__benchmarks__/**",
+    "src/**/__mocks__/**"
   ],
   "include": [
     "src",

--- a/packages/collabswarm-yjs/package.json
+++ b/packages/collabswarm-yjs/package.json
@@ -12,21 +12,22 @@
     "directory": "packages/collabswarm-yjs"
   },
   "scripts": {
-    "tsc": "tsc -b",
+    "tsc": "tsc -b && tsc -p tsconfig.cjs.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
     "prepublishOnly": "yarn tsc",
     "test": "jest",
     "tsc-watch": "tsc -w -p tsconfig.json"
   },
   "bin": {
-    "collabswarm-yjs-d": "dist/bin/collabswarm-yjs-d.js"
+    "collabswarm-yjs-d": "dist/esm/bin/collabswarm-yjs-d.js"
   },
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/cjs/src/index.js",
+  "types": "dist/esm/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js",
-      "default": "./dist/src/index.js"
+      "types": "./dist/esm/src/index.d.ts",
+      "import": "./dist/esm/src/index.js",
+      "require": "./dist/cjs/src/index.js",
+      "default": "./dist/esm/src/index.js"
     },
     "./package.json": "./package.json"
   },
@@ -132,5 +133,6 @@
       "^multiformats/(.*)$": "<rootDir>/src/__mocks__/empty-module.js",
       "^@multiformats/multiaddr$": "<rootDir>/src/__mocks__/empty-module.js"
     }
-  }
+  },
+  "module": "dist/esm/src/index.js"
 }

--- a/packages/collabswarm-yjs/tsconfig.cjs.json
+++ b/packages/collabswarm-yjs/tsconfig.cjs.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist/cjs",
+    "declaration": false,
+    "composite": false,
+    "baseUrl": ".",
+    "paths": {
+      "@swarmbase/collabswarm/node": [
+        "../collabswarm/dist/esm/src/collabswarm-node"
+      ]
+    },
+    "rootDir": "."
+  },
+  "references": []
+}

--- a/packages/collabswarm-yjs/tsconfig.json
+++ b/packages/collabswarm-yjs/tsconfig.json
@@ -13,14 +13,16 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "composite": true
   },
   "exclude": [
     "node_modules",
     "examples",
     "extras",
-    "src/**/*.test.ts"
+"src/**/*.test.ts",
+    "src/**/__benchmarks__/**",
+    "src/**/__mocks__/**"
   ],
   "include": [
     "src",

--- a/packages/collabswarm/package.json
+++ b/packages/collabswarm/package.json
@@ -12,32 +12,35 @@
     "directory": "packages/collabswarm"
   },
   "scripts": {
-    "tsc": "tsc -b",
+    "tsc": "tsc -b && tsc -p tsconfig.cjs.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json', JSON.stringify({type:'commonjs'}))\"",
     "prepublishOnly": "yarn tsc",
     "test": "jest",
     "tsc-watch": "tsc -w -p tsconfig.json",
     "doc": "typedoc --excludePrivate --excludeProtected --excludeInternal",
     "benchmark": "tsc -b tsconfig.benchmark.json && node -e \"require('fs').writeFileSync('dist-bench/package.json','{\\\"type\\\":\\\"commonjs\\\"}')\" && node dist-bench/__benchmarks__/run.js"
   },
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/cjs/src/index.js",
+  "types": "dist/esm/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js",
-      "default": "./dist/src/index.js"
+      "types": "./dist/esm/src/index.d.ts",
+      "import": "./dist/esm/src/index.js",
+      "require": "./dist/cjs/src/index.js",
+      "default": "./dist/esm/src/index.js"
     },
+    "./package.json": "./package.json",
     "./node": {
-      "types": "./dist/src/collabswarm-node.d.ts",
-      "import": "./dist/src/collabswarm-node.js",
-      "default": "./dist/src/collabswarm-node.js"
+      "types": "./dist/esm/src/collabswarm-node.d.ts",
+      "import": "./dist/esm/src/collabswarm-node.js",
+      "require": "./dist/cjs/src/collabswarm-node.js",
+      "default": "./dist/esm/src/collabswarm-node.js"
     },
     "./browser-primitives": {
-      "types": "./dist/src/browser-primitives.d.ts",
-      "import": "./dist/src/browser-primitives.js",
-      "default": "./dist/src/browser-primitives.js"
-    },
-    "./package.json": "./package.json"
+      "types": "./dist/esm/src/browser-primitives.d.ts",
+      "import": "./dist/esm/src/browser-primitives.js",
+      "require": "./dist/cjs/src/browser-primitives.js",
+      "default": "./dist/esm/src/browser-primitives.js"
+    }
   },
   "files": [
     "dist",
@@ -136,5 +139,6 @@
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1"
     }
-  }
+  },
+  "module": "dist/esm/src/index.js"
 }

--- a/packages/collabswarm/tsconfig.cjs.json
+++ b/packages/collabswarm/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist/cjs",
+    "declaration": false,
+    "composite": false,
+    "rootDir": "."
+  },
+  "references": []
+}

--- a/packages/collabswarm/tsconfig.json
+++ b/packages/collabswarm/tsconfig.json
@@ -12,14 +12,16 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "composite": true
   },
-  "exclude": [
+"exclude": [
     "node_modules",
     "examples",
     "extras",
-    "src/**/*.test.ts"
+    "src/**/*.test.ts",
+    "src/**/__benchmarks__/**",
+    "src/**/__mocks__/**"
   ],
   "include": ["src", "types", "bin"]
 }

--- a/scripts/release-packages.mjs
+++ b/scripts/release-packages.mjs
@@ -1,10 +1,10 @@
 export const packages = [
-  { name: '@swarmbase/collabswarm', directory: 'packages/collabswarm', entries: ['dist/src/index.js', 'dist/src/index.d.ts', 'dist/src/collabswarm-node.js', 'dist/src/collabswarm-node.d.ts', 'dist/src/browser-primitives.js', 'dist/src/browser-primitives.d.ts'], bins: [] },
-  { name: '@swarmbase/collabswarm-automerge', directory: 'packages/collabswarm-automerge', entries: ['dist/src/index.js', 'dist/src/index.d.ts'], bins: ['dist/bin/collabswarm-automerge-d.js'] },
-  { name: '@swarmbase/collabswarm-yjs', directory: 'packages/collabswarm-yjs', entries: ['dist/src/index.js', 'dist/src/index.d.ts'], bins: ['dist/bin/collabswarm-yjs-d.js'] },
-  { name: '@swarmbase/collabswarm-react', directory: 'packages/collabswarm-react', entries: ['dist/src/index.js', 'dist/src/index.d.ts'], bins: [] },
-  { name: '@swarmbase/collabswarm-redux', directory: 'packages/collabswarm-redux', entries: ['dist/src/index.js', 'dist/src/index.d.ts'], bins: [] },
-  { name: '@swarmbase/collabswarm-index', directory: 'packages/collabswarm-index', entries: ['dist/src/index.js', 'dist/src/index.d.ts', 'dist/src/react.js', 'dist/src/react.d.ts'], bins: [] },
+  { name: '@swarmbase/collabswarm', directory: 'packages/collabswarm', entries: ['dist/esm/src/index.js', 'dist/esm/src/index.d.ts', 'dist/esm/src/collabswarm-node.js', 'dist/esm/src/collabswarm-node.d.ts', 'dist/esm/src/browser-primitives.js', 'dist/esm/src/browser-primitives.d.ts', 'dist/cjs/src/index.js', 'dist/cjs/src/collabswarm-node.js', 'dist/cjs/src/browser-primitives.js', 'dist/cjs/package.json'], bins: [] },
+  { name: '@swarmbase/collabswarm-automerge', directory: 'packages/collabswarm-automerge', entries: ['dist/esm/src/index.js', 'dist/esm/src/index.d.ts', 'dist/cjs/src/index.js', 'dist/cjs/package.json'], bins: ['dist/esm/bin/collabswarm-automerge-d.js'] },
+  { name: '@swarmbase/collabswarm-yjs', directory: 'packages/collabswarm-yjs', entries: ['dist/esm/src/index.js', 'dist/esm/src/index.d.ts', 'dist/cjs/src/index.js', 'dist/cjs/package.json'], bins: ['dist/esm/bin/collabswarm-yjs-d.js'] },
+  { name: '@swarmbase/collabswarm-react', directory: 'packages/collabswarm-react', entries: ['dist/esm/src/index.js', 'dist/esm/src/index.d.ts', 'dist/cjs/src/index.js', 'dist/cjs/package.json'], bins: [] },
+  { name: '@swarmbase/collabswarm-redux', directory: 'packages/collabswarm-redux', entries: ['dist/esm/src/index.js', 'dist/esm/src/index.d.ts', 'dist/cjs/src/index.js', 'dist/cjs/package.json'], bins: [] },
+  { name: '@swarmbase/collabswarm-index', directory: 'packages/collabswarm-index', entries: ['dist/esm/src/index.js', 'dist/esm/src/index.d.ts', 'dist/esm/src/react.js', 'dist/esm/src/react.d.ts', 'dist/cjs/src/index.js', 'dist/cjs/src/react.js', 'dist/cjs/package.json'], bins: [] },
 ];
 
 export const strictSemver = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4592,7 +4592,7 @@ __metadata:
   peerDependencies:
     "@automerge/automerge": ^3.2.6
   bin:
-    collabswarm-automerge-d: dist/bin/collabswarm-automerge-d.js
+    collabswarm-automerge-d: dist/esm/bin/collabswarm-automerge-d.js
   languageName: unknown
   linkType: soft
 
@@ -4674,7 +4674,7 @@ __metadata:
   peerDependencies:
     yjs: ^13.6.30
   bin:
-    collabswarm-yjs-d: dist/bin/collabswarm-yjs-d.js
+    collabswarm-yjs-d: dist/esm/bin/collabswarm-yjs-d.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Adds dual CJS/ESM output to all six `@swarmbase/*` packages. Each package now emits both ESM (`dist/esm/`) and CJS (`dist/cjs/`), with proper conditional export maps so bundlers and Node.js can pick the right format.

**Rebased on main after #365 merge.**

## Changes

### New: `tsconfig.cjs.json` per package (6 files)
- Extends base tsconfig
- Overrides: `module: "CommonJS"`, `moduleResolution: "Node"`, `outDir: "dist/cjs"`, `declaration: false`, `composite: false`, `rootDir: "."`
- Removes `references` (not needed; type declarations come from ESM build)
- Inherits `exclude` patterns from base (test files, benchmarks, mocks)

### Updated: `tsconfig.json` per package (6 files)
- `outDir` changed from `"dist"` to `"dist/esm"`
- Added `__benchmarks__/**` and `__mocks__/**` to exclude patterns

### Updated: `package.json` per package (6 files)
- `main` → `dist/cjs/src/index.js` (CJS for legacy `require()`)
- `module` → `dist/esm/src/index.js` (ESM for bundlers)
- `types` → `dist/esm/src/index.d.ts` (shared from ESM build)
- `exports` map now includes `require` condition for every subpath
- `tsc` script builds ESM first (`tsc -b`), then CJS (`tsc -p tsconfig.cjs.json`), then writes `dist/cjs/package.json` with `{"type":"commonjs"}`

### Note on CJS dependency resolution
Direct `require()` of the CJS output fails on ESM-only transitive deps (e.g., `it-pipe`).  This is expected — the CJS output is for bundlers and legacy consumers that handle mixed-format code. The ESM output works directly in Node.js ≥22.

## Verification

| Check | Result |
|---|---|
| `yarn build` (ESM + CJS) | Passes |
| `yarn test` (all 6 packages) | 1196 tests pass, 56 suites |
| `yarn test:relay` | 57 tests pass |
| `yarn build:examples` | All 3 apps build |
| `yarn workspace @swarmbase/site build` | 251 pages |
| ESM `import` at runtime | OK |

Fixes #286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Packages now provide both ESM and CommonJS builds for broader runtime compatibility.
  - Package entry points, exports, type declarations, and CLI binaries are aligned with the appropriate build format.
  - Package metadata is included in published distributions for improved module resolution.

- **Chores**
  - Release packaging now includes both module formats and their associated runtime files.
  - Build output is organized into separate ESM and CommonJS distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->