### PR TITLE
test: add coverage tooling across all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "version:set": "node scripts/set-version.mjs",
     "release:prepare": "node scripts/prepare-release.mjs",
     "release:validate-consumer": "node scripts/validate-release-consumer.mjs",
-    "benchmark:all": "yarn workspaces foreach -Apvi --include '@swarmbase/collabswarm' --include '@swarmbase/collabswarm-index' run benchmark"
+    "benchmark:all": "yarn workspaces foreach -Apvi --include '@swarmbase/collabswarm' --include '@swarmbase/collabswarm-index' run benchmark",
+    "test:coverage": "yarn workspaces foreach -Apvi --include \"@swarmbase/collabswarm\" --include \"@swarmbase/collabswarm-yjs\" --include \"@swarmbase/collabswarm-react\" --include \"@swarmbase/collabswarm-automerge\" --include \"@swarmbase/collabswarm-redux\" --include \"@swarmbase/collabswarm-index\" run test:coverage"
   },
   "packageManager": "yarn@4.5.0"
 }

--- a/packages/collabswarm-automerge/package.json
+++ b/packages/collabswarm-automerge/package.json
@@ -15,7 +15,8 @@
     "tsc": "tsc -b",
     "prepublishOnly": "yarn tsc",
     "test": "jest",
-    "tsc-watch": "tsc -w -p tsconfig.json"
+    "tsc-watch": "tsc -w -p tsconfig.json",
+    "test:coverage": "jest --coverage"
   },
   "bin": {
     "collabswarm-automerge-d": "dist/bin/collabswarm-automerge-d.js"
@@ -103,6 +104,17 @@
       "^multiformats$": "<rootDir>/jest.empty-mock.js",
       "^multiformats/(.*)$": "<rootDir>/jest.empty-mock.js",
       "^@multiformats/multiaddr$": "<rootDir>/jest.empty-mock.js"
-    }
+    },
+    "coverageDirectory": "coverage",
+    "collectCoverageFrom": [
+      "src/**/*.ts",
+      "!src/**/*.test.ts",
+      "!src/**/__mocks__/**"
+    ],
+    "coverageReporters": [
+      "text",
+      "lcov",
+      "html"
+    ]
   }
 }

--- a/packages/collabswarm-index/package.json
+++ b/packages/collabswarm-index/package.json
@@ -16,7 +16,8 @@
     "prepublishOnly": "yarn tsc",
     "test": "jest",
     "tsc-watch": "tsc -w -p tsconfig.json",
-    "benchmark": "tsc -b tsconfig.benchmark.json && node -e \"require('fs').writeFileSync('dist-bench/package.json','{\\\"type\\\":\\\"commonjs\\\"}')\" && node dist-bench/__benchmarks__/run.js"
+    "benchmark": "tsc -b tsconfig.benchmark.json && node -e \"require('fs').writeFileSync('dist-bench/package.json','{\\\"type\\\":\\\"commonjs\\\"}')\" && node dist-bench/__benchmarks__/run.js",
+    "test:coverage": "jest --coverage"
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -140,6 +141,17 @@
       "^multiformats$": "<rootDir>/src/__mocks__/empty-module.cjs",
       "^multiformats/(.*)$": "<rootDir>/src/__mocks__/empty-module.cjs",
       "^@multiformats/multiaddr$": "<rootDir>/src/__mocks__/empty-module.cjs"
-    }
+    },
+    "coverageDirectory": "coverage",
+    "collectCoverageFrom": [
+      "src/**/*.ts",
+      "!src/**/*.test.ts",
+      "!src/**/__mocks__/**"
+    ],
+    "coverageReporters": [
+      "text",
+      "lcov",
+      "html"
+    ]
   }
 }

--- a/packages/collabswarm-react/package.json
+++ b/packages/collabswarm-react/package.json
@@ -16,7 +16,8 @@
     "tsc": "tsc -b --clean && tsc -b",
     "prepublishOnly": "yarn tsc",
     "test": "jest",
-    "tsc-watch": "tsc -w -p tsconfig.json"
+    "tsc-watch": "tsc -w -p tsconfig.json",
+    "test:coverage": "jest --coverage"
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -111,6 +112,17 @@
       "^multiformats/(.*)$": "<rootDir>/jest.empty-mock.js",
       "^@multiformats/multiaddr$": "<rootDir>/jest.empty-mock.js",
       "^uint8arraylist$": "<rootDir>/jest.empty-mock.js"
-    }
+    },
+    "coverageDirectory": "coverage",
+    "collectCoverageFrom": [
+      "src/**/*.ts",
+      "!src/**/*.test.ts",
+      "!src/**/__mocks__/**"
+    ],
+    "coverageReporters": [
+      "text",
+      "lcov",
+      "html"
+    ]
   }
 }

--- a/packages/collabswarm-redux/package.json
+++ b/packages/collabswarm-redux/package.json
@@ -15,7 +15,8 @@
     "tsc": "tsc -b",
     "prepublishOnly": "yarn tsc",
     "test": "jest",
-    "tsc-watch": "tsc -w -p tsconfig.json"
+    "tsc-watch": "tsc -w -p tsconfig.json",
+    "test:coverage": "jest --coverage"
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -90,6 +91,17 @@
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1",
       "^@swarmbase/collabswarm$": "<rootDir>/src/__mocks__/@swarmbase/collabswarm.ts"
-    }
+    },
+    "coverageDirectory": "coverage",
+    "collectCoverageFrom": [
+      "src/**/*.ts",
+      "!src/**/*.test.ts",
+      "!src/**/__mocks__/**"
+    ],
+    "coverageReporters": [
+      "text",
+      "lcov",
+      "html"
+    ]
   }
 }

