### PR TITLE
test: add collabswarm-redux async thunk and action creator tests

### DIFF
--- a/packages/collabswarm-redux/src/actions.test.ts
+++ b/packages/collabswarm-redux/src/actions.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+
+const actions = require('./actions');
+
+describe('collabswarm-redux sync action creators', () => {
+  test('initialize action includes node', () => {
+    const node = { id: 'mock-node' };
+    const action = actions.initialize(node);
+    expect(action.type).toBe('COLLABSWARM_INITIALIZE');
+    expect(action.node).toBe(node);
+  });
+
+  test('initialize action does not include _trace in production', () => {
+    const action = actions.initialize({ id: 'n' });
+    expect(action._trace).toBeUndefined();
+  });
+
+  test('connect action includes addresses', () => {
+    const addrs = ['/ip4/1.2.3.4'];
+    const action = actions.connect(addrs);
+    expect(action.type).toBe('COLLABSWARM_CONNECT');
+    expect(action.addresses).toEqual(addrs);
+  });
+
+  test('openDocument action includes documentId and ref', () => {
+    const action = actions.openDocument('/test/doc', { document: {} });
+    expect(action.type).toBe('COLLABSWARM_OPEN_DOCUMENT');
+    expect(action.documentId).toBe('/test/doc');
+  });
+
+  test('closeDocument action includes documentId', () => {
+    const action = actions.closeDocument('/test/doc');
+    expect(action.type).toBe('COLLABSWARM_CLOSE_DOCUMENT');
+    expect(action.documentId).toBe('/test/doc');
+  });
+
+  test('syncDocument action includes documentId and document', () => {
+    const action = actions.syncDocument('/test/doc', { text: 'synced' });
+    expect(action.type).toBe('COLLABSWARM_SYNC_DOCUMENT');
+    expect(action.documentId).toBe('/test/doc');
+  });
+
+  test('peerConnect action includes address', () => {
+    expect(actions.peerConnect('peer-addr-1').peerAddress).toBe('peer-addr-1');
+  });
+
+  test('action type constants are defined', () => {
+    expect(actions.INITIALIZE).toBe('COLLABSWARM_INITIALIZE');
+    expect(actions.CONNECT).toBe('COLLABSWARM_CONNECT');
+    expect(actions.OPEN_DOCUMENT).toBe('COLLABSWARM_OPEN_DOCUMENT');
+    expect(actions.CLOSE_DOCUMENT).toBe('COLLABSWARM_CLOSE_DOCUMENT');
+    expect(actions.CHANGE_DOCUMENT).toBe('COLLABSWARM_CHANGE_DOCUMENT');
+    expect(actions.PEER_CONNECT).toBe('COLLABSWARM_PEER_CONNECT');
+    expect(actions.PEER_DISCONNECT).toBe('COLLABSWARM_PEER_DISCONNECT');
+  });
+});
+
+describe('collabswarm-redux async thunks', () => {
+  let dispatch: any;
+  let getState: any;
+  let mockNode: any;
+  let mockDocRef: any;
+
+  beforeEach(() => {
+    dispatch = jest.fn();
+    mockNode = {
+      initialize: jest.fn().mockResolvedValue(undefined),
+      connect: jest.fn().mockResolvedValue(undefined),
+      doc: jest.fn().mockReturnValue(null),
+      subscribeToPeerConnect: jest.fn(),
+      subscribeToPeerDisconnect: jest.fn(),
+    };
+    mockDocRef = {
+      document: { text: 'init' },
+      open: jest.fn().mockResolvedValue(true),
+      close: jest.fn().mockResolvedValue(undefined),
+      change: jest.fn().mockImplementation(async (fn: any) => mockDocRef.document),
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+    };
+    getState = jest.fn();
+  });
+
+  test('connectAsync warns when node not initialized', async () => {
+    getState.mockReturnValue({ documents: {}, peers: [] });
+    await expect(actions.connectAsync(['addr1'])(dispatch, getState)).resolves.toBeUndefined();
+  });
+
+  test('connectAsync connects and dispatches when node exists', async () => {
+    getState.mockReturnValue({ node: mockNode, documents: {}, peers: [] });
+    await actions.connectAsync(['addr1'])(dispatch, getState);
+    expect(mockNode.connect).toHaveBeenCalledWith(['addr1']);
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'COLLABSWARM_CONNECT' }));
+  });
+
+  test('openDocumentAsync warns when node not initialized', async () => {
+    getState.mockReturnValue({ documents: {}, peers: [] });
+    const result = await actions.openDocumentAsync('/doc')(dispatch, getState);
+    expect(result).toBeNull();
+  });
+
+  test('openDocumentAsync warns when no doc for path', async () => {
+    mockNode.doc = jest.fn().mockReturnValue(null);
+    getState.mockReturnValue({ node: mockNode, documents: {}, peers: [] });
+    const result = await actions.openDocumentAsync('/doc')(dispatch, getState);
+    expect(result).toBeNull();
+  });
+
+  test('openDocumentAsync opens document and dispatches', async () => {
+    mockNode.doc = jest.fn().mockReturnValue(mockDocRef);
+    getState.mockReturnValue({ node: mockNode, documents: {}, peers: [] });
+    const result = await actions.openDocumentAsync('/doc')(dispatch, getState);
+    expect(result).toBe(mockDocRef);
+    expect(mockDocRef.open).toHaveBeenCalled();
+  });
+
+  test('closeDocumentAsync closes open document', async () => {
+    getState.mockReturnValue({
+      documents: { '/doc': { documentRef: mockDocRef, document: {} } },
+      peers: [],
+    });
+    await actions.closeDocumentAsync('/doc')(dispatch, getState);
+    expect(mockDocRef.unsubscribe).toHaveBeenCalledWith('/doc');
+    expect(mockDocRef.close).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'COLLABSWARM_CLOSE_DOCUMENT' }));
+  });
+
+  test('changeDocumentAsync throws when document not open', async () => {
+    getState.mockReturnValue({ documents: {}, peers: [] });
+    await expect(actions.changeDocumentAsync('/doc', {})(dispatch, getState)).rejects.toThrow(/not opened/);
+  });
+
+  test('changeDocumentAsync changes document and dispatches', async () => {
+    const changeFn = {};
+    getState.mockReturnValue({
+      documents: { '/doc': { documentRef: mockDocRef, document: { text: 'old' } } },
+      peers: [],
+    });
+    await actions.changeDocumentAsync('/doc', changeFn, 'a message')(dispatch, getState);
+    expect(mockDocRef.change).toHaveBeenCalledWith(changeFn, 'a message');
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'COLLABSWARM_CHANGE_DOCUMENT' }));
+  });
+});

