### PR TITLE
Add architecture and trust-boundary diagrams

### DIFF
--- a/site/src/assets/diagrams/change-pipeline.svg
+++ b/site/src/assets/diagrams/change-pipeline.svg
@@ -1,0 +1,121 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 760" role="img" aria-labelledby="title desc">
+  <title id="title">A Peerborne change creates separate storage and wire artifacts</title>
+  <desc id="desc">A local mutation is serialized and encrypted into a CID-addressed stored change payload. Its CID, inline history, and deferred CID references are assembled into a separate CRDT sync message, signed when enabled, encrypted, and published as a full GossipSub envelope. A receiver decrypts that envelope before known-writer authorization, applies inline history, and fetches only missing or deferred CID blocks for CID integrity validation and decryption.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="storagePanel" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#1e1b4b"/>
+      <stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="wirePanel" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#0f3f46"/>
+      <stop offset="1" stop-color="#164e63"/>
+    </linearGradient>
+    <marker id="arrowIndigo" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#a5b4fc"/>
+    </marker>
+    <marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#5eead4"/>
+    </marker>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#020617" flood-opacity="0.35"/>
+    </filter>
+    <style>
+      text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .eyebrow { font-size: 15px; font-weight: 700; letter-spacing: 1.6px; }
+      .heading { fill: #f8fafc; font-size: 31px; font-weight: 750; }
+      .subheading { fill: #cbd5e1; font-size: 17px; }
+      .step { fill: #f8fafc; font-size: 18px; font-weight: 700; }
+      .detail { fill: #cbd5e1; font-size: 15px; }
+      .number { fill: #0f172a; font-size: 16px; font-weight: 800; text-anchor: middle; dominant-baseline: middle; }
+      .footer { fill: #cbd5e1; font-size: 15px; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="760" rx="28" fill="url(#background)"/>
+  <text x="54" y="58" class="eyebrow" fill="#818cf8">PEERBORNE CHANGE PIPELINE</text>
+  <text x="54" y="98" class="heading">One change, two related artifacts</text>
+  <text x="54" y="128" class="subheading">The stored block and the GossipSub envelope have different integrity and authorization checks.</text>
+
+  <rect x="44" y="154" width="1112" height="174" rx="22" fill="url(#storagePanel)" stroke="#6366f1" stroke-width="2"/>
+  <text x="68" y="183" class="eyebrow" fill="#a5b4fc">A · ENCRYPTED, CID-ADDRESSED STORAGE ARTIFACT</text>
+
+  <g filter="url(#shadow)">
+    <rect x="68" y="202" width="226" height="98" rx="16" fill="#1e293b" stroke="#475569"/>
+    <circle cx="91" cy="225" r="15" fill="#a5b4fc"/><text x="91" y="226" class="number">1</text>
+    <text x="114" y="230" class="step">Local CRDT mutation</text>
+    <text x="88" y="263" class="detail">produces change bytes</text>
+
+    <rect x="336" y="202" width="226" height="98" rx="16" fill="#1e293b" stroke="#475569"/>
+    <circle cx="359" cy="225" r="15" fill="#a5b4fc"/><text x="359" y="226" class="number">2</text>
+    <text x="382" y="230" class="step">Serialize payload</text>
+    <text x="356" y="263" class="detail">change data, not sync envelope</text>
+
+    <rect x="604" y="202" width="226" height="98" rx="16" fill="#1e293b" stroke="#475569"/>
+    <circle cx="627" cy="225" r="15" fill="#a5b4fc"/><text x="627" y="226" class="number">3</text>
+    <text x="650" y="230" class="step">AES-GCM encrypt</text>
+    <text x="624" y="263" class="detail">with the document key</text>
+
+    <rect x="872" y="202" width="260" height="98" rx="16" fill="#1e293b" stroke="#818cf8"/>
+    <circle cx="895" cy="225" r="15" fill="#a5b4fc"/><text x="895" y="226" class="number">4</text>
+    <text x="918" y="230" class="step">Store ciphertext</text>
+    <text x="892" y="259" class="detail">Helia returns its content ID (CID)</text>
+    <text x="892" y="280" class="detail">for later references and retrieval</text>
+  </g>
+  <path d="M 294 251 H 330 M 562 251 H 598 M 830 251 H 866" fill="none" stroke="#a5b4fc" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+
+  <rect x="44" y="350" width="1112" height="180" rx="22" fill="url(#wirePanel)" stroke="#14b8a6" stroke-width="2"/>
+  <text x="68" y="379" class="eyebrow" fill="#5eead4">B · SEPARATE GOSSIPSUB WIRE ARTIFACT</text>
+
+  <g filter="url(#shadow)">
+    <rect x="68" y="398" width="294" height="104" rx="16" fill="#15343b" stroke="#2dd4bf"/>
+    <circle cx="91" cy="421" r="15" fill="#5eead4"/><text x="91" y="422" class="number">5</text>
+    <text x="114" y="426" class="step">Build CRDTSyncMessage</text>
+    <text x="88" y="455" class="detail">new CID + inline change tree</text>
+    <text x="88" y="477" class="detail">+ deferred CID references</text>
+
+    <rect x="405" y="398" width="212" height="104" rx="16" fill="#15343b" stroke="#2dd4bf"/>
+    <circle cx="428" cy="421" r="15" fill="#5eead4"/><text x="428" y="422" class="number">6</text>
+    <text x="451" y="426" class="step">Sign if enabled</text>
+    <text x="425" y="455" class="detail">signature covers the</text>
+    <text x="425" y="477" class="detail">entire sync message</text>
+
+    <rect x="660" y="398" width="214" height="104" rx="16" fill="#15343b" stroke="#2dd4bf"/>
+    <circle cx="683" cy="421" r="15" fill="#5eead4"/><text x="683" y="422" class="number">7</text>
+    <text x="706" y="426" class="step">Serialize + encrypt</text>
+    <text x="680" y="455" class="detail">AES-GCM envelope with</text>
+    <text x="680" y="477" class="detail">the document key</text>
+
+    <rect x="917" y="398" width="215" height="104" rx="16" fill="#15343b" stroke="#5eead4"/>
+    <circle cx="940" cy="421" r="15" fill="#5eead4"/><text x="940" y="422" class="number">8</text>
+    <text x="963" y="426" class="step">Publish envelope</text>
+    <text x="937" y="455" class="detail">full encrypted message</text>
+    <text x="937" y="477" class="detail">over GossipSub—not CID-only</text>
+  </g>
+  <path d="M 362 450 H 399 M 617 450 H 654 M 874 450 H 911" fill="none" stroke="#5eead4" stroke-width="3" marker-end="url(#arrowTeal)"/>
+
+  <rect x="44" y="552" width="1112" height="140" rx="22" fill="#111f34" stroke="#475569" stroke-width="2"/>
+  <text x="68" y="581" class="eyebrow" fill="#93c5fd">REMOTE DEVICE · ORDERED CHECKS</text>
+  <g>
+    <circle cx="92" cy="620" r="16" fill="#93c5fd"/><text x="92" y="621" class="number">9</text>
+    <text x="119" y="616" class="step">Decrypt envelope first</text>
+    <text x="119" y="640" class="detail">then deserialize the sync message</text>
+
+    <circle cx="430" cy="620" r="16" fill="#93c5fd"/><text x="430" y="621" class="number">10</text>
+    <text x="457" y="610" class="step">Authorize known writer</text>
+    <text x="457" y="634" class="detail">verify outer signature + writer ACL</text>
+    <text x="457" y="655" class="detail">when signing is enabled and writers are known</text>
+
+    <circle cx="814" cy="620" r="16" fill="#93c5fd"/><text x="814" y="621" class="number">11</text>
+    <text x="841" y="610" class="step">Apply inline history</text>
+    <text x="841" y="634" class="detail">Fetch only missing or deferred CIDs.</text>
+    <text x="841" y="655" class="detail">CID check → decrypt → deserialize and apply.</text>
+  </g>
+  <path d="M 374 620 H 404 M 758 620 H 788" fill="none" stroke="#93c5fd" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+
+  <rect x="44" y="710" width="1112" height="30" rx="15" fill="#332742"/>
+  <text x="600" y="731" class="footer" text-anchor="middle">Failure boundary: a local mutation can remain visible if later storage or publish fails; there is no rollback, durable outbox, or delivery receipt.</text>
+</svg>

--- a/site/src/assets/diagrams/initial-load.svg
+++ b/site/src/assets/diagrams/initial-load.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 840" role="img" aria-labelledby="title desc">
+  <title id="title">Peerborne remote initial document load</title>
+  <desc id="desc">A quorum-enabled remote document load requires Q-of-K peers to agree on a frontier hash before Peerborne binds a selected response, strips inline changes, and fetches the CIDs enumerated by its served changes tree before mutation. A quorum-bound first load has no prior writer set for outer-signature authentication, so it drops an unverifiable snapshot and requires an available changes tree. With quorum disabled, the legacy path skips peer advertisements, frontier binding, stripping, and prefetch. CID validation covers fetched ciphertext bytes, not responder-supplied node kinds or interior topology, writer identity, or history completeness.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8"/>
+    </marker>
+    <marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#5eead4"/>
+    </marker>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#020617" flood-opacity="0.35"/>
+    </filter>
+    <style>
+      text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .eyebrow { font-size: 15px; font-weight: 750; letter-spacing: 1.4px; }
+      .heading { fill: #f8fafc; font-size: 31px; font-weight: 750; }
+      .subheading { fill: #cbd5e1; font-size: 17px; }
+      .step { fill: #f8fafc; font-size: 18px; font-weight: 700; }
+      .detail { fill: #cbd5e1; font-size: 15px; }
+      .number { fill: #0f172a; font-size: 16px; font-weight: 800; text-anchor: middle; dominant-baseline: middle; }
+      .result { font-size: 17px; font-weight: 700; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="840" rx="28" fill="url(#background)"/>
+  <text x="54" y="58" class="eyebrow" fill="#818cf8">REMOTE EXISTING DOCUMENT</text>
+  <text x="54" y="98" class="heading">Quorum-bound load checks before mutation</text>
+  <text x="54" y="128" class="subheading">When enabled, agreement, response binding, and changes-tree prefetch finish before replica mutation.</text>
+
+  <g filter="url(#shadow)">
+    <rect x="46" y="158" width="220" height="112" rx="18" fill="#102a2a" stroke="#2dd4bf" stroke-width="2"/>
+    <circle cx="71" cy="185" r="15" fill="#5eead4"/><text x="71" y="186" class="number">1</text>
+    <text x="96" y="191" class="step">document.open()</text>
+    <text x="68" y="218" class="detail">Attempts a remote</text>
+    <text x="68" y="239" class="detail">load from currently</text>
+    <text x="68" y="260" class="detail">connected peers.</text>
+
+    <rect x="318" y="158" width="250" height="112" rx="18" fill="#172033" stroke="#64748b" stroke-width="2"/>
+    <circle cx="343" cy="185" r="15" fill="#cbd5e1"/><text x="343" y="186" class="number">2</text>
+    <text x="368" y="191" class="step">If enabled: probe peers</text>
+    <text x="340" y="226" class="detail">Up to effective K distinct peers</text>
+    <text x="340" y="249" class="detail">advertise served-frontier hashes.</text>
+
+    <rect x="620" y="146" width="534" height="136" rx="18" fill="#1e1b4b" stroke="#818cf8" stroke-width="2"/>
+    <circle cx="647" cy="175" r="15" fill="#a5b4fc"/><text x="647" y="176" class="number">3</text>
+    <text x="674" y="181" class="step">Configured remote-load mode</text>
+    <text x="646" y="216" class="detail">Enabled: require Q matching frontier hashes from up to effective K peers.</text>
+    <text x="646" y="242" class="detail">Disabled: skip probes and quorum checks; use the legacy response path.</text>
+    <text x="646" y="265" class="detail">Single-peer fallback applies only when effective K is already 1.</text>
+  </g>
+  <path d="M 266 214 H 312 M 568 214 H 614" fill="none" stroke="#94a3b8" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <rect x="44" y="312" width="1112" height="242" rx="22" fill="#111f34" stroke="#475569" stroke-width="2"/>
+  <text x="68" y="343" class="eyebrow" fill="#93c5fd">QUORUM PATH · ORDER BEFORE STATE MUTATION</text>
+  <g filter="url(#shadow)">
+    <rect x="68" y="365" width="290" height="114" rx="16" fill="#172033" stroke="#64748b"/>
+    <circle cx="93" cy="392" r="15" fill="#93c5fd"/><text x="93" y="393" class="number">4</text>
+    <text x="118" y="398" class="step">Decrypt response first</text>
+    <text x="90" y="425" class="detail">Select held/restored key,</text>
+    <text x="90" y="446" class="detail">decrypt, then deserialize</text>
+    <text x="90" y="467" class="detail">the sync message.</text>
+
+    <rect x="399" y="365" width="344" height="114" rx="16" fill="#172033" stroke="#64748b"/>
+    <circle cx="424" cy="392" r="15" fill="#93c5fd"/><text x="424" y="393" class="number">5</text>
+    <text x="449" y="398" class="step">Conditional outer authentication</text>
+    <text x="421" y="433" class="detail">Subsequent load + signing enabled</text>
+    <text x="421" y="456" class="detail">+ prior writers: verify the outer signature.</text>
+
+    <rect x="784" y="365" width="348" height="114" rx="16" fill="#172033" stroke="#818cf8"/>
+    <circle cx="809" cy="392" r="15" fill="#a5b4fc"/><text x="809" y="393" class="number">6</text>
+    <text x="834" y="398" class="step">Bind the served frontier</text>
+    <text x="806" y="433" class="detail">Derive the response frontier and</text>
+    <text x="806" y="456" class="detail">match the agreed hash and required tips.</text>
+  </g>
+  <path d="M 358 422 H 393 M 743 422 H 778" fill="none" stroke="#94a3b8" stroke-width="3" marker-end="url(#arrow)"/>
+  <rect x="68" y="498" width="1064" height="38" rx="19" fill="#31243b" stroke="#fb7185" stroke-opacity="0.65"/>
+  <text x="600" y="523" fill="#fecdd3" font-size="15" text-anchor="middle">Quorum-bound first load: no prior writer set authenticates the outer signature; drop its snapshot and require an available changes tree.</text>
+
+  <rect x="44" y="578" width="1112" height="160" rx="22" fill="#0f3539" stroke="#2dd4bf" stroke-width="2"/>
+  <text x="68" y="609" class="eyebrow" fill="#5eead4">QUORUM-BOUND HISTORY FETCH + MATERIALIZATION</text>
+  <g>
+    <circle cx="92" cy="652" r="16" fill="#5eead4"/><text x="92" y="653" class="number">7</text>
+    <text x="119" y="646" class="step">Prefetch changes-tree CIDs</text>
+    <text x="119" y="672" class="detail">Strip inline changes, then fetch each CID</text>
+    <text x="119" y="694" class="detail">enumerated by the served changes tree.</text>
+
+    <circle cx="455" cy="652" r="16" fill="#5eead4"/><text x="455" y="653" class="number">8</text>
+    <text x="482" y="646" class="step">CID-validate fetched bytes</text>
+    <text x="482" y="672" class="detail">Helia validates ciphertext during prefetch;</text>
+    <text x="482" y="694" class="detail">decryption happens later inside sync.</text>
+
+    <circle cx="850" cy="652" r="16" fill="#5eead4"/><text x="850" y="653" class="number">9</text>
+    <text x="877" y="646" class="step">Decrypt + apply history</text>
+    <text x="877" y="672" class="detail">sync builds from cached blocks;</text>
+    <text x="877" y="694" class="detail">a later failure has no rollback.</text>
+  </g>
+  <path d="M 395 652 H 429 M 790 652 H 824" fill="none" stroke="#5eead4" stroke-width="3" marker-end="url(#arrowTeal)"/>
+  <text x="600" y="723" fill="#99f6e4" font-size="13" text-anchor="middle">CID validation covers fetched ciphertext bytes—not responder-supplied node kinds/interior topology, writer identity, or history completeness.</text>
+
+  <rect x="44" y="762" width="420" height="54" rx="27" fill="#102a2a" stroke="#2dd4bf" stroke-width="2"/>
+  <text x="254" y="796" class="result" fill="#99f6e4" text-anchor="middle">Ready · local mutations may begin</text>
+  <rect x="488" y="762" width="668" height="54" rx="27" fill="#301821" stroke="#fb7185" stroke-width="2"/>
+  <text x="822" y="786" class="result" fill="#fda4af" text-anchor="middle">Fail · gate, key, signature, frontier, or history error</text>
+  <text x="822" y="806" fill="#fecdd3" font-size="14" text-anchor="middle">missing CID stops pre-sync; later block failure may leave partial state</text>
+</svg>

--- a/site/src/assets/diagrams/trust-boundary.svg
+++ b/site/src/assets/diagrams/trust-boundary.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title description">
+  <title id="title">How Peerborne changes the document trust boundary</title>
+  <desc id="description">A centralized application routes plaintext through a trusted application server and database. Peerborne keeps plaintext and keys on authorized devices while infrastructure forwards bidirectional encrypted document traffic. Sync envelopes are signed when enabled and encrypted; separately fetched change blocks are encrypted and CID-addressed. Infrastructure can observe metadata and disrupt delivery but lacks document plaintext without the document key.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1200" y2="720" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#090d1a" />
+      <stop offset="0.55" stop-color="#111936" />
+      <stop offset="1" stop-color="#172554" />
+    </linearGradient>
+    <linearGradient id="peerPanel" x1="620" y1="128" x2="1150" y2="594" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1e1b4b" stop-opacity="0.62" />
+      <stop offset="1" stop-color="#0f2f35" stop-opacity="0.58" />
+    </linearGradient>
+    <marker id="arrowSlate" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M1 1L9 5L1 9Z" fill="#94a3b8" />
+    </marker>
+    <marker id="arrowTeal" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M1 1L9 5L1 9Z" fill="#2dd4bf" />
+    </marker>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#c7d2fe" stroke-opacity="0.045" />
+    </pattern>
+  </defs>
+
+  <rect width="1200" height="720" rx="24" fill="url(#background)" />
+  <rect width="1200" height="720" rx="24" fill="url(#grid)" />
+
+  <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+    <text x="60" y="64" fill="#f8fafc" font-size="34" font-weight="750">Where document plaintext lives</text>
+    <text x="60" y="98" fill="#94a3b8" font-size="19">The collaboration goal is similar. The trust boundary is not.</text>
+
+    <rect x="50" y="128" width="520" height="466" rx="22" fill="#111827" fill-opacity="0.86" stroke="#475569" />
+    <rect x="630" y="128" width="520" height="466" rx="22" fill="url(#peerPanel)" stroke="#6366f1" stroke-opacity="0.82" />
+
+    <circle cx="82" cy="169" r="8" fill="#94a3b8" />
+    <text x="102" y="178" fill="#e2e8f0" font-size="25" font-weight="700">Centralized application</text>
+    <text x="80" y="211" fill="#94a3b8" font-size="17">One custodian sits on the document path</text>
+
+    <circle cx="662" cy="169" r="8" fill="#2dd4bf" />
+    <text x="682" y="178" fill="#f8fafc" font-size="25" font-weight="700">Peerborne</text>
+    <text x="660" y="211" fill="#99f6e4" font-size="17">Plaintext stays at authorized endpoints</text>
+
+    <rect x="82" y="248" width="184" height="82" rx="14" fill="#1e293b" stroke="#64748b" />
+    <text x="174" y="280" fill="#f8fafc" font-size="19" font-weight="700" text-anchor="middle">Participant A</text>
+    <text x="174" y="307" fill="#cbd5e1" font-size="16" text-anchor="middle">reads and writes</text>
+
+    <rect x="354" y="248" width="184" height="82" rx="14" fill="#1e293b" stroke="#64748b" />
+    <text x="446" y="280" fill="#f8fafc" font-size="19" font-weight="700" text-anchor="middle">Participant B</text>
+    <text x="446" y="307" fill="#cbd5e1" font-size="16" text-anchor="middle">reads and writes</text>
+
+    <path d="M174 338V386" fill="none" stroke="#94a3b8" stroke-width="3" marker-start="url(#arrowSlate)" marker-end="url(#arrowSlate)" />
+    <path d="M446 338V386" fill="none" stroke="#94a3b8" stroke-width="3" marker-start="url(#arrowSlate)" marker-end="url(#arrowSlate)" />
+    <text x="310" y="365" fill="#cbd5e1" font-size="16" text-anchor="middle">plaintext reads and writes</text>
+
+    <rect x="130" y="395" width="360" height="116" rx="16" fill="#31243b" stroke="#fb7185" stroke-opacity="0.72" />
+    <text x="310" y="431" fill="#fecdd3" font-size="21" font-weight="700" text-anchor="middle">Application server + database</text>
+    <text x="310" y="463" fill="#f8fafc" font-size="18" text-anchor="middle">stores document plaintext</text>
+    <text x="310" y="490" fill="#cbd5e1" font-size="15" text-anchor="middle">trusted for content and availability</text>
+
+    <rect x="80" y="535" width="460" height="38" rx="19" fill="#1e293b" />
+    <text x="310" y="560" fill="#cbd5e1" font-size="15" text-anchor="middle">Central service can read and govern access to content</text>
+
+    <rect x="662" y="247" width="205" height="96" rx="16" fill="#172554" stroke="#818cf8" />
+    <text x="764.5" y="279" fill="#f8fafc" font-size="19" font-weight="700" text-anchor="middle">Authorized device A</text>
+    <text x="764.5" y="307" fill="#c7d2fe" font-size="16" text-anchor="middle">plaintext + local keys</text>
+    <text x="764.5" y="329" fill="#94a3b8" font-size="13" text-anchor="middle">local CRDT replica</text>
+
+    <rect x="913" y="247" width="205" height="96" rx="16" fill="#0f3638" stroke="#2dd4bf" />
+    <text x="1015.5" y="279" fill="#f8fafc" font-size="19" font-weight="700" text-anchor="middle">Authorized device B</text>
+    <text x="1015.5" y="307" fill="#99f6e4" font-size="16" text-anchor="middle">plaintext + local keys</text>
+    <text x="1015.5" y="329" fill="#94a3b8" font-size="13" text-anchor="middle">local CRDT replica</text>
+
+    <path d="M765 352C765 374 813 382 835 395" fill="none" stroke="#2dd4bf" stroke-width="3" marker-start="url(#arrowTeal)" marker-end="url(#arrowTeal)" />
+    <path d="M1016 352C1016 374 968 382 946 395" fill="none" stroke="#2dd4bf" stroke-width="3" marker-start="url(#arrowTeal)" marker-end="url(#arrowTeal)" />
+    <rect x="706" y="401" width="388" height="125" rx="16" fill="#172033" stroke="#6366f1" />
+    <text x="900" y="427" fill="#e0e7ff" font-size="19" font-weight="700" text-anchor="middle">Relay / network infrastructure</text>
+    <text x="900" y="451" fill="#99f6e4" font-size="15" text-anchor="middle">forwards bidirectional encrypted traffic</text>
+    <text x="900" y="475" fill="#c7d2fe" font-size="14" text-anchor="middle">Sync envelope: signed if enabled + encrypted</text>
+    <text x="900" y="498" fill="#c7d2fe" font-size="14" text-anchor="middle">Fetched change block: encrypted + CID-addressed</text>
+    <text x="900" y="518" fill="#cbd5e1" font-size="13" text-anchor="middle">sees peer IDs, topics, timing, and volume</text>
+
+    <rect x="660" y="535" width="458" height="38" rx="19" fill="#0f2f35" stroke="#2dd4bf" stroke-opacity="0.45" />
+    <text x="889" y="560" fill="#99f6e4" font-size="15" text-anchor="middle">Cannot read document plaintext without its key</text>
+
+    <rect x="50" y="620" width="1100" height="64" rx="18" fill="#111827" stroke="#475569" />
+    <circle cx="82" cy="652" r="7" fill="#818cf8" />
+    <text x="102" y="646" fill="#e2e8f0" font-size="17" font-weight="700">Application responsibility</text>
+    <text x="102" y="670" fill="#94a3b8" font-size="15">Identity, key backup, and recovery remain app-owned.</text>
+    <circle cx="641" cy="652" r="7" fill="#2dd4bf" />
+    <text x="661" y="646" fill="#e2e8f0" font-size="17" font-weight="700">Availability still matters</text>
+    <text x="661" y="670" fill="#94a3b8" font-size="15">Peers and infrastructure may be unavailable or disrupt delivery.</text>
+  </g>
+</svg>

--- a/site/src/content/docs/concepts/architecture.md
+++ b/site/src/content/docs/concepts/architecture.md
@@ -23,73 +23,69 @@ Peerborne composes several open-source subsystems into a coherent local-first st
 
 ## Data flow: writing a change
 
-```
-Application
-  │
-  ▼
-document.change((state) => { state.getArray('items').push(['buy milk']) })
-  │
-  ▼
-CRDT Provider (Yjs / Automerge)
-  │  applies mutation to local CRDT replica
-  │  serializes the update
-  ▼
-PeerborneDocument
-  │  wraps update in a signed CRDTChangeBlock
-  │  encrypts block with document AES-GCM key
-  │  addresses block by CID (SHA-256 hash of ciphertext)
-  ▼
-Helia Blockstore (local IndexedDB)
-  │  stores encrypted block
-  ▼
-libp2p PubSub (GossipSub)
-  │  publishes CID to document topic peers
-  ▼
-Remote Peers
-  │  receive CID announcement
-  │  fetch encrypted block via libp2p bitswap / HTTP
-  │  verify signature, decrypt, apply to local replica
-  ▼
-CRDT converges
-```
+![A local CRDT mutation creates an encrypted CID-addressed stored payload and a separate signed-when-enabled, encrypted GossipSub sync envelope; receivers decrypt and authorize the envelope, apply inline history, and fetch only missing or deferred CID blocks for CID validation and decryption.](../../../assets/diagrams/change-pipeline.svg)
+
+The local replica changes before either outbound artifact is complete. First,
+Peerborne serializes the change payload, encrypts it with the document key, and
+stores that ciphertext in Helia under its CID. It then builds a separate
+`CRDTSyncMessage` containing the new CID, inline change history, and any deferred
+CID references. The complete sync message is signed when signing is enabled,
+serialized, encrypted, and published through GossipSub; the publication is not
+a CID-only announcement.
+
+A receiving peer decrypts the GossipSub envelope before deserializing it and,
+when signing is enabled, checking the outer signature against known authorized
+writers. It applies inline history directly and fetches only missing or deferred
+CID references. Helia validates fetched ciphertext against the requested CID;
+Peerborne then decrypts and deserializes the stored change payload. Those stored
+blocks do not carry their own writer signature or ACL decision. A storage or
+publication error can reject `change()` after the mutation is already visible
+locally. There is no automatic rollback, durable outbox, or remote delivery
+receipt.
+
+**Evidence boundary:** the component pipeline and its failure semantics are
+implemented and covered by focused tests. Live post-load browser mutation and
+convergence through this complete path are not yet demonstrated in CI.
 
 ## Data flow: loading an existing document
 
-```
-Application
-  │
-  ▼
-document.open()
-  │
-  ▼
-PeerborneNode
-  │  resolves document ID to CID via IPNS or bootstrap
-  │  if local: loads frontier from Helia blockstore
-  │  if remote: queries Q-of-K peers for frontier agreement
-  ▼
-Load Quorum Orchestrator
-  │  requests tips from configured bootstrap peers
-  │  selects candidate with highest epoch
-  │  waits for Q-of-K agreement before proceeding
-  ▼
-Shadow Graph Walk
-  │  walks CRDTChangeNode chain from frontier backward
-  │  fetches missing blocks (bitswap / HTTP)
-  │  verifies signatures, decrypts, applies to CRDT
-  ▼
-Document is ready
-  │  Mutations are now accepted via document.change()
-  │  Reception of remote updates continues via GossipSub
-```
+![A quorum-enabled remote document load obtains Q-of-K frontier agreement, decrypts the selected response before any conditional known-writer signature check, binds its served frontier, and fetches the CIDs enumerated by its served changes tree before mutation; a quorum-bound first load drops an unverifiable snapshot and requires an available changes tree, while the quorum-disabled legacy path skips those gates.](../../../assets/diagrams/initial-load.svg)
+
+The configured initial-load gate probes up to an effective K distinct connected
+peers and requires Q matching frontier advertisements before accepting a remote
+history. Peerborne decrypts the selected response first. On a subsequent load,
+when signing is enabled and a prior writer set is already known, it then verifies
+the response's outer signature before mutating document state. If quorum ran,
+Peerborne also derives the served frontier and binds it to the agreed hash and
+required tips.
+
+For a quorum-bound load, inline changes are stripped from the response and every
+CID enumerated by its served changes tree is prefetched before state mutation.
+Helia validates the fetched ciphertext against each CID during that prefetch.
+After the gate passes, `sync()` decrypts, deserializes, and applies the cached
+payloads. A later per-block failure can therefore follow partial local mutation;
+there is no rollback. CID integrity authenticates those ciphertext bytes, not
+the responder-supplied node kind or interior tree topology, a writer identity,
+or a complete-history claim. The fetched blocks have no per-block signature or
+ACL decision.
+
+On a first load there is no prior writer set with which to authenticate the
+outer response. A quorum-bound first load therefore drops an unverifiable
+snapshot and replays an available changes tree; a snapshot-only response is
+refused. When quorum is disabled, the legacy response path skips advertisement
+probes, frontier binding, inline stripping, and the prefetch-before-mutation
+gate. The decision logic and orchestration have focused tests; conflicting real
+peers serving adversarial DAG payloads are not yet exercised end to end.
 
 ## The sync model
 
-Peerborne uses a **shadow sync graph** rather than a conventional Merkle-DAG:
+Peerborne uses a **shadow sync graph** rather than putting its graph links inside
+each stored block:
 
-- Each `document.change()` call creates one `CRDTChangeBlock` — an encrypted, signed, CID-addressed node containing a serialized CRDT update.
-- Each block references its parent(s) by CID, forming a DAG.
-- New blocks are announced to peers via GossipSub (by CID, never by content).
-- Peers fetch missing blocks on demand (bitswap or HTTP fetch).
+- Each `document.change()` call stores an encrypted serialized change payload in Helia; the CID addresses the resulting ciphertext.
+- A separate `CRDTSyncMessage` names the new CID and carries an inline shadow change tree whose child keys reference earlier CIDs; older cross-links may be deferred to CID-only references.
+- The complete sync message is signed when signing is enabled, then serialized, encrypted, and published through GossipSub.
+- Receivers apply inline history and fetch only missing or deferred CID blocks on demand through the configured block-fetch path.
 - The CRDT layer resolves concurrent edits without a consensus leader.
 
 This model is **eventually consistent**: local edits apply immediately, remote edits merge when they arrive. There is no global ordering, no server-assigned sequence number, and no single source of truth.
@@ -140,14 +136,23 @@ PeerborneNode manages:
   ├── Signing key → libp2p PeerId mapping (separate keys)
   └── ACL entries (reader/writer lists bound to signing public keys)
 
-Per change:
-  ├── Writer signs the CRDT update with their P-384 key
-  ├── Payload is encrypted with the document's AES-GCM key
-  ├── Signature is verified by receivers before decryption
-  └── Encryption is transparent to the CRDT layer
+Per document change:
+  ├── Stored artifact
+  │   ├── Serialized change payload is AES-GCM encrypted and stored by CID
+  │   └── The stored block has no separate writer signature or ACL check
+  ├── GossipSub artifact
+  │   ├── CRDTSyncMessage is signed with P-384 when signing is enabled
+  │   └── The complete message is serialized and AES-GCM encrypted
+  └── Receiver
+      ├── Decrypts the envelope before conditional known-writer authorization
+      └── CID-validates, decrypts, and deserializes only fetched change blocks
 ```
 
-Key material never leaves the device in plaintext. Document keys are shared between authorized peers using BeeKEM — a key encapsulation mechanism that wraps the document key for each group member.
+Peerborne does not transmit private signing or KEM keys. Public identity keys
+are exchanged as protocol inputs. When reader KEM enrollment is configured,
+the BeeKEM Welcome flow delivers recipient-bound encrypted keychain material;
+applications still own identity enrollment, private-key storage, backup, and
+recovery.
 
 ## Where infrastructure is needed
 

--- a/site/src/content/docs/concepts/why-peerborne.md
+++ b/site/src/content/docs/concepts/why-peerborne.md
@@ -11,11 +11,15 @@ Peerborne is an **encrypted, peer-to-peer CRDT document toolkit** for TypeScript
 
 ### When centralization is the downside
 
-Peerborne removes the plaintext application database from the document path. Documents are encrypted, signed, and content-addressed before peers exchange them through relay infrastructure. Relays do not receive document plaintext, but they still observe connection and traffic metadata and can drop, delay, or censor traffic. Peerborne changes the trust boundary; it does not eliminate infrastructure.
+Peerborne removes the plaintext application database from the document path. It stores encrypted change payloads by CID and exchanges separate encrypted sync messages, signed when enabled, through network infrastructure. Relays do not receive document plaintext without the document key, but they still observe connection and traffic metadata and can drop, delay, or censor traffic. Peerborne changes the trust boundary; it does not eliminate infrastructure.
+
+![Centralized collaboration sends plaintext through a trusted application database; Peerborne devices exchange signed-when-enabled encrypted sync envelopes and separately encrypted CID-addressed blocks through infrastructure that sees metadata and can disrupt delivery but lacks document plaintext without the document key.](../../../assets/diagrams/trust-boundary.svg)
+
+**Evidence boundary:** This compares trust models, not availability or production readiness. Applications still own identity, key backup, and recovery; infrastructure may observe metadata or disrupt delivery, and durable restart recovery remains unproven.
 
 ### Encryption is the default, not an add-on
 
-By default (`enableSigning: true`), every document change is signed with the writer's identity and encrypted with AES-GCM before it leaves the device. Relays, bootstrap nodes, and remote storage see only opaque ciphertext. Encryption is always on, whether signing is enabled or not. Key material stays on devices — Peerborne never transmits unencrypted document content.
+Stored change payloads and wire sync envelopes are encrypted with AES-GCM. By default (`enableSigning: true`), the complete outgoing sync message is also signed with the writer's identity before it is encrypted. The stored CID-addressed block is a separate encrypted artifact and does not carry its own writer signature or ACL decision. Relays, bootstrap nodes, and remote storage handle ciphertext rather than document plaintext. Encryption remains on whether signing is enabled or not; Peerborne does not intentionally transmit unencrypted document content.
 
 ### Composable, not monolithic
 

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -39,6 +39,75 @@ pre.astro-code {
   border-radius: 0.5rem;
 }
 
+/* Keep system diagrams at their designed type size and scroll within the page frame. */
+.sl-markdown-content > p:has(> img[src*='.svg']:only-child) {
+  --diagram-frame-width: 100%;
+
+  width: var(--diagram-frame-width);
+  max-width: none;
+  margin-inline: 0;
+  padding-block-end: 0.5rem;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: thin;
+}
+
+.sl-markdown-content > p:has(> img[src*='.svg']:only-child) > img {
+  display: block;
+  width: 75rem;
+  min-width: 75rem;
+  max-width: none;
+  height: auto;
+}
+
+@media (min-width: 50rem) and (max-width: 71.999rem) {
+  html[data-has-sidebar]
+    .sl-markdown-content
+    > p:has(> img[src*='.svg']:only-child) {
+    --diagram-frame-width: min(
+      75rem,
+      calc(100vw - var(--sl-sidebar-width) - 2 * var(--sl-content-pad-x))
+    );
+  }
+}
+
+@media (min-width: 72rem) {
+  html[data-has-sidebar][data-has-toc]
+    .sl-markdown-content
+    > p:has(> img[src*='.svg']:only-child) {
+    --diagram-frame-width: min(
+      75rem,
+      calc(100vw - 2 * var(--sl-sidebar-width) - 2 * var(--sl-content-pad-x)),
+      calc(50vw + 1.75rem)
+    );
+    margin-inline-start: calc(100% - var(--diagram-frame-width));
+  }
+
+  html[data-has-sidebar][data-has-toc]
+    .sl-markdown-content
+    > p:has(> img[src*='.svg']:only-child)
+    > img {
+    width: 100%;
+    min-width: 0;
+  }
+}
+
+@media print {
+  .sl-markdown-content > p:has(> img[src*='.svg']:only-child) {
+    --diagram-frame-width: 100%;
+
+    margin-inline: 0;
+    padding-block-end: 0;
+    overflow: visible;
+  }
+
+  .sl-markdown-content > p:has(> img[src*='.svg']:only-child) > img {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+}
+
 :is(h2, h3, h4) code {
   font-weight: inherit;
 }


### PR DESCRIPTION
Adds three accessible, repository-native diagrams for Peerborne's trust boundary, change pipeline, and initial-load validation path. Replaces optimistic ASCII flows with explicit failure and evidence boundaries.

Validation:
- Site build
- Site tooling tests
- Link checker
- SVG XML and visual inspection
- git diff --check