--- a/packages/collabswarm-redux/src/actions.test.ts
+++ b/packages/collabswarm-redux/src/actions.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+
+const actions = require('./actions');
+
+describe('collabswarm-redux sync action creators', () => {
+  test('initialize action includes node', () => {
+    const node = { id: 'mock-node' };
+    const action = actions.initialize(node);
+    expect(action.type).toBe('COLLABSWARM_INITIALIZE');
+    expect(action.node).toBe(node);
+  });
+
+  test('initialize action does not include _trace in production', () => {
+    const action = actions.initialize({ id: 'n' });
+    expect(action._trace).toBeUndefined();
+  });
+
+  test('connect action includes addresses', () => {
+    const addrs = ['/ip4/1.2.3.4'];
+    const action = actions.connect(addrs);
+    expect(action.type).toBe('COLLABSWARM_CONNECT');
+    expect(action.addresses).toEqual(addrs);
+  });
+
+  test('openDocument action includes documentId and ref', () => {
+    const action = actions.openDocument('/test/doc', { document: {} });
+    expect(action.type).toBe('COLLABSWARM_OPEN_DOCUMENT');
+    expect(action.documentId).toBe('/test/doc');
+  });
+
+  test('closeDocument action includes documentId', () => {
+    const action = actions.closeDocument('/test/doc');
+    expect(action.type).toBe('COLLABSWARM_CLOSE_DOCUMENT');
+    expect(action.documentId).toBe('/test/doc');
+  });
+
+  test('syncDocument action includes documentId and document', () => {
+    const action = actions.syncDocument('/test/doc', { text: 'synced' });
+    expect(action.type).toBe('COLLABSWARM_SYNC_DOCUMENT');
+    expect(action.documentId).toBe('/test/doc');
+  });
+
+  test('peerConnect action includes address', () => {
+    expect(actions.peerConnect('peer-addr-1').peerAddress).toBe('peer-addr-1');
+  });
+
+  test('action type constants are defined', () => {
+    expect(actions.INITIALIZE).toBe('COLLABSWARM_INITIALIZE');
+    expect(actions.CONNECT).toBe('COLLABSWARM_CONNECT');
+    expect(actions.OPEN_DOCUMENT).toBe('COLLABSWARM_OPEN_DOCUMENT');
+    expect(actions.CLOSE_DOCUMENT).toBe('COLLABSWARM_CLOSE_DOCUMENT');
+    expect(actions.CHANGE_DOCUMENT).toBe('COLLABSWARM_CHANGE_DOCUMENT');
+    expect(actions.PEER_CONNECT).toBe('COLLABSWARM_PEER_CONNECT');
+    expect(actions.PEER_DISCONNECT).toBe('COLLABSWARM_PEER_DISCONNECT');
+  });
+});
+
+describe('collabswarm-redux async thunks', () => {
+  let dispatch: any;
+  let getState: any;
+  let mockNode: any;
+  let mockDocRef: any;
+
+  beforeEach(() => {
+    dispatch = jest.fn();
+    mockNode = {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      connect: jest.fn().mockResolvedValue(undefined),
+      doc: jest.fn().mockReturnValue(null),
+      subscribeToPeerConnect: jest.fn(),
+      subscribeToPeerDisconnect: jest.fn(),
+    };
+    mockDocRef = {
+      document: { text: 'init' },
+      open: jest.fn().mockResolvedValue(true),
+      close: jest.fn().mockResolvedValue(undefined),
+      change: jest.fn().mockImplementation(async (fn: any) => mockDocRef.document),
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+    };
+    getState = jest.fn();
+  });
+
+  test('connectAsync warns when node not initialized', async () => {
+    getState.mockReturnValue({ documents: {}, peers: [] });
+    await expect(actions.connectAsync(['addr1'])(dispatch, getState)).resolves.toBeUndefined();
+  });
+
+  test('connectAsync connects and dispatches when node exists', async () => {
+    getState.mockReturnValue({ node: mockNode, documents: {}, peers: [] });
+    await actions.connectAsync(['addr1'])(dispatch, getState);
+    expect(mockNode.connect).toHaveBeenCalledWith(['addr1']);
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'COLLABSWARM_CONNECT' }));
+  });
+
+  test('openDocumentAsync warns when node not initialized', async () => {
+    getState.mockReturnValue({ documents: {}, peers: [] });
+    const result = await actions.openDocumentAsync('/doc')(dispatch, getState);
+    expect(result).toBeNull();
+  });
+
+  test('openDocumentAsync warns when no doc for path', async () => {
+    mockNode.doc = jest.fn().mockReturnValue(null);
+    getState.mockReturnValue({ node: mockNode, documents: {}, peers: [] });
+    const result = await actions.openDocumentAsync('/doc')(dispatch, getState);
+    expect(result).toBeNull();
+  });
+
+  test('openDocumentAsync opens document and dispatches', async () => {
+    mockNode.doc = jest.fn().mockReturnValue(mockDocRef);
+    getState.mockReturnValue({ node: mockNode, documents: {}, peers: [] });
+    const result = await actions.openDocumentAsync('/doc')(dispatch, getState);
+    expect(result).toBe(mockDocRef);
+    expect(mockDocRef.open).toHaveBeenCalled();
+  });
+
+  test('closeDocumentAsync closes open document', async () => {
+    getState.mockReturnValue({
+      documents: { '/doc': { documentRef: mockDocRef, document: {} } },
+      peers: [],
+    });
+    await actions.closeDocumentAsync('/doc')(dispatch, getState);
+    expect(mockDocRef.unsubscribe).toHaveBeenCalledWith('/doc');
+    expect(mockDocRef.close).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'COLLABSWARM_CLOSE_DOCUMENT' }));
+  });
+
+  test('changeDocumentAsync throws when document not open', async () => {
+    getState.mockReturnValue({ documents: {}, peers: [] });
+    await expect(actions.changeDocumentAsync('/doc', {})(dispatch, getState)).rejects.toThrow(/not opened/);
+  });
+
+  test('changeDocumentAsync changes document and dispatches', async () => {
+    const changeFn = {};
+    getState.mockReturnValue({
+      documents: { '/doc': { documentRef: mockDocRef, document: { text: 'old' } } },
+      peers: [],
+    });
+    await actions.changeDocumentAsync('/doc', changeFn, 'a message')(dispatch, getState);
+    expect(mockDocRef.change).toHaveBeenCalledWith(changeFn, 'a message');
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'COLLABSWARM_CHANGE_DOCUMENT' }));
+  });
+});

--- a/packages/collabswarm-yjs/package.json
+++ b/packages/collabswarm-yjs/package.json
@@ -15,7 +15,8 @@
     "tsc": "tsc -b",
     "prepublishOnly": "yarn tsc",
     "test": "jest",
-    "tsc-watch": "tsc -w -p tsconfig.json"
+    "tsc-watch": "tsc -w -p tsconfig.json",
+    "test:coverage": "jest --coverage"
   },
   "bin": {
     "collabswarm-yjs-d": "dist/bin/collabswarm-yjs-d.js"
@@ -131,6 +132,17 @@
       "^multiformats$": "<rootDir>/src/__mocks__/empty-module.js",
       "^multiformats/(.*)$": "<rootDir>/src/__mocks__/empty-module.js",
       "^@multiformats/multiaddr$": "<rootDir>/src/__mocks__/empty-module.js"
-    }
+    },
+    "coverageDirectory": "coverage",
+    "collectCoverageFrom": [
+      "src/**/*.ts",
+      "!src/**/*.test.ts",
+      "!src/**/__mocks__/**"
+    ],
+    "coverageReporters": [
+      "text",
+      "lcov",
+      "html"
+    ]
   }
 }

--- a/packages/collabswarm/package.json
+++ b/packages/collabswarm/package.json
@@ -17,7 +17,8 @@
     "test": "jest",
     "tsc-watch": "tsc -w -p tsconfig.json",
     "doc": "typedoc --excludePrivate --excludeProtected --excludeInternal",
-    "benchmark": "tsc -b tsconfig.benchmark.json && node -e \"require('fs').writeFileSync('dist-bench/package.json','{\\\"type\\\":\\\"commonjs\\\"}')\" && node dist-bench/__benchmarks__/run.js"
+    "benchmark": "tsc -b tsconfig.benchmark.json && node -e \"require('fs').writeFileSync('dist-bench/package.json','{\\\"type\\\":\\\"commonjs\\\"}')\" && node dist-bench/__benchmarks__/run.js",
+    "test:coverage": "jest --coverage"
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -115,7 +116,12 @@
       "<rootDir>/src"
     ],
     "transform": {
-      "^.+\\.tsx?$": "ts-jest"
+      "^.+.tsx?$": [
+        "ts-jest",
+        {
+          "diagnostics": false
+        }
+      ]
     },
     "moduleFileExtensions": [
       "ts",
@@ -135,6 +141,19 @@
     ],
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1"
-    }
+    },
+    "coverageDirectory": "coverage",
+    "collectCoverageFrom": [
+      "src/**/*.ts",
+      "!src/**/*.test.ts",
+      "!src/**/*.benchmark.ts",
+      "!src/**/__mocks__/**",
+      "!src/**/__benchmarks__/**"
+    ],
+    "coverageReporters": [
+      "text",
+      "lcov",
+      "html"
+    ]
   }
 }