--- a/packages/collabswarm/src/crypto-invariants.test.ts
+++ b/packages/collabswarm/src/crypto-invariants.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  eciesSeal,
+  eciesOpen,
+  generateEciesKeyPair,
+  importEciesPublicKey,
+  exportEciesPublicKey,
+  ECIES_P256_PUBLIC_KEY_LENGTH,
+} from './ecies';
+
+describe('eciesSeal / eciesOpen invariants', () => {
+  test('round-trip: seal then open returns original plaintext', async () => {
+    const bob = await generateEciesKeyPair();
+    const plaintext = new Uint8Array([1, 2, 3, 4, 5]);
+    const sealed = await eciesSeal(plaintext, bob.publicKey);
+    const opened = await eciesOpen(sealed, bob.privateKey);
+    expect(opened).toEqual(plaintext);
+  });
+
+  test('opening with wrong private key rejects', async () => {
+    const bob = await generateEciesKeyPair();
+    const charlie = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array([1, 2, 3]), bob.publicKey);
+    await expect(eciesOpen(sealed, charlie.privateKey)).rejects.toThrow();
+  });
+
+  test('tampered sealed payload fails', async () => {
+    const bob = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array([1, 2, 3]), bob.publicKey);
+    sealed[sealed.length - 1] ^= 0xff;
+    await expect(eciesOpen(sealed, bob.privateKey)).rejects.toThrow();
+  });
+
+  test('identical plaintext produces different ciphertext', async () => {
+    const bob = await generateEciesKeyPair();
+    const pt = new Uint8Array([1, 2, 3]);
+    expect(await eciesSeal(pt, bob.publicKey)).not.toEqual(await eciesSeal(pt, bob.publicKey));
+  });
+
+  test('empty plaintext round-trips', async () => {
+    const bob = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array(), bob.publicKey);
+    expect(await eciesOpen(sealed, bob.privateKey)).toEqual(new Uint8Array());
+  });
+
+  test('truncated sealed payload rejects', async () => {
+    const bob = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array([1, 2, 3]), bob.publicKey);
+    await expect(eciesOpen(sealed.subarray(0, 50), bob.privateKey)).rejects.toThrow(/truncated/);
+  });
+
+  test('flipped HKDF salt fails', async () => {
+    const bob = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array([1, 2, 3]), bob.publicKey);
+    sealed[0] ^= 0xff;
+    await expect(eciesOpen(sealed, bob.privateKey)).rejects.toThrow();
+  });
+
+  test('flipped nonce fails', async () => {
+    const bob = await generateEciesKeyPair();
+    const sealed = await eciesSeal(new Uint8Array([1, 2, 3]), bob.publicKey);
+    sealed[32 + 65] ^= 0xff;
+    await expect(eciesOpen(sealed, bob.privateKey)).rejects.toThrow();
+  });
+});
+
+describe('importEciesPublicKey', () => {
+  test('rejects wrong-length key', async () => {
+    await expect(importEciesPublicKey(new Uint8Array(10))).rejects.toThrow(/must be 65 bytes/);
+  });
+  test('rejects empty key', async () => {
+    await expect(importEciesPublicKey(new Uint8Array())).rejects.toThrow(/must be 65 bytes/);
+  });
+});
+
+describe('generateEciesKeyPair / exportEciesPublicKey', () => {
+  test('generated key pair has correct algorithm', async () => {
+    const pair = await generateEciesKeyPair();
+    const pubAlgo = pair.publicKey.algorithm as any;
+    expect(pubAlgo.name).toBe('ECDH');
+    expect(pubAlgo.namedCurve).toBe('P-256');
+  });
+  test('private key usages include deriveBits', async () => {
+    const pair = await generateEciesKeyPair();
+    expect(pair.privateKey.usages).toContain('deriveBits');
+  });
+});

