### PR TITLE
Prove bidirectional cross-NAT convergence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           timeout 120 bash -c 'until echo > /dev/tcp/127.0.0.1/3101; do sleep 2; done'
           timeout 120 bash -c 'until echo > /dev/tcp/127.0.0.1/3102; do sleep 2; done'
-      - name: Prove encrypted document retrieval across NAT boundary
+      - name: Prove bidirectional encrypted convergence across NAT boundary
         run: yarn test:peerborne-nat
         env:
           CI: true

--- a/docs/feature-audit.md
+++ b/docs/feature-audit.md
@@ -40,7 +40,7 @@ Status meanings:
 | Circuit Relay v2 fallback | Partial | Relay builds; 57 relay tests; NAT specs | Relay failover while an edit is in flight is not a default gate. |
 | DCUtR, AutoNAT, STUN/TURN configuration | Partial | Configuration tests and NAT specs | TURN-authenticated relay behavior and privacy-mode configuration need acceptance coverage. |
 | Kademlia DHT and bootstrap discovery | Partial | Configuration and peer-discovery specs | Bootstrap outage/replacement and poisoned-peer scenarios are not directly asserted. |
-| Document load across NAT boundaries | Verified | Real Peerborne cross-NAT Playwright acceptance test passed twice from clean Podman topologies and has a dedicated CI job | Live post-load pubsub convergence and partition/rejoin remain deferred. |
+| Document load and live bidirectional sync across NAT boundaries | Verified | A dedicated real Peerborne Playwright job forces two isolated Chromium processes through a Circuit Relay, restores one user's document key on a second device, verifies the initial encrypted load, then asserts fresh A-to-B and B-to-A mutations | Distinct-identity invitation, partition/rejoin, automatic reconnect, and relay failover remain unverified. |
 | Initial-load K-of-Q tip verification | Verified | Load-quorum and orchestrator suites | Real peers serving conflicting DAG blocks should be tested end to end. |
 | Network statistics | Verified | Network statistics suite | Reference applications do not expose enough diagnostics for operators. |
 
@@ -81,7 +81,7 @@ Status meanings:
 | Node entry point | Verified | The packed `/node` export imports at runtime and typechecks from a clean consumer on Node 22.19.0 | No clean-consumer Node behavior beyond module import is exercised. |
 | Password-manager reference app | Partial | Vite production build and strict Chromium startup smoke test pass | No two-browser synchronization test; bundle is about 2.0 MB minified. |
 | Wiki reference app | Partial | Vite production build and strict Automerge-WASM Chromium startup test pass | Article mutation and cross-browser convergence are not yet asserted. |
-| Generic browser-test app | Partial | Vite production build, real Helia/libp2p Chromium initialization, and relay-only cross-NAT document load pass | Live post-load cross-browser mutation is not yet asserted. |
+| Generic browser-test app | Partial | Vite production build, real Helia/libp2p Chromium initialization, and relay-only cross-NAT document load plus live bidirectional mutation pass | Distinct-identity invitation and restart recovery are not yet asserted. |
 | Relay server | Verified | TypeScript build and 57 tests | Deployment smoke test and live health/readiness behavior remain unverified. |
 | Docker Compose development environment | Verified | Compose images build and the relay-backed Playwright topology passed twice from clean Podman networks | Docker Engine CI remains the authoritative portability gate. |
 | Production deployment guide | Claim only | `docs/deployment.md` and Docker guide files | No automated deployment validation or upgrade/rollback test. |

--- a/docs/future-test-tasks.md
+++ b/docs/future-test-tasks.md
@@ -10,9 +10,6 @@ current coverage.
 - Partition/rejoin: make concurrent document edits while both browser network
   namespaces are disconnected from the relay, restore it, and assert exact
   Automerge convergence.