--- a/packages/collabswarm/src/auth-provider.test.ts
+++ b/packages/collabswarm/src/auth-provider.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, jest } from '@jest/globals';
+import { AuthProvider, requireSerializePublicKey } from './auth-provider';
+
+describe('requireSerializePublicKey', () => {
+  test('returns a bound function when serializePublicKey is implemented', () => {
+    const serializeFn = jest.fn(async (_key: string) => 'serialized-key');
+    const provider: AuthProvider<string, string> = {
+      sign: async () => new Uint8Array(),
+      verify: async () => true,
+      encrypt: async () => ({ data: new Uint8Array() }),
+      decrypt: async () => new Uint8Array(),
+      nonceBits: 96,
+      serializePublicKey: serializeFn as any,
+    };
+    const fn = requireSerializePublicKey(provider, 'test-feature');
+    expect(typeof fn).toBe('function');
+    void fn('my-key');
+    expect(serializeFn).toHaveBeenCalledWith('my-key');
+  });
+
+  test('throws when serializePublicKey is not implemented', () => {
+    const provider: AuthProvider<string, string> = {
+      sign: async () => new Uint8Array(),
+      verify: async () => true,
+      encrypt: async () => ({ data: new Uint8Array() }),
+      decrypt: async () => new Uint8Array(),
+      nonceBits: 96,
+    };
+    expect(() => requireSerializePublicKey(provider, 'BeeKEM Welcome')).toThrow(
+      /BeeKEM Welcome requires AuthProvider.serializePublicKey/,
+    );
+  });
+
+  test('error message includes the feature name', () => {
+    const provider: AuthProvider<string, string> = {
+      sign: async () => new Uint8Array(),
+      verify: async () => true,
+      encrypt: async () => ({ data: new Uint8Array() }),
+      decrypt: async () => new Uint8Array(),
+      nonceBits: 96,
+    };
+    expect(() => requireSerializePublicKey(provider, 'MyFeature')).toThrow(
+      /MyFeature requires AuthProvider.serializePublicKey/,
+    );
+  });
+});

--- a/packages/collabswarm/src/crypto-invariants.test.ts
+++ b/packages/collabswarm/src/crypto-invariants.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  eciesSeal,
+  eciesOpen,
+  generateEciesKeyPair,
+  importEciesPublicKey,
+  exportEciesPublicKey,
+  ECIES_P256_PUBLIC_KEY_LENGTH,
+} from './ecies';
+
+describe('eciesSeal / eciesOpen invariants', () => {
+  test('round-trip: seal then open returns original plaintext', async () => {
+    const bob = await generateEciesKeyPair();
+    const plaintext = new Uint8Array([1, 2, 3, 4, 5]);
+    const sealed = await eciesSeal(plaintext, bob.publicKey);
+    const opened = await eciesOpen(sealed, bob.privateKey);
+    expect(opened).toEqual(plaintext);
+  });
+
+  test('opening with wrong private key rejects', async () => {
+    const bob = await generateEciesKeyPair();
+    const charlie = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array([1, 2, 3]), bob.publicKey);
+    await expect(eciesOpen(sealed, charlie.privateKey)).rejects.toThrow();
+  });
+
+  test('tampered sealed payload fails', async () => {
+    const bob = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array([1, 2, 3]), bob.publicKey);
+    sealed[sealed.length - 1] ^= 0xff;
+    await expect(eciesOpen(sealed, bob.privateKey)).rejects.toThrow();
+  });
+
+  test('identical plaintext produces different ciphertext', async () => {
+    const bob = await generateEciesKeyPair();
+    const pt = new Uint8Array([1, 2, 3]);
+    expect(await eciesSeal(pt, bob.publicKey)).not.toEqual(await eciesSeal(pt, bob.publicKey));
+  });
+
+  test('empty plaintext round-trips', async () => {
+    const bob = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array(), bob.publicKey);
+    expect(await eciesOpen(sealed, bob.privateKey)).toEqual(new Uint8Array());
+  });
+
+  test('truncated sealed payload rejects', async () => {
+    const bob = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array([1, 2, 3]), bob.publicKey);
+    await expect(eciesOpen(sealed.subarray(0, 50), bob.privateKey)).rejects.toThrow(/truncated/);
+  });
+
+  test('flipped HKDF salt fails', async () => {
+    const bob = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array([1, 2, 3]), bob.publicKey);
+    sealed[0] ^= 0xff;
+    await expect(eciesOpen(sealed, bob.privateKey)).rejects.toThrow();
+  });
+
+  test('flipped nonce fails', async () => {
+    const bob = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array([1, 2, 3]), bob.publicKey);
+    sealed[32 + 65] ^= 0xff;
+    await expect(eciesOpen(sealed, bob.privateKey)).rejects.toThrow();
+  });
+});
+
+describe('importEciesPublicKey', () => {
+  test('rejects wrong-length key', async () => {
+    await expect(importEciesPublicKey(new Uint8Array(10))).rejects.toThrow(/must be 65 bytes/);
+  });
+  test('rejects empty key', async () => {
+    await expect(importEciesPublicKey(new Uint8Array())).rejects.toThrow(/must be 65 bytes/);
+  });
+});
+
+describe('generateEciesKeyPair / exportEciesPublicKey', () => {
+  test('generated key pair has correct algorithm', async () => {
+    const pair = await generateEciesKeyPair();
+    const pubAlgo = pair.publicKey.algorithm as any;
+    expect(pubAlgo.name).toBe('ECDH');
+    expect(pubAlgo.namedCurve).toBe('P-256');
+  });
+  test('private key usages include deriveBits', async () => {
+    const pair = await generateEciesKeyPair();
+    expect(pair.privateKey.usages).toContain('deriveBits');
+  });
+});

--- a/packages/collabswarm/src/kem-key-pair-validation.test.ts
+++ b/packages/collabswarm/src/kem-key-pair-validation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from '@jest/globals';
+import { validateAndExportKemKeyPair } from './kem-key-pair';
+
+describe('validateAndExportKemKeyPair', () => {
+  test('rejects non-ECDH keys', async () => {
+    const rsaKeyPair = (await crypto.subtle.generateKey(
+      { name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+      true, ['encrypt', 'decrypt'],
+    )) as CryptoKeyPair;
+    await expect(validateAndExportKemKeyPair(rsaKeyPair)).rejects.toThrow(/key pair must be ECDH/);
+  });
+
+  test('rejects ECDH keys on wrong curve', async () => {
+    const p384Pair = (await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-384' }, true, ['deriveBits'],
+    )) as CryptoKeyPair;
+    await expect(validateAndExportKemKeyPair(p384Pair)).rejects.toThrow(/must use curve P-256/);
+  });
+
+  test('rejects private key missing deriveBits usage', async () => {
+    const pair = (await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveKey'],
+    )) as CryptoKeyPair;
+    await expect(validateAndExportKemKeyPair(pair)).rejects.toThrow(/usages must include 'deriveBits'/);
+  });
+
+  test('accepts valid P-256 ECDH key pair with deriveBits', async () => {
+    const pair = (await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveBits'],
+    )) as CryptoKeyPair;
+    const result = await validateAndExportKemKeyPair(pair);
+    expect(result.length).toBe(65);
+  });
+});