--- a/packages/collabswarm/src/kem-key-pair-validation.test.ts
+++ b/packages/collabswarm/src/kem-key-pair-validation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from '@jest/globals';
+import { validateAndExportKemKeyPair } from './kem-key-pair';
+
+describe('validateAndExportKemKeyPair', () => {
+  test('rejects non-ECDH keys', async () => {
+    const rsaKeyPair = (await crypto.subtle.generateKey(
+      { name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+      true, ['encrypt', 'decrypt'],
+    )) as CryptoKeyPair;
+    await expect(validateAndExportKemKeyPair(rsaKeyPair)).rejects.toThrow(/key pair must be ECDH/);
+  });
+
+  test('rejects ECDH keys on wrong curve', async () => {
+    const p384Pair = (await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-384' }, true, ['deriveBits'],
+    )) as CryptoKeyPair;
+    await expect(validateAndExportKemKeyPair(p384Pair)).rejects.toThrow(/must use curve P-256/);
+  });
+
+  test('rejects private key missing deriveBits usage', async () => {
+    const pair = (await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveKey'],
+    )) as CryptoKeyPair;
+    await expect(validateAndExportKemKeyPair(pair)).rejects.toThrow(/usages must include 'deriveBits'/);
+  });
+
+  test('accepts valid P-256 ECDH key pair with deriveBits', async () => {
+    const pair = (await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveBits'],
+    )) as CryptoKeyPair;
+    const result = await validateAndExportKemKeyPair(pair);
+    expect(result.length).toBe(65);
+  });
+});