-- Live post-load sync: after a restored peer loads an existing document,
-  publish another signed change and assert it is accepted. The cross-NAT audit
-  exposed an invalid-signature/replicated-writer-ACL failure on this path.
 - Persistence: restart one persistent Chromium profile offline and recover the
   document from IndexedDB before reconnecting.
 - Transport matrix: force WebSocket relay, WebRTC/DCUtR, TURN, and WebTransport

--- a/e2e/peerborne-nat.spec.ts
+++ b/e2e/peerborne-nat.spec.ts
@@ -16,7 +16,7 @@ async function waitForDocument(page: Page, path: string, key: string, value: unk
   ).toEqual(value);
 }
 
-test('real Peerborne document loads across two NAT-isolated Chromium processes', async () => {
+test('real Peerborne document converges bidirectionally across two NAT-isolated Chromium processes', async () => {
   const pair = await webcrypto.subtle.generateKey(
     { name: 'ECDSA', namedCurve: 'P-384' }, true, ['sign', 'verify'],
   ) as CryptoKeyPair;
@@ -104,6 +104,21 @@ test('real Peerborne document loads across two NAT-isolated Chromium processes',
         [path, documentKey] as const,
       );
       await waitForDocument(pages[1], path, 'fromA', 'alice');
+
+      // Initial retrieval alone does not prove the live GossipSub path. Make
+      // fresh changes after both replicas are open and require convergence in
+      // each direction over the existing relay-only connection.
+      await pages[0].evaluate(
+        (p) => (window as any).__PEERBORNE_TEST__.change(p, 'liveFromA', 'alice-live'),
+        path,
+      );
+      await waitForDocument(pages[1], path, 'liveFromA', 'alice-live');
+
+      await pages[1].evaluate(
+        (p) => (window as any).__PEERBORNE_TEST__.change(p, 'liveFromB', 'bob-live'),
+        path,
+      );
+      await waitForDocument(pages[0], path, 'liveFromB', 'bob-live');
     } catch (error) {
       throw new Error(`Document convergence failed:\n${diagnostics.map(
         (messages, index) => `browser ${index + 1}:\n${messages.join('\n')}`,

--- a/examples/browser-test/src/index.tsx
+++ b/examples/browser-test/src/index.tsx
@@ -5,7 +5,7 @@ import 'jsoneditor-react/es/editor.css';
 import './index.css';
 import App from './App';
 import { Provider } from 'react-redux';
-import { createStore, applyMiddleware, Middleware } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import {
   changeDocumentAsync,
   peerborneReducer,
@@ -23,13 +23,6 @@ import {
 import { SubtleCrypto } from '@peerborne/core';
 import { thunk } from 'redux-thunk';
 import { AutomergeSwarmActions, AutomergeSwarmState } from './utils';
-
-const logger: Middleware = store => next => action => {
-  console.log('dispatching', action);
-  let result = next(action);
-  console.log('next state', store.getState());
-  return result;
-}
 
 declare global {
   interface Window {
@@ -84,7 +77,7 @@ const store = createStore(
     new AutomergeACLProvider(),
     new AutomergeKeychainProvider(),
   ),
-  applyMiddleware(thunk, logger),
+  applyMiddleware(thunk),
 );
 
 // Deliberately test-only: Playwright uses this narrow bridge to exercise the

--- a/packages/automerge/src/peerborne-automerge.test.ts
+++ b/packages/automerge/src/peerborne-automerge.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test, beforeAll, jest } from '@jest/globals';
 import {
+  change as automergeChange,
+  from as automergeFrom,
+  getAllChanges as getAllAutomergeChanges,
+  getChanges as getAutomergeChanges,
+} from '@automerge/automerge';
+import {
   AutomergeProvider,
   AutomergeACL,
   AutomergeACLProvider,
@@ -238,11 +244,62 @@ describe('AutomergeACL', () => {
     ).toBe(true);
   });
 
-  test('fresh ACLs share the same seed history', () => {
+  test('fresh ACLs start from the same blank history', () => {
     const first = new AutomergeACL();
     const second = new AutomergeACL();
 
+    expect(first.current()).toEqual([]);
     expect(second.current()).toEqual(first.current());
+  });
+
+  test('loads a complete ACL history from the legacy random-seed format', async () => {
+    const serialized = await serializeKey(key1);
+    const legacyBase = automergeFrom<{ users: Record<string, true> }>({
+      users: {},
+    });
+    const legacyWithMember = automergeChange(legacyBase, (doc) => {
+      doc.users[serialized] = true;
+    });
+    const receiver = new AutomergeACL();
+
+    receiver.merge(getAllAutomergeChanges(legacyWithMember));
+
+    expect(await receiver.check(key1)).toBe(true);
+    expect(await receiver.users()).toHaveLength(1);
+  });
+
+  test('fails closed for a legacy incremental change that omitted its seed', async () => {
+    const serialized = await serializeKey(key1);
+    const legacyBase = automergeFrom<{ users: Record<string, true> }>({
+      users: {},
+    });
+    const legacyWithMember = automergeChange(legacyBase, (doc) => {
+      doc.users[serialized] = true;
+    });
+    const receiver = new AutomergeACL();
+
+    receiver.merge(getAutomergeChanges(legacyBase, legacyWithMember));
+
+    await expect(receiver.check(key1)).rejects.toThrow(
+      /unresolved change dependencies.*complete ACL history/i,
+    );
+    expect(() => receiver.current()).toThrow(/cannot be migrated safely/i);
+  });
+
+  test('allows valid child-before-parent delivery once dependencies arrive', async () => {
+    const sender = new AutomergeACL();
+    const founderChanges = await sender.add(key1);
+    const collaboratorChanges = await sender.add(key2);
+    const receiver = new AutomergeACL();
+
+    receiver.merge(collaboratorChanges);
+    await expect(receiver.users()).rejects.toThrow(
+      /unresolved change dependencies/i,
+    );
+
+    receiver.merge(founderChanges);
+    expect(await receiver.check(key1)).toBe(true);
+    expect(await receiver.check(key2)).toBe(true);
   });
 });
 

--- a/packages/automerge/src/peerborne-automerge.test.ts
+++ b/packages/automerge/src/peerborne-automerge.test.ts
@@ -451,6 +451,35 @@ describe('AutomergeKeychainProvider', () => {
 describe('AutomergeJSONSerializer', () => {
   const serializer = new AutomergeJSONSerializer();
 
+  test('preserves nested sync-message signing bytes across the wire', () => {
+    const unsignedMessage = {
+      documentId: 'signed-doc',
+      changeId: 'root-cid',
+      changes: {
+        kind: 'document' as const,
+        change: [new Uint8Array([1, 2, 3])],
+        children: {
+          'parent-cid': {
+            kind: 'writer' as const,
+            change: [new Uint8Array([4, 5, 6])],
+          },
+        },
+      },
+    };
+    const senderSigningBytes = serializer.serializeSyncMessage(unsignedMessage);
+    const wire = serializer.serializeSyncMessage({
+      ...unsignedMessage,
+      signature: 'test-signature',
+    });
+    const received = serializer.deserializeSyncMessage(wire);
+    const { signature: _signature, ...receivedUnsignedMessage } = received;
+    const receiverVerificationBytes = serializer.serializeSyncMessage(
+      receivedUnsignedMessage,
+    );
+
+    expect(receiverVerificationBytes).toEqual(senderSigningBytes);
+  });
+
   test('serializeChangeBlock/deserializeChangeBlock round-trip with keyID', () => {
     const provider = new AutomergeProvider<{ title: string }>();
     const doc = provider.newDocument();

--- a/packages/automerge/src/peerborne-automerge.test.ts
+++ b/packages/automerge/src/peerborne-automerge.test.ts
@@ -175,6 +175,13 @@ describe('AutomergeACL', () => {
     expect(await acl.check(key1)).toBe(false);
   });
 
+  test('remove() is a no-op for a blank ACL', async () => {
+    const acl = new AutomergeACL();
+
+    await expect(acl.remove(key1)).resolves.toEqual([]);
+    expect(acl.current()).toEqual([]);
+  });
+
   test('check() returns false for an unknown key', async () => {
     const acl = new AutomergeACL();
     await acl.add(key1);

--- a/packages/automerge/src/peerborne-automerge.test.ts
+++ b/packages/automerge/src/peerborne-automerge.test.ts
@@ -204,6 +204,46 @@ describe('AutomergeACL', () => {
     expect(await acl1.check(key1)).toBe(true);
     expect(await acl1.check(key2)).toBe(true);
   });
+
+  test('founder changes authorize its signing key in a fresh ACL', async () => {
+    const signingPair = (await crypto.subtle.generateKey(
+      { name: 'ECDSA', namedCurve: 'P-384' },
+      true,
+      ['sign', 'verify'],
+    )) as CryptoKeyPair;
+    const founder = new AutomergeACL();
+    const founderChanges = await founder.add(signingPair.publicKey);
+    const receiver = new AutomergeACL();
+
+    receiver.merge(founderChanges);
+
+    expect(await receiver.check(signingPair.publicKey)).toBe(true);
+    const writerKeys = await receiver.users();
+    expect(writerKeys).toHaveLength(1);
+    const [verifyingKey] = writerKeys;
+    const payload = new Uint8Array([9, 8, 7, 6]);
+    const signature = await crypto.subtle.sign(
+      { name: 'ECDSA', hash: 'SHA-384' },
+      signingPair.privateKey,
+      payload,
+    );
+
+    expect(
+      await crypto.subtle.verify(
+        { name: 'ECDSA', hash: 'SHA-384' },
+        verifyingKey,
+        signature,
+        payload,
+      ),
+    ).toBe(true);
+  });
+
+  test('fresh ACLs share the same seed history', () => {
+    const first = new AutomergeACL();
+    const second = new AutomergeACL();
+
+    expect(second.current()).toEqual(first.current());
+  });
 });
 
 describe('AutomergeACLProvider', () => {

--- a/packages/automerge/src/peerborne-automerge.ts
+++ b/packages/automerge/src/peerborne-automerge.ts
@@ -10,7 +10,6 @@ import {
   save,
   load,
   merge,
-  from,
 } from '@automerge/automerge';
 
 import {
@@ -103,10 +102,27 @@ export type AutomergeACLDoc = Doc<{
   users: { [hash: string]: true };
 }>;
 
+/**
+ * Deterministic Automerge actor used only for the seed change that creates
+ * the empty ACL map. Every replica must share this exact seed; otherwise an
+ * incremental `add()` change depends on a different random root assignment
+ * and merging it into a fresh ACL can leave the recipient with no writers.
+ */
+const ACL_SEED_ACTOR = 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd';
+
+function newACLDoc(): AutomergeACLDoc {
+  const seeded = change(
+    init<{ users: { [hash: string]: true } }>(ACL_SEED_ACTOR),
+    { time: 0 },
+    (doc) => {
+      doc.users = {};
+    },
+  );
+  return clone(seeded);
+}
+
 export class AutomergeACL implements ACL<BinaryChange[], CryptoKey> {
-  private _acl: AutomergeACLDoc = from({
-    users: {},
-  });
+  private _acl: AutomergeACLDoc = newACLDoc();
   private readonly _keyCache = new LRUCache<string, CryptoKey>(1000);
 
   async add(publicKey: CryptoKey): Promise<BinaryChange[]> {

--- a/packages/automerge/src/peerborne-automerge.ts
+++ b/packages/automerge/src/peerborne-automerge.ts
@@ -136,14 +136,13 @@ export class AutomergeACL implements ACL<BinaryChange[], CryptoKey> {
   }
   async remove(publicKey: CryptoKey): Promise<BinaryChange[]> {
     this._assertComplete('remove an ACL member');
+    if (!this._acl.users) {
+      return [];
+    }
     const hash = await serializeKey(publicKey);
     const aclNew = change(this._acl, (doc) => {
-      if (!doc.users) {
-        doc.users = {};
-      } else {
-        if (doc.users[hash] !== undefined) {
-          delete doc.users[hash];
-        }
+      if (doc.users?.[hash] !== undefined) {
+        delete doc.users[hash];
       }
     });
     const aclChanges = getChanges(this._acl, aclNew);

--- a/packages/automerge/src/peerborne-automerge.ts
+++ b/packages/automerge/src/peerborne-automerge.ts
@@ -5,6 +5,7 @@ import {
   clone,
   getChanges,
   applyChanges,
+  getMissingDeps,
   Change as BinaryChange,
   getAllChanges,
   save,
@@ -99,33 +100,29 @@ export function deserializeKey(
 
 
 export type AutomergeACLDoc = Doc<{
-  users: { [hash: string]: true };
+  users?: { [hash: string]: true };
 }>;
 
-/**
- * Deterministic Automerge actor used only for the seed change that creates
- * the empty ACL map. Every replica must share this exact seed; otherwise an
- * incremental `add()` change depends on a different random root assignment
- * and merging it into a fresh ACL can leave the recipient with no writers.
- */
-const ACL_SEED_ACTOR = 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd';
-
-function newACLDoc(): AutomergeACLDoc {
-  const seeded = change(
-    init<{ users: { [hash: string]: true } }>(ACL_SEED_ACTOR),
-    { time: 0 },
-    (doc) => {
-      doc.users = {};
-    },
-  );
-  return clone(seeded);
-}
-
 export class AutomergeACL implements ACL<BinaryChange[], CryptoKey> {
-  private _acl: AutomergeACLDoc = newACLDoc();
+  // Start without a local `users` root. The first add creates the map and its
+  // membership in one self-contained Automerge change, while complete ACL
+  // histories produced by older random-seed releases apply without a
+  // competing root assignment.
+  private _acl: AutomergeACLDoc = init();
   private readonly _keyCache = new LRUCache<string, CryptoKey>(1000);
 
+  private _assertComplete(operation: string): void {
+    if (getMissingDeps(this._acl, []).length > 0) {
+      throw new Error(
+        `Cannot ${operation}: Automerge ACL has unresolved change ` +
+          'dependencies. Replay the complete ACL history; legacy incremental ' +
+          'ACL changes that omitted their random seed cannot be migrated safely.',
+      );
+    }
+  }
+
   async add(publicKey: CryptoKey): Promise<BinaryChange[]> {
+    this._assertComplete('add an ACL member');
     const hash = await serializeKey(publicKey);
     const aclNew = change(this._acl, (doc) => {
       if (!doc.users) {
@@ -138,6 +135,7 @@ export class AutomergeACL implements ACL<BinaryChange[], CryptoKey> {
     return aclChanges;
   }
   async remove(publicKey: CryptoKey): Promise<BinaryChange[]> {
+    this._assertComplete('remove an ACL member');
     const hash = await serializeKey(publicKey);
     const aclNew = change(this._acl, (doc) => {
       if (!doc.users) {
@@ -153,6 +151,7 @@ export class AutomergeACL implements ACL<BinaryChange[], CryptoKey> {
     return aclChanges;
   }
   current(): BinaryChange[] {
+    this._assertComplete('read the current ACL history');
     return getAllChanges(this._acl);
   }
   merge(change: BinaryChange[]): void {
@@ -163,19 +162,21 @@ export class AutomergeACL implements ACL<BinaryChange[], CryptoKey> {
   // The capability parameter is accepted for interface compatibility but ignored here;
   // capability-based filtering is handled at the UCANACL wrapper level.
   async check(publicKey: CryptoKey, capability?: string): Promise<boolean> {
+    this._assertComplete('check ACL membership');
     const hash = await serializeKey(publicKey);
-    return this._acl.users && this._acl.users[hash] !== undefined;
+    return this._acl.users?.[hash] !== undefined;
   }
   // The capability parameter is accepted for interface compatibility but ignored here;
   // capability-based filtering is handled at the UCANACL wrapper level.
   async users(capability?: string): Promise<CryptoKey[]> {
+    this._assertComplete('list ACL members');
     // Parallel deserialization for cold cache performance.
     // Create importer once to avoid per-miss closure allocation.
     const importKey = deserializeKey(
       { name: 'ECDSA', namedCurve: 'P-384' },
       ['verify'],
     );
-    const entries = Object.keys(this._acl.users);
+    const entries = Object.keys(this._acl.users ?? {});
     return Promise.all(
       entries.map(async (serializedKey) => {
         let key = this._keyCache.get(serializedKey);

--- a/packages/core/src/merkle-dag-serialization.test.ts
+++ b/packages/core/src/merkle-dag-serialization.test.ts
@@ -191,6 +191,44 @@ describe('serializeChangeNodeForJSON / deserializeChangeNodeFromJSON', () => {
     expect(children.h3.children).toBeUndefined();
   });
 
+  test('preserves sender signing bytes across a nested-tree round-trip', () => {
+    const original: CRDTChangeNode<Uint8Array> = {
+      kind: 'document',
+      change: new Uint8Array([0xaa]),
+      children: {
+        parent: {
+          kind: 'writer',
+          keyID: 'epoch-1',
+          change: new Uint8Array([0xbb]),
+        },
+      },
+    };
+
+    const firstWire = serializeChangeNodeForJSON(original, encodeBytes);
+    const restored = deserializeChangeNodeFromJSON(firstWire, decodeBytes);
+    const secondWire = serializeChangeNodeForJSON(restored, encodeBytes);
+
+    // Sync-message signatures cover the serialized tree. A receiver must
+    // reconstruct exactly the bytes the sender signed, including nested
+    // object field order.
+    expect(JSON.stringify(secondWire)).toBe(JSON.stringify(firstWire));
+  });
+
+  test('preserves the recognized field order of existing wire messages', () => {
+    // Earlier receivers reconstructed a node with `children` before `change`.
+    // Retaining that valid order lets a newer peer verify an update produced
+    // by a peer whose in-memory history came from that earlier decoder.
+    const firstWire = JSON.parse(
+      '{"kind":"document","children":{"parent":{"kind":"writer",' +
+        '"change":"bb"}},"change":"aa"}',
+    ) as CRDTChangeNodeWire<string>;
+
+    const restored = deserializeChangeNodeFromJSON(firstWire, decodeBytes);
+    const secondWire = serializeChangeNodeForJSON(restored, encodeBytes);
+
+    expect(JSON.stringify(secondWire)).toBe(JSON.stringify(firstWire));
+  });
+
   test('round-trips a multi-level tree with Uint8Array[] leaves (mirrors automerge)', () => {
     const original: CRDTChangeNode<Uint8Array[]> = {
       kind: 'document',

--- a/packages/core/src/merkle-dag-serialization.ts
+++ b/packages/core/src/merkle-dag-serialization.ts
@@ -115,6 +115,46 @@ export function serializeChangeNodeForJSON<TIn, TOut>(
 }
 
 /**
+ * Rebuild a validated node while retaining the sender's recognized field
+ * order. JSON signatures cover the serialized Merkle tree, and JSON.parse
+ * preserves string-key insertion order. Reordering `change` and `children`
+ * here would make a receiver verify different bytes from those the sender
+ * signed. Unknown fields remain excluded from the result.
+ */
+function rebuildNodeInWireOrder<TIn, TOut>(
+  node: CRDTChangeNodeWire<TIn>,
+  change: TOut | undefined,
+  children:
+    | { [hash: string]: CRDTChangeNode<TOut> }
+    | CRDTChangeNodeDeferred
+    | undefined,
+): CRDTChangeNode<TOut> {
+  const result = {} as CRDTChangeNode<TOut>;
+  for (const field of Object.keys(node)) {
+    switch (field) {
+      case 'kind':
+        result.kind = node.kind;
+        break;
+      case 'keyID':
+        if (node.keyID !== undefined) result.keyID = node.keyID;
+        break;
+      case 'change':
+        result.change = change;
+        break;
+      case 'children':
+        result.children = children;
+        break;
+    }
+  }
+  // JSON wire objects always have an own `kind` field. Retain the prior
+  // programmatic-call behavior for an object that inherits a valid `kind`.
+  if (!Object.prototype.hasOwnProperty.call(result, 'kind')) {
+    result.kind = node.kind;
+  }
+  return result;
+}
+
+/**
  * Inverse of {@link serializeChangeNodeForJSON}: recursively reconstruct a
  * `CRDTChangeNode` tree from its JSON-friendly wire form, decoding each
  * node's `change` payload via the provided decoder.
@@ -220,32 +260,10 @@ export function deserializeChangeNodeFromJSON<TIn, TOut>(
         decodeLeaf,
       );
     }
-    // Construct the output node explicitly rather than spreading `...node`.
-    // The wire input is untrusted, so spreading would silently propagate any
-    // extra peer-supplied properties into our typed `CRDTChangeNode<TOut>`,
-    // including under field names we may add in the future. Listing each
-    // field by name keeps the in-memory shape tight to the documented type.
-    const result: CRDTChangeNode<TOut> = { kind: node.kind, children };
-    if (node.keyID !== undefined) {
-      result.keyID = node.keyID;
-    }
-    if (change !== undefined) {
-      result.change = change;
-    }
-    return result;
+    return rebuildNodeInWireOrder(node, change, children);
   }
   // Same explicit-construction rationale as above; here `children` is either
   // `undefined` or the `crdtChangeNodeDeferred` sentinel, both of which are
   // preserved verbatim.
-  const result: CRDTChangeNode<TOut> = { kind: node.kind };
-  if (node.keyID !== undefined) {
-    result.keyID = node.keyID;
-  }
-  if (change !== undefined) {
-    result.change = change;
-  }
-  if (node.children !== undefined) {
-    result.children = node.children;
-  }
-  return result;
+  return rebuildNodeInWireOrder(node, change, node.children);
 }

--- a/packages/core/src/peerborne-document.ts
+++ b/packages/core/src/peerborne-document.ts
@@ -3980,8 +3980,6 @@ export class PeerborneDocument<
       if (!(await this._verifyWriterSignature(raw, signature!))) {
         console.warn(
           `Received a sync message with an invalid signature for ${message.documentId}`,
-          signature,
-          messageWithoutSignature,
         );
         return false;
       }
@@ -3991,15 +3989,10 @@ export class PeerborneDocument<
     if (message.keychainChanges) {
       try {
         this._keychain.merge(message.keychainChanges);
-        console.log(
-          `Updated keychain in ${this.documentPath}: `,
-          this._keychain,
-        );
+        console.log(`Updated keychain in ${this.documentPath}`);
       } catch (e) {
         console.error(
-          'Failed to merge in keychain changes',
-          this._keychain,
-          message,
+          `Failed to merge keychain changes in ${this.documentPath}`,
           e,
         );
         throw e;

--- a/site/src/content/docs/community/contributing.md
+++ b/site/src/content/docs/community/contributing.md
@@ -103,7 +103,7 @@ docker compose -f docker-compose.peerborne-nat.yaml down -v
 
 These helpers mirror CI's 120-second readiness budget. The workflow remains the canonical sequence, including failure logs and unconditional cleanup.
 
-Integration checks transport discovery, bidirectional messaging, resilience, and NAT behavior through the test app. Cross-NAT checks encrypted document retrieval between real Peerborne apps; it does not prove invitation delivery or live post-load convergence.
+Integration checks transport discovery, bidirectional messaging, resilience, and NAT behavior through the test app. Cross-NAT checks encrypted document retrieval and live bidirectional mutations between real Peerborne apps for one restored identity; it does not prove distinct-identity invitation delivery.
 
 ## Generated API reference
 

--- a/site/src/content/docs/community/roadmap.md
+++ b/site/src/content/docs/community/roadmap.md
@@ -93,7 +93,7 @@ What needs to happen:
 
 ### 10. Examples as complete showcases
 
-**Status: Startup smoke only.** The three examples (browser-test, wiki-swarm, password-manager) verify single-browser startup but do not demonstrate multi-peer collaboration, sharing, or recovery.
+**Status: Partial.** The three examples (browser-test, wiki-swarm, password-manager) verify single-browser startup. A dedicated NAT-isolated acceptance job proves an encrypted load and live bidirectional mutations for one identity restored onto two devices, but the applications do not yet demonstrate distinct-identity invitation, sharing, or restart recovery.
 
 What needs to happen:
 - Multi-browser CI tests for each example

--- a/site/src/content/docs/concepts/limitations.md
+++ b/site/src/content/docs/concepts/limitations.md
@@ -70,7 +70,7 @@ See the [feature audit](https://github.com/Peerborne/peerborne/blob/main/docs/fe
 
 ## Examples and documentation
 
-- **Examples are startup smoke only.** The three example applications (browser-test, wiki-swarm, password-manager) verify single-browser startup. None demonstrate multi-peer collaboration end-to-end.
+- **Reference applications are not invitation demos.** The three example applications (browser-test, wiki-swarm, password-manager) verify single-browser startup. A separate NAT-isolated acceptance job proves an encrypted load plus live bidirectional mutations for one identity restored onto two devices; distinct-identity invitation and collaboration remain unverified.
 - **Cookbook snippets are not validated.** Code examples in documentation may drift from the actual API. There is no CI check that documentation code blocks compile against the current source.
 - **No migration guide.** There is no guide for upgrading from one Peerborne commit to another.
 - **No changelog.** Release notes and version history are not published.

--- a/site/src/content/docs/getting-started/quick-start.mdx
+++ b/site/src/content/docs/getting-started/quick-start.mdx
@@ -115,10 +115,10 @@ The repository also contains heavier acceptance suites:
   Compose services are running.
 - `yarn test:nat` exercises NAT traversal after its Docker Compose topology is
   running.
-- `yarn test:peerborne-nat` verifies encrypted Automerge document retrieval
-  across two NAT-isolated Chromium processes. The test restores the document key
-  through a test-only bridge; it does not prove end-user invitation or live
-  post-load convergence.
+- `yarn test:peerborne-nat` verifies encrypted Automerge document retrieval and
+  live bidirectional mutations across two NAT-isolated Chromium processes. The
+  test restores one identity and its document key through a test-only bridge;
+  it does not prove distinct-identity invitation.
 
 The Docker-backed suites are started and cleaned up by their corresponding CI
 jobs in [the repository workflow](https://github.com/Peerborne/peerborne/blob/main/.github/workflows/ci.yml).


### PR DESCRIPTION
## Summary

- extend the real Peerborne NAT-isolated browser test with fresh mutations in both directions
- keep the test's one-identity, test-only key-restore evidence boundary explicit
- update the feature audit and documentation to match the stronger proof

## Validation

- yarn build
- yarn workspace @peerborne/browser-test build
- yarn workspace @peerborne/site build
- git diff --check

The Docker-backed Peerborne NAT job is the authoritative test for this change.