--- a/packages/collabswarm/src/keychain.test.ts
+++ b/packages/collabswarm/src/keychain.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, jest } from '@jest/globals';
+import { Keychain, keychainHistorySinceOrFull } from './keychain.js';
+
+describe('keychainHistorySinceOrFull', () => {
+  test('calls historySince when the implementation provides it', async () => {
+    const historySinceMock = jest
+      .fn<(keyID: Uint8Array) => Promise<string>>()
+      .mockResolvedValue('delta-since');
+    const keychain: Keychain<string, string> = {
+      add: async () => [new Uint8Array(), 'key', 'change'],
+      history: () => 'full-history',
+      merge: () => {},
+      keys: async () => [],
+      current: async () => [new Uint8Array(), 'current-key'],
+      getKey: () => 'key',
+      currentKeyChange: async () => 'current-change',
+      addEpochKey: async () => 'epoch-change',
+      historySince: historySinceMock as any,
+    };
+    const fn = keychainHistorySinceOrFull(keychain);
+    const keyID = new Uint8Array([1, 2, 3]);
+    const result = await fn(keyID);
+    expect(historySinceMock).toHaveBeenCalledWith(keyID);
+    expect(result).toBe('delta-since');
+  });
+
+  test('falls back to history() when historySince is not implemented', async () => {
+    const keychain: Keychain<string, string> = {
+      add: async () => [new Uint8Array(), 'key', 'change'],
+      history: () => 'full-history',
+      merge: () => {},
+      keys: async () => [],
+      current: async () => [new Uint8Array(), 'current-key'],
+      getKey: () => 'key',
+      currentKeyChange: async () => 'current-change',
+      addEpochKey: async () => 'epoch-change',
+    };
+    const fn = keychainHistorySinceOrFull(keychain);
+    const result = await fn(new Uint8Array([1]));
+    expect(result).toBe('full-history');
+  });
+});

--- a/packages/collabswarm/src/malformed-beekem-welcome.test.ts
+++ b/packages/collabswarm/src/malformed-beekem-welcome.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  deserializeBeeKEMWelcomeFromWire,
+  serializeBeeKEMWelcomeForWire,
+} from './beekem-welcome-wire';
+
+function buildValidWelcome() {
+  return {
+    leafIndex: 3,
+    pathKeys: [{
+      nodeIndex: 4,
+      publicKey: new Uint8Array(65).fill(2),
+      encryptedPrivateKey: new Uint8Array([40, 50, 60]),
+    }],
+    treeNodePublicKeys: [
+      { nodeIndex: 0, publicKey: new Uint8Array(65).fill(70) },
+      { nodeIndex: 1, publicKey: null },
+    ],
+    treeHash: new Uint8Array([99, 100, 101]),
+  };
+}
+
+function buildValidWire() {
+  return serializeBeeKEMWelcomeForWire(buildValidWelcome());
+}
+
+describe('deserializeBeeKEMWelcomeFromWire malformed inputs', () => {
+  test('rejects null', () => {
+    expect(() => deserializeBeeKEMWelcomeFromWire(null)).toThrow(/expected a plain object/);
+  });
+  test('rejects array', () => {
+    expect(() => deserializeBeeKEMWelcomeFromWire([1, 2, 3])).toThrow(/expected a plain object/);
+  });
+  test('rejects string', () => {
+    expect(() => deserializeBeeKEMWelcomeFromWire('bad')).toThrow(/expected a plain object/);
+  });
+  test('rejects boolean', () => {
+    expect(() => deserializeBeeKEMWelcomeFromWire(true)).toThrow(/expected a plain object/);
+  });
+  test('rejects non-integer leafIndex', () => {
+    const bad = { ...buildValidWire(), leafIndex: 1.5 };
+    expect(() => deserializeBeeKEMWelcomeFromWire(bad)).toThrow(/leafIndex/);
+  });
+  test('rejects negative leafIndex', () => {
+    const bad = { ...buildValidWire(), leafIndex: -1 };
+    expect(() => deserializeBeeKEMWelcomeFromWire(bad)).toThrow(/leafIndex/);
+  });
+  test('rejects string leafIndex', () => {
+    const bad = { ...buildValidWire(), leafIndex: 'three' };
+    expect(() => deserializeBeeKEMWelcomeFromWire(bad)).toThrow(/leafIndex/);
+  });
+  test('rejects non-array pathKeys', () => {
+    const bad = { ...buildValidWire(), pathKeys: { 0: {} } };
+    expect(() => deserializeBeeKEMWelcomeFromWire(bad)).toThrow(/'pathKeys' must be an array/);
+  });
+  test('rejects null pathKeys', () => {
+    const bad = { ...buildValidWire(), pathKeys: null };
+    expect(() => deserializeBeeKEMWelcomeFromWire(bad)).toThrow(/'pathKeys' must be an array/);
+  });
+  test('rejects non-array treeNodePublicKeys', () => {
+    const bad = { ...buildValidWire(), treeNodePublicKeys: 'not-an-array' };
+    expect(() => deserializeBeeKEMWelcomeFromWire(bad)).toThrow(/'treeNodePublicKeys' must be an array/);
+  });
+  test('rejects non-string treeHash', () => {
+    const bad = { ...buildValidWire(), treeHash: 123 };
+    expect(() => deserializeBeeKEMWelcomeFromWire(bad)).toThrow(/'treeHash' must be a base64/);
+  });
+  test('rejects pathKey element that is not an object', () => {
+    const bad = { ...buildValidWire(), pathKeys: ['not-an-object'] as any };
+    expect(() => deserializeBeeKEMWelcomeFromWire(bad)).toThrow(/pathKeys\[0\] must be a plain object/);
+  });
+  test('rejects pathKey with non-integer nodeIndex', () => {
+    const wire = buildValidWire();
+    (wire.pathKeys[0] as any).nodeIndex = 1.5;
+    expect(() => deserializeBeeKEMWelcomeFromWire(wire)).toThrow(/pathKeys\[0\].nodeIndex/);
+  });
+  test('rejects pathKey with non-string publicKey', () => {
+    const wire = buildValidWire();
+    (wire.pathKeys[0] as any).publicKey = 123;
+    expect(() => deserializeBeeKEMWelcomeFromWire(wire)).toThrow(/pathKeys\[0\].publicKey must be a base64/);
+  });
+  test('rejects treeNodePublicKey element that is not an object', () => {
+    const bad = { ...buildValidWire(), treeNodePublicKeys: ['bad'] };
+    expect(() => deserializeBeeKEMWelcomeFromWire(bad)).toThrow(/treeNodePublicKeys\[0\] must be a plain object/);
+  });
+  test('rejects treeNodePublicKey with non-integer nodeIndex', () => {
+    const wire = buildValidWire();
+    (wire.treeNodePublicKeys[0] as any).nodeIndex = 'abc';
+    expect(() => deserializeBeeKEMWelcomeFromWire(wire)).toThrow(/treeNodePublicKeys\[0\].nodeIndex/);
+  });
+  test('rejects treeNodePublicKey with invalid publicKey type', () => {
+    const wire = buildValidWire();
+    (wire.treeNodePublicKeys[0] as any).publicKey = 123;
+    expect(() => deserializeBeeKEMWelcomeFromWire(wire)).toThrow(/treeNodePublicKeys\[0\].publicKey must be a base64/);
+  });
+});
+
+describe('deserializeBeeKEMWelcomeFromWire valid inputs', () => {
+  test('round-trips a valid welcome', () => {
+    const wire = buildValidWire();
+    const result = deserializeBeeKEMWelcomeFromWire(wire);
+    expect(result.leafIndex).toBe(3);
+    expect(result.pathKeys).toHaveLength(1);
+    expect(result.treeNodePublicKeys).toHaveLength(2);
+    expect(result.treeNodePublicKeys[1].publicKey).toBeNull();
+  });
+  test('handles empty pathKeys and treeNodePublicKeys', () => {
+    const wire = { ...buildValidWire(), pathKeys: [], treeNodePublicKeys: [] };
+    const result = deserializeBeeKEMWelcomeFromWire(wire);
+    expect(result.pathKeys).toHaveLength(0);
+    expect(result.treeNodePublicKeys).toHaveLength(0);
+  });
+});