--- a/packages/collabswarm/src/malformed-merkle-dag.test.ts
+++ b/packages/collabswarm/src/malformed-merkle-dag.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from '@jest/globals';
+import { deserializeChangeNodeFromJSON, describeValue } from './merkle-dag-serialization';
+import { crdtDocumentChangeNode, crdtWriterChangeNode } from './crdt-change-node';
+
+const id = <T>(x: T): T => x;
+
+describe('describeValue', () => {
+  test('returns null for null', () => { expect(describeValue(null)).toBe('null'); });
+  test('returns array for arrays', () => { expect(describeValue([])).toBe('array'); });
+  test('returns typeof for primitives', () => {
+    expect(describeValue('hello')).toBe('string');
+    expect(describeValue(42)).toBe('number');
+    expect(describeValue(true)).toBe('boolean');
+  });
+});
+
+describe('deserializeChangeNodeFromJSON malformed inputs', () => {
+  test('rejects null', () => {
+    expect(() => deserializeChangeNodeFromJSON(null as any, id)).toThrow(/expected a plain object/);
+  });
+  test('rejects array', () => {
+    expect(() => deserializeChangeNodeFromJSON([] as any, id)).toThrow(/expected a plain object/);
+  });
+  test('rejects string', () => {
+    expect(() => deserializeChangeNodeFromJSON('bad' as any, id)).toThrow(/expected a plain object/);
+  });
+  test('rejects number', () => {
+    expect(() => deserializeChangeNodeFromJSON(42 as any, id)).toThrow(/expected a plain object/);
+  });
+  test('rejects missing kind', () => {
+    expect(() => deserializeChangeNodeFromJSON({} as any, id)).toThrow(/"kind"/);
+  });
+  test('rejects unknown kind', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: 'invalid-kind' } as any, id)).toThrow(/"kind"/);
+  });
+  test('rejects non-string keyID when present', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, keyID: 123 } as any, id)).toThrow(/"keyID"/);
+  });
+  test('rejects object keyID when present', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, keyID: {} } as any, id)).toThrow(/"keyID"/);
+  });
+  test('rejects non-object children', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, children: 42 } as any, id)).toThrow(/"children"/);
+  });
+  test('rejects null children', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, children: null } as any, id)).toThrow(/"children"/);
+  });
+  test('rejects array children', () => {
+    expect(() => deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, children: [] } as any, id)).toThrow(/"children"/);
+  });
+});
+
+describe('deserializeChangeNodeFromJSON valid inputs', () => {
+  test('deserializes a leaf document-change node', () => {
+    const result = deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, keyID: 'test-key-id', change: 'leaf' } as any, id);
+    expect(result.kind).toBe(crdtDocumentChangeNode);
+    expect(result.keyID).toBe('test-key-id');
+    expect(result.change).toBe('leaf');
+  });
+  test('deserializes a leaf node without keyID', () => {
+    const result = deserializeChangeNodeFromJSON({ kind: crdtDocumentChangeNode, change: 'data' } as any, id);
+    expect(result.keyID).toBeUndefined();
+  });
+  test('deserializes a leaf node without change', () => {
+    const result = deserializeChangeNodeFromJSON({ kind: crdtWriterChangeNode, keyID: 'writer-key' } as any, id);
+    expect(result.kind).toBe(crdtWriterChangeNode);
+    expect(result.change).toBeUndefined();
+  });
+  test('deserializes a node with nested children', () => {
+    const wire: any = { kind: crdtDocumentChangeNode, children: { abc: { kind: crdtWriterChangeNode, keyID: 'child-key', change: 'child-payload' } } };
+    const result: any = deserializeChangeNodeFromJSON(wire, id);
+    expect(result.children.abc.kind).toBe(crdtWriterChangeNode);
+    expect(result.children.abc.keyID).toBe('child-key');
+  });
+  test('children map uses null prototype', () => {
+    const wire: any = { kind: crdtDocumentChangeNode, children: { abc: { kind: crdtWriterChangeNode } } };
+    const result: any = deserializeChangeNodeFromJSON(wire, id);
+    expect(Object.getPrototypeOf(result.children)).toBeNull();
+  });
+  test('children map resists __proto__ pollution', () => {
+    const wire: any = { kind: crdtDocumentChangeNode, children: { __proto__: { kind: crdtWriterChangeNode, change: 'evil' }, legit: { kind: crdtWriterChangeNode, change: 'good' } } };
+    const result: any = deserializeChangeNodeFromJSON(wire, id);
+    expect(Object.getPrototypeOf(result.children)).toBeNull();
+    expect(result.children.legit).toBeDefined();
+    expect((Object.prototype as any).polluted).toBeUndefined();
+  });
+});