--- a/packages/collabswarm/src/malformed-merkle-dag.test.ts
+++ b/packages/collabswarm/src/malformed-merkle-dag.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from '@jest/globals';
+import { deserializeChangeNodeFromJSON, describeValue } from './merkle-dag-serialization';
+import { crdtDocumentChangeNode, crdtWriterChangeNode } from './crdt-change-node';
+
+const id = <T>(x: T): T => x;
+
+describe('describeValue', () => {
+  test('returns null for null', () => { expect(describeValue(null)).toBe('null'); });
+  test('returns array for arrays', () => { expect(describeValue([])).toBe('array'); });
+  test('returns typeof for primitives', () => {
+    expect(describeValue('hello')).toBe('string');
+    expect(describeValue(42)).toBe('number');
+    expect(describeValue(true)).toBe('boolean');
+  });
+});
+
+describe('deserializeChangeNodeFromJSON malformed inputs', () => {
+  test('rejects null', () => {
+    expect(() => deserializeChangeNodeFromJSON(null as any, id)).toThrow(/expected a plain object/);
+  });
+  test('rejects array', () => {
+    expect(() => deserializeChangeNodeFromJSON([] as any, id)).toThrow(/expected a plain object/);
+  });
+  test('rejects string', () => {
+    expect(() => deserializeChangeNodeFromJSON('bad' as any, id)).toThrow(/expected a plain object/);
+  });
+  test('rejects number', () => {
+    expect(() => deserializeChangeNodeFromJSON(42 as any, id)).toThrow(/expected a plain object/);
+  });
+  test('rejects missing kind', () => {
+    expect(() => deserializeChangeNodeFromJSON({} as any, id)).toThrow(/"kind"/);
+  });
+  test('rejects unknown kind', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: 'invalid-kind' } as any, id)).toThrow(/"kind"/);
+  });
+  test('rejects non-string keyID when present', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, keyID: 123 } as any, id)).toThrow(/"keyID"/);
+  });
+  test('rejects object keyID when present', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, keyID: {} } as any, id)).toThrow(/"keyID"/);
+  });
+  test('rejects non-object children', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, children: 42 } as any, id)).toThrow(/"children"/);
+  });
+  test('rejects null children', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, children: null } as any, id)).toThrow(/"children"/);
+  });
+  test('rejects array children', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, children: [] } as any, id)).toThrow(/"children"/);
+  });
+});
+
+describe('deserializeChangeNodeFromJSON valid inputs', () => {
+  test('deserializes a leaf document-change node', () => {
+    const result = deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, keyID: 'test-key-id', change: 'leaf' } as any, id);
+    expect(result.kind).toBe(crdtDocumentChangeNode);
+    expect(result.keyID).toBe('test-key-id');
+    expect(result.change).toBe('leaf');
+  });
+  test('deserializes a leaf node without keyID', () => {
+    const result = deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, change: 'data' } as any, id);
+    expect(result.keyID).toBeUndefined();
+  });
+  test('deserializes a leaf node without change', () => {
+    const result = deserializeChangeNodeFromJSON({ kind: crdtWriterChangeNode, keyID: 'writer-key' } as any, id);
+    expect(result.kind).toBe(crdtWriterChangeNode);
+    expect(result.change).toBeUndefined();
+  });
+  test('deserializes a node with nested children', () => {
+    const wire: any = { kind: crdtDocumentChangeNode, children: { abc: { kind: crdtWriterChangeNode, keyID: 'child-key', change: 'child-payload' } } };
+    const result: any = deserializeChangeNodeFromJSON(wire, id);
+    expect(result.children.abc.kind).toBe(crdtWriterChangeNode);
+    expect(result.children.abc.keyID).toBe('child-key');
+  });
+  test('children map uses null prototype', () => {
+    const wire: any = { kind: crdtDocumentChangeNode, children: { abc: { kind: crdtWriterChangeNode } } };
+    const result: any = deserializeChangeNodeFromJSON(wire, id);
+    expect(Object.getPrototypeOf(result.children)).toBeNull();
+  });
+  test('children map resists __proto__ pollution', () => {
+    const wire: any = { kind: crdtDocumentChangeNode, children: { __proto__: { kind: crdtWriterChangeNode, change: 'evil' }, legit: { kind: crdtWriterChangeNode, change: 'good' } } };
+    const result: any = deserializeChangeNodeFromJSON(wire, id);
+    expect(Object.getPrototypeOf(result.children)).toBeNull();
+    expect(result.children.legit).toBeDefined();
+    expect((Object.prototype as any).polluted).toBeUndefined();
+  });
+});

--- a/packages/collabswarm/src/malformed-path-update.test.ts
+++ b/packages/collabswarm/src/malformed-path-update.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from '@jest/globals';
+import { Base64 } from 'js-base64';
+import {
+  deserializePathUpdateFromWire,
+  serializePathUpdateForWire,
+} from './path-update-wire.js';
+
+function buildValidPayload() {
+  const update = {
+    senderLeafIndex: 3,
+    senderLeafPublicKey: new Uint8Array(65).fill(1),
+    nodes: [{
+      nodeIndex: 4,
+      publicKey: new Uint8Array(65).fill(2),
+      encryptedPrivateKey: new Uint8Array([40, 50, 60]),
+    }],
+  };
+  return serializePathUpdateForWire(update);
+}
+
+describe('deserializePathUpdateFromWire malformed inputs', () => {
+  test('rejects null', () => {
+    expect(() => deserializePathUpdateFromWire(null)).toThrow(/expected a plain object/);
+  });
+  test('rejects array', () => {
+    expect(() => deserializePathUpdateFromWire([])).toThrow(/expected a plain object/);
+  });
+  test('rejects string', () => {
+    expect(() => deserializePathUpdateFromWire('bad')).toThrow(/expected a plain object/);
+  });
+  test('rejects missing senderLeafIndex', () => {
+    const bad = { ...buildValidPayload() };
+    delete (bad as any).senderLeafIndex;
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/senderLeafIndex/);
+  });
+  test('rejects non-integer senderLeafIndex', () => {
+    const bad = { ...buildValidPayload(), senderLeafIndex: 1.5 };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/senderLeafIndex/);
+  });
+  test('rejects negative senderLeafIndex', () => {
+    const bad = { ...buildValidPayload(), senderLeafIndex: -1 };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/senderLeafIndex/);
+  });
+  test('rejects non-string senderLeafIndex', () => {
+    const bad = { ...buildValidPayload(), senderLeafIndex: 'three' };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/senderLeafIndex/);
+  });
+  test('rejects non-string senderLeafPublicKey', () => {
+    const bad = { ...buildValidPayload(), senderLeafPublicKey: 123 };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/senderLeafPublicKey/);
+  });
+  test('rejects non-array nodes', () => {
+    const bad = { ...buildValidPayload(), nodes: { 0: {} } };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/'nodes' must be an array/);
+  });
+  test('rejects null nodes', () => {
+    const bad = { ...buildValidPayload(), nodes: null };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/'nodes' must be an array/);
+  });
+  test('rejects node element that is not an object', () => {
+    const bad = { ...buildValidPayload(), nodes: ['not-a-node'] as any };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/node\[0\] must be a plain object/);
+  });
+  test('rejects node element that is null', () => {
+    const bad = { ...buildValidPayload(), nodes: [null] as any };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/node\[0\] must be a plain object/);
+  });
+  test('rejects node with missing nodeIndex', () => {
+    const node = {
+      publicKey: Base64.fromUint8Array(new Uint8Array(65).fill(2)),
+      encryptedPrivateKey: Base64.fromUint8Array(new Uint8Array([40])),
+    };
+    const bad = { ...buildValidPayload(), nodes: [node] };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/node\[0\].nodeIndex/);
+  });
+  test('rejects node with negative nodeIndex', () => {
+    const node = {
+      nodeIndex: -1,
+      publicKey: Base64.fromUint8Array(new Uint8Array(65).fill(2)),
+      encryptedPrivateKey: Base64.fromUint8Array(new Uint8Array([40])),
+    };
+    const bad = { ...buildValidPayload(), nodes: [node] };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/node\[0\].nodeIndex/);
+  });
+  test('rejects node with non-string publicKey', () => {
+    const node = {
+      nodeIndex: 4,
+      publicKey: 123,
+      encryptedPrivateKey: Base64.fromUint8Array(new Uint8Array([40])),
+    };
+    const bad = { ...buildValidPayload(), nodes: [node] };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/node\[0\].publicKey must be a base64/);
+  });
+  test('rejects node with non-string encryptedPrivateKey', () => {
+    const node = {
+      nodeIndex: 4,
+      publicKey: Base64.fromUint8Array(new Uint8Array(65).fill(2)),
+      encryptedPrivateKey: null,
+    };
+    const bad = { ...buildValidPayload(), nodes: [node] };
+    expect(() => deserializePathUpdateFromWire(bad)).toThrow(/node\[0\].encryptedPrivateKey must be a base64/);
+  });
+});
+
+describe('deserializePathUpdateFromWire valid inputs', () => {
+  test('round-trips a valid payload', () => {
+    const payload = buildValidPayload();
+    const result = deserializePathUpdateFromWire(payload);
+    expect(result.senderLeafIndex).toBe(3);
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0].nodeIndex).toBe(4);
+  });
+  test('handles empty nodes array', () => {
+    const payload = { ...buildValidPayload(), nodes: [] };
+    const result = deserializePathUpdateFromWire(payload);
+    expect(result.nodes).toHaveLength(0);
+  });
+});