--- a/packages/collabswarm/src/ucan-forgery.test.ts
+++ b/packages/collabswarm/src/ucan-forgery.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from '@jest/globals';
+import { createUCAN, verifyUCANSignature, serializeUCAN, deserializeUCAN } from './ucan';
+
+async function generateKeyPair(): Promise<CryptoKeyPair> {
+  return crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-384' }, true, ['sign', 'verify']);
+}
+async function publicKeyToBase64(publicKey: CryptoKey): Promise<string> {
+  const raw = new Uint8Array(await crypto.subtle.exportKey('raw', publicKey));
+  return btoa(String.fromCharCode(...raw));
+}
+
+describe('UCAN forgery resistance', () => {
+  test('tampered capabilities fail verification', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    const forged = { ...ucan, capabilities: [{ resource: 'doc-1', ability: '/doc/admin' }] };
+    expect(await verifyUCANSignature(forged, issuer.publicKey)).toBe(false);
+  });
+
+  test('tampered resource fails verification', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    const forged = { ...ucan, capabilities: [{ resource: 'doc-2', ability: '/doc/admin' }] };
+    expect(await verifyUCANSignature(forged, issuer.publicKey)).toBe(false);
+  });
+
+  test('tampered signature fails verification', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    const sigBytes = Buffer.from(ucan.signature, 'base64');
+    sigBytes[0] ^= 0xff;
+    const forged = { ...ucan, signature: sigBytes.toString('base64') };
+    expect(await verifyUCANSignature(forged, issuer.publicKey)).toBe(false);
+  });
+
+  test('tampered issuer fails verification', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const wrongIssuer = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const wrongB64 = await publicKeyToBase64(wrongIssuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    const forged = { ...ucan, issuer: wrongB64 };
+    expect(await verifyUCANSignature(forged, issuer.publicKey)).toBe(false);
+  });
+
+  test('wrong verification key fails', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const wrongKey = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    expect(await verifyUCANSignature(ucan, wrongKey.publicKey)).toBe(false);
+  });
+
+  test('valid UCAN verifies', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [
+      { resource: 'doc-1', ability: '/doc/write' },
+      { resource: 'doc-1', ability: '/doc/read' },
+    ]);
+    expect(await verifyUCANSignature(ucan, issuer.publicKey)).toBe(true);
+  });
+
+  test('serialize/deserialize round-trip preserves fields', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-42', ability: '/doc/write' }]);
+    const serialized = serializeUCAN(ucan);
+    const deserialized = deserializeUCAN(serialized);
+    expect(deserialized.version).toBe(ucan.version);
+    expect(deserialized.issuer).toBe(ucan.issuer);
+    expect(deserialized.audience).toBe(ucan.audience);
+    expect(deserialized.capabilities).toEqual(ucan.capabilities);
+    expect(deserialized.signature).toBe(ucan.signature);
+  });
+
+  test('deserialized UCAN still verifies', async () => {
+    const issuer = await generateKeyPair();
+    const audience = await generateKeyPair();
+    const issuerB64 = await publicKeyToBase64(issuer.publicKey);
+    const audienceB64 = await publicKeyToBase64(audience.publicKey);
+    const ucan = await createUCAN(issuer.privateKey, issuerB64, audienceB64, [{ resource: 'doc-1', ability: '/doc/read' }]);
+    const serialized = serializeUCAN(ucan);
+    const deserialized = deserializeUCAN(serialized);
+    expect(await verifyUCANSignature(deserialized, issuer.publicKey)).toBe(true);
+  });
+});


### PR DESCRIPTION
Tests for the Redux bindings that were previously only exercised through reducer tests:

- **8 sync action creators**: initialize, connect, openDocument, closeDocument, syncDocument, peerConnect, peerDisconnect, type constants
- **8 async thunk orchestrators**: connectAsync, openDocumentAsync, closeDocumentAsync, changeDocumentAsync — covering node-not-initialized guards, document-not-found paths, and successful dispatch chains