--- a/packages/collabswarm/src/stream-adapter.test.ts
+++ b/packages/collabswarm/src/stream-adapter.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import { wrapStream, DuplexStream } from './stream-adapter';
+
+describe('wrapStream', () => {
+  let sendMock: any;
+  let onDrainMock: any;
+  let closeMock: any;
+  let wrapped: DuplexStream;
+
+  beforeEach(() => {
+    sendMock = jest.fn();
+    onDrainMock = jest.fn();
+    closeMock = jest.fn();
+
+    async function* asyncGen() {
+      yield new Uint8Array([4, 5, 6]);
+    }
+    const mockStream = {
+      send: sendMock,
+      onDrain: onDrainMock,
+      close: closeMock,
+      [Symbol.asyncIterator]: asyncGen,
+    } as any;
+    wrapped = wrapStream(mockStream);
+  });
+
+  test('sends all chunks and then half-closes', async () => {
+    sendMock.mockReturnValue(true);
+    closeMock.mockResolvedValue(undefined);
+    const chunks = [new Uint8Array([1, 2]), new Uint8Array([3, 4])];
+    await wrapped.sink(chunks);
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('awaits onDrain when send returns false', async () => {
+    sendMock.mockReturnValueOnce(false).mockReturnValue(true);
+    onDrainMock.mockResolvedValue(undefined);
+    closeMock.mockResolvedValue(undefined);
+    await wrapped.sink([new Uint8Array([1]), new Uint8Array([2])]);
+    expect(onDrainMock).toHaveBeenCalledTimes(1);
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls close even with no chunks', async () => {
+    sendMock.mockReturnValue(true);
+    closeMock.mockResolvedValue(undefined);
+    await wrapped.sink([]);
+    expect(closeMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  test('close delegates to stream.close()', async () => {
+    closeMock.mockResolvedValue(undefined);
+    await wrapped.close();
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('sink does not close if stream throws during send', async () => {
+    const failingStream = {
+      send: jest.fn().mockImplementation(() => { throw new Error('send failed'); }),
+      onDrain: async () => {},
+      close: jest.fn(),
+      [Symbol.asyncIterator]: async function* () {},
+    } as any;
+    const w = wrapStream(failingStream);
+    await expect(w.sink([new Uint8Array([1])])).rejects.toThrow('send failed');
+    expect(failingStream.close).not.toHaveBeenCalled();
+  });
+});

--- a/packages/collabswarm/src/ucan-acl.test.ts
+++ b/packages/collabswarm/src/ucan-acl.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+
+const ucanAcl = require('./ucan-acl');
+const UCANACLImpl = ucanAcl.UCANACL;
+const UCANACLProviderImpl = ucanAcl.UCANACLProvider;
+
+jest.mock('./ucan', () => ({ createUCAN: jest.fn() }));
+const mockCreateUCAN = require('./ucan').createUCAN;
+
+interface UCAN {
+  version: '0.1.0';
+  issuer: string;
+  audience: string;
+  capabilities: Array<{ resource: string; ability: string }>;
+  expiration: number | null;
+  notBefore: number | null;
+  nonce: string;
+  proofs: string[];
+  signature: string;
+}
+
+function makeFakeUcan(overrides: Partial<UCAN> = {}): UCAN {
+  return {
+    version: '0.1.0',
+    issuer: 'issuer-b64',
+    audience: 'audience-b64',
+    capabilities: [],
+    expiration: null,
+    notBefore: null,
+    nonce: 'nonce-1',
+    proofs: [],
+    signature: 'base64sig',
+    ...overrides,
+  };
+}
+
+function makeMockAcl() {
+  return {
+    add: jest.fn(),
+    remove: jest.fn(),
+    current: jest.fn(),
+    merge: jest.fn(),
+    check: jest.fn(),
+    users: jest.fn(),
+  };
+}
+
+describe('UCANACL', () => {
+  let backing: any;
+  let acl: any;
+
+  beforeEach(() => {
+    backing = makeMockAcl();
+    acl = new UCANACLImpl(backing, jest.fn(async (key: string) => `serialized:${key}`));
+    mockCreateUCAN.mockReset();
+  });
+
+  test('add delegates to backing ACL', async () => {
+    backing.add.mockResolvedValue('changes');
+    const result = await acl.add('key1');
+    expect(backing.add).toHaveBeenCalledWith('key1');
+    expect(result).toBe('changes');
+  });
+
+  test('remove revokes access', async () => {
+    backing.remove.mockResolvedValue('changes');
+    await acl.remove('key1');
+    const hasAccess = await acl.check('key1', '/doc/write');
+    expect(hasAccess).toBe(false);
+  });
+
+  test('current delegates to backing ACL', () => {
+    backing.current.mockReturnValue('current-state');
+    expect(acl.current()).toBe('current-state');
+  });
+
+  test('merge delegates to backing ACL', () => {
+    acl.merge('incoming-changes');
+    expect(backing.merge).toHaveBeenCalledWith('incoming-changes');
+  });
+
+  test('check without capability delegates to backing ACL', async () => {
+    backing.check.mockResolvedValue(true);
+    const result = await acl.check('key1');
+    expect(result).toBe(true);
+  });
+
+  test('check with capability falls back to backing ACL when no UCAN entry', async () => {
+    backing.check.mockResolvedValue(true);
+    const result = await acl.check('key1', '/doc/write');
+    expect(result).toBe(true);
+  });
+
+  test('check with capability after grant respects capability hierarchy', async () => {
+    const fakeUcan = makeFakeUcan({
+      issuer: 'issuer',
+      audience: 'serialized:user1',
+      capabilities: [{ resource: 'doc-1', ability: '/doc/write' }],
+    });
+    mockCreateUCAN.mockResolvedValue(fakeUcan);
+    backing.add.mockResolvedValue('changes');
+
+    await (acl.grant as any)('user1', '/doc/write', 'doc-1', {} as CryptoKey, 'issuer');
+
+    const writeResult = await acl.check('user1', '/doc/write');
+    expect(writeResult).toBe(true);
+    const readResult = await acl.check('user1', '/doc/read');
+    expect(readResult).toBe(true);
+    const adminResult = await acl.check('user1', '/doc/admin');
+    expect(adminResult).toBe(false);
+  });
+
+  test('users without capability delegates to backing ACL', async () => {
+    backing.users.mockResolvedValue(['userA', 'userB']);
+    const result = await acl.users();
+    expect(result).toEqual(['userA', 'userB']);
+  });
+
+  test('grant creates UCAN and stores entry', async () => {
+    const fakeUcan = makeFakeUcan({
+      issuer: 'issuer-b64',
+      audience: 'serialized:user1',
+      capabilities: [{ resource: 'doc-1', ability: '/doc/write' }],
+    });
+    mockCreateUCAN.mockResolvedValue(fakeUcan);
+    backing.add.mockResolvedValue('changes');
+
+    await (acl.grant as any)('user1', '/doc/write', 'doc-1', {} as CryptoKey, 'issuer-b64', []);
+    const entry = await acl.getEntry('user1');
+    expect(entry).toBeDefined();
+    expect(entry!.ucan).toBe(fakeUcan);
+    expect(entry!.capabilities).toEqual(['/doc/write']);
+    expect(entry!.revoked).toBe(false);
+  });
+
+  test('grant with epochId stores it', async () => {
+    const fakeUcan = makeFakeUcan({
+      issuer: 'issuer-b64',
+      audience: 'serialized:user2',
+      capabilities: [{ resource: 'doc-1', ability: '/doc/admin' }],
+    });
+    mockCreateUCAN.mockResolvedValue(fakeUcan);
+    backing.add.mockResolvedValue('changes');
+
+    const epochId = new Uint8Array([10, 20, 30]);
+    await (acl.grant as any)('user2', '/doc/admin', 'doc-1', {} as CryptoKey, 'issuer-b64', [], epochId);
+    const entry = await acl.getEntry('user2');
+    expect(entry!.epochId).toEqual(epochId);
+  });
+
+  test('revoke delegates to remove', async () => {
+    backing.remove.mockResolvedValue('changes');
+    const result = await acl.revoke('user1');
+    expect(result).toBe('changes');
+  });
+
+  test('getEntry returns undefined for unknown user', async () => {
+    const entry = await acl.getEntry('unknown');
+    expect(entry).toBeUndefined();
+  });
+
+  test('getEntry returns entry after grant', async () => {
+    const fakeUcan = makeFakeUcan({
+      issuer: 'issuer',
+      audience: 'serialized:user1',
+      capabilities: [{ resource: 'doc-1', ability: '/doc/read' }],
+    });
+    mockCreateUCAN.mockResolvedValue(fakeUcan);
+    backing.add.mockResolvedValue('changes');
+
+    await (acl.grant as any)('user1', '/doc/read', 'doc-1', {} as CryptoKey, 'issuer');
+    const entry = await acl.getEntry('user1');
+    expect(entry!.publicKeyBase64).toBe('serialized:user1');
+  });
+
+  test('getEntry returns undefined after remove', async () => {
+    const fakeUcan = makeFakeUcan({
+      issuer: 'issuer',
+      audience: 'serialized:user1',
+      capabilities: [{ resource: 'doc-1', ability: '/doc/read' }],
+    });
+    mockCreateUCAN.mockResolvedValue(fakeUcan);
+    backing.add.mockResolvedValue('changes');
+    backing.remove.mockResolvedValue('changes-rm');
+
+    await (acl.grant as any)('user1', '/doc/read', 'doc-1', {} as CryptoKey, 'issuer');
+    await acl.remove('user1');
+    const entry = await acl.getEntry('user1');
+    expect(entry).toBeUndefined();
+  });
+});
+
+describe('UCANACLProvider', () => {
+  test('initialize creates a UCANACL with the backing ACL', () => {
+    const mockBackingAclProvider = { initialize: jest.fn(() => makeMockAcl()) };
+    const serializeKey = jest.fn(async (key: string) => `s:${key}`);
+    const provider = new UCANACLProviderImpl(mockBackingAclProvider, serializeKey);
+    const acl = provider.initialize();
+    expect(acl).toBeInstanceOf(UCANACLImpl);
+    expect(mockBackingAclProvider.initialize).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/collabswarm/src/ucan-forgery.test.ts
+++ b/packages/collabswarm/src/ucan-forgery.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from '@jest/globals';
+import { createUCAN, verifyUCANSignature, serializeUCAN, deserializeUCAN } from './ucan';
+
+async function generateKeyPair(): Promise<CryptoKeyPair> {
+  return crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-384' }, true, ['sign', 'verify']);
+}
+async function publicKeyToBase64(publicKey: CryptoKey): Promise<string> {
+  const raw = new Uint8Array(await crypto.subtle.exportKey('raw', publicKey));
+  return btoa(String.fromCharCode(...raw));
+}
+
+describe('UCAN forgery resistance', () => {
+  test('tampered capabilities fail verification', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    const forged = { ...ucan, capabilities: [{ resource: 'doc-1', ability: '/doc/admin' }] };
+    expect(await verifyUCANSignature(forged, issuer.publicKey)).toBe(false);
+  });
+
+  test('tampered resource fails verification', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    const forged = { ...ucan, capabilities: [{ resource: 'doc-2', ability: '/doc/admin' }] };
+    expect(await verifyUCANSignature(forged, issuer.publicKey)).toBe(false);
+  });
+
+  test('tampered signature fails verification', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    const sigBytes = Buffer.from(ucan.signature, 'base64');
+    sigBytes[0] ^= 0xff;
+    const forged = { ...ucan, signature: sigBytes.toString('base64') };
+    expect(await verifyUCANSignature(forged, issuer.publicKey)).toBe(false);
+  });
+
+  test('tampered issuer fails verification', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const wrongIssuer = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const wrongB64 = await publicKeyToBase64(wrongIssuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    const forged = { ...ucan, issuer: wrongB64 };
+    expect(await verifyUCANSignature(forged, issuer.publicKey)).toBe(false);
+  });
+
+  test('wrong verification key fails', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const wrongKey = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    expect(await verifyUCANSignature(ucan, wrongKey.publicKey)).toBe(false);
+  });
+
+  test('valid UCAN verifies', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [
+      { resource: 'doc-1', ability: '/doc/write' },
+      { resource: 'doc-1', ability: '/doc/read' },
+    ]);
+    expect(await verifyUCANSignature(ucan, issuer.publicKey)).toBe(true);
+  });
+
+  test('serialize/deserialize round-trip preserves fields', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-42', ability: '/doc/write' }]);
+    const serialized = serializeUCAN(ucan);
+    const deserialized = deserializeUCAN(serialized);
+    expect(deserialized.version).toBe(ucan.version);
+    expect(deserialized.issuer).toBe(ucan.issuer);
+    expect(deserialized.audience).toBe(ucan.audience);
+    expect(deserialized.capabilities).toEqual(ucan.capabilities);
+    expect(deserialized.signature).toBe(ucan.signature);
+  });
+
+  test('deserialized UCAN still verifies', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    const serialized = serializeUCAN(ucan);
+    const deserialized = deserializeUCAN(serialized);
+    expect(await verifyUCANSignature(deserialized, issuer.publicKey)).toBe(true);
+  });
+});

--- a/packages/collabswarm/src/welcome-sealed-payload.test.ts
+++ b/packages/collabswarm/src/welcome-sealed-payload.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from '@jest/globals';
+import { Base64 } from 'js-base64';
+import {
+  encodeWelcomeSealedPayload,
+  decodeWelcomeSealedPayload,
+} from './welcome-sealed-payload';
+
+describe('welcome-sealed-payload round-trip', () => {
+  const keychainBytes = new Uint8Array([1, 2, 3, 4, 5]);
+
+  test('encode then decode with beekemWelcome present', () => {
+    const beekemWelcome = {
+      leafIndex: 3,
+      pathKeys: [{
+        nodeIndex: 4,
+        publicKey: new Uint8Array([10, 20, 30]),
+        encryptedPrivateKey: new Uint8Array([40, 50, 60]),
+      }],
+      treeNodePublicKeys: [
+        { nodeIndex: 0, publicKey: new Uint8Array([70, 80]) },
+        { nodeIndex: 1, publicKey: null },
+      ],
+      treeHash: new Uint8Array([99, 100, 101]),
+    };
+    const encoded = encodeWelcomeSealedPayload({
+      keychainChanges: keychainBytes,
+      beekemWelcome,
+    });
+    const decoded = decodeWelcomeSealedPayload(encoded);
+    expect(decoded.keychainChanges).toEqual(keychainBytes);
+    expect(decoded.beekemWelcome).not.toBeNull();
+    expect(decoded.beekemWelcome!.leafIndex).toBe(3);
+    expect(decoded.beekemWelcome!.pathKeys).toHaveLength(1);
+  });
+
+  test('encode then decode with beekemWelcome null', () => {
+    const encoded = encodeWelcomeSealedPayload({
+      keychainChanges: keychainBytes,
+      beekemWelcome: null,
+    });
+    const decoded = decodeWelcomeSealedPayload(encoded);
+    expect(decoded.keychainChanges).toEqual(keychainBytes);
+    expect(decoded.beekemWelcome).toBeNull();
+  });
+});
+
+describe('decodeWelcomeSealedPayload error paths', () => {
+  test('throws on invalid UTF-8', () => {
+    const invalidUtf8 = new Uint8Array([0xff, 0xfe, 0xfd]);
+    expect(() => decodeWelcomeSealedPayload(invalidUtf8)).toThrow(/not valid UTF-8/);
+  });
+
+  test('throws on invalid JSON', () => {
+    expect(() => decodeWelcomeSealedPayload(new TextEncoder().encode('not json {{{'))).toThrow(/not valid JSON/);
+  });
+
+  test('throws on array instead of object', () => {
+    expect(() => decodeWelcomeSealedPayload(new TextEncoder().encode('[]'))).toThrow(/expected a plain object/);
+  });
+
+  test('throws on null', () => {
+    expect(() => decodeWelcomeSealedPayload(new TextEncoder().encode('null'))).toThrow(/expected a plain object/);
+  });
+
+  test('throws on string', () => {
+    expect(() => decodeWelcomeSealedPayload(new TextEncoder().encode('"hello"'))).toThrow(/expected a plain object/);
+  });
+
+  test('throws on number', () => {
+    expect(() => decodeWelcomeSealedPayload(new TextEncoder().encode('42'))).toThrow(/expected a plain object/);
+  });
+
+  test('throws when k is missing', () => {
+    expect(() => decodeWelcomeSealedPayload(new TextEncoder().encode('{}'))).toThrow(/'k'.*base64/);
+  });
+
+  test('throws when k is not a string', () => {
+    expect(() => decodeWelcomeSealedPayload(new TextEncoder().encode('{"k":123}'))).toThrow(/'k'.*base64/);
+  });
+
+  test('throws when bk is invalid', () => {
+    const k = Base64.fromUint8Array(new Uint8Array([1, 2, 3]));
+    const text = new TextEncoder().encode(JSON.stringify({ k, bk: 'bad' }));
+    expect(() => decodeWelcomeSealedPayload(text)).toThrow(/invalid 'bk'.*BeeKEM welcome/);
+  });
+
+  test('allows bk absent', () => {
+    const k = Base64.fromUint8Array(new Uint8Array([1, 2, 3]));
+    const result = decodeWelcomeSealedPayload(new TextEncoder().encode(JSON.stringify({ k })));
+    expect(result.keychainChanges).toEqual(new Uint8Array([1, 2, 3]));
+    expect(result.beekemWelcome).toBeNull();
+  });
+
+  test('allows bk null', () => {
+    const k = Base64.fromUint8Array(new Uint8Array([1, 2, 3]));
+    const result = decodeWelcomeSealedPayload(new TextEncoder().encode(JSON.stringify({ k, bk: null })));
+    expect(result.keychainChanges).toEqual(new Uint8Array([1, 2, 3]));
+    expect(result.beekemWelcome).toBeNull();
+  });
+});

--- a/packages/collabswarm/tsconfig.json
+++ b/packages/collabswarm/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ESNext", "DOM"],
     "sourceMap": true,
     "downlevelIteration": true,
@@ -15,6 +15,6 @@
     "outDir": "dist",
     "composite": true
   },
-  "exclude": ["node_modules", "examples", "extras"],
+  "exclude": ["node_modules", "examples", "extras", "src/**/*.test.ts"],
   "include": ["src", "types", "bin"]
 }

--- a/relay-server/jest.config.cjs
+++ b/relay-server/jest.config.cjs
@@ -38,4 +38,7 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  coverageDirectory: 'coverage',
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/__mocks__/**'],
+  coverageReporters: ['text', 'lcov', 'html'],
 }

--- a/relay-server/package.json
+++ b/relay-server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node dist/index.js",
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@chainsafe/libp2p-noise": "^17.0.0",


### PR DESCRIPTION
Add `test:coverage` scripts and Jest coverage configuration (text/lcov/html reporters, collectCoverageFrom) to all 6 library packages and relay-server.

- `test:coverage` scripts on all 7 packages
- Jest coverage config: `collectCoverageFrom`, `coverageReporters` (text/lcov/html), `coverageDirectory`
- `ts-jest diagnostics:false` on collabswarm for ESM module mock compatibility
- Exclude test files from tsconfig build for clean `tsc -b`