### PR TITLE
Map offline and recovery boundaries

### DIFF
--- a/site/src/assets/diagrams/durability-recovery.svg
+++ b/site/src/assets/diagrams/durability-recovery.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 820" role="img" aria-labelledby="title desc">
+  <title id="title">Peerborne durability and recovery boundaries</title>
+  <desc id="desc">Two browser origins have separate local IndexedDB stores containing only payloads written or fetched there, while request and response traffic crosses a relay that does not retain document blocks. A broken line marks the incomplete remote-pinning integration. A tiered recovery chart lists the material needed to reconstruct, write, or manage reader membership.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 10 5 0 10z" fill="#818cf8"/>
+    </marker>
+    <marker id="arrow-amber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 10 5 0 10z" fill="#fbbf24"/>
+    </marker>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="7" stdDeviation="8" flood-color="#020617" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="820" rx="28" fill="#0f172a"/>
+  <text x="56" y="62" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700">A local copy is not a durability guarantee</text>
+  <text x="56" y="98" fill="#94a3b8" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="19">A recoverable document needs more than surviving encrypted bytes.</text>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif" filter="url(#shadow)">
+    <rect x="55" y="142" width="286" height="174" rx="20" fill="#102a2a" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="83" y="182" fill="#5eead4" font-size="16" font-weight="700">PEER A · BROWSER ORIGIN</text>
+    <text x="83" y="221" fill="#f8fafc" font-size="24" font-weight="700">Local IndexedDB</text>
+    <text x="83" y="253" fill="#cbd5e1" font-size="17">Payloads written or fetched here</text>
+    <rect x="83" y="273" width="177" height="26" rx="13" fill="#134e4a"/>
+    <text x="171" y="291" text-anchor="middle" fill="#99f6e4" font-size="14" font-weight="700">origin-scoped store</text>
+
+    <rect x="457" y="142" width="286" height="174" rx="20" fill="#1e1b4b" stroke="#818cf8" stroke-width="2"/>
+    <text x="485" y="182" fill="#a5b4fc" font-size="16" font-weight="700">CIRCUIT RELAY</text>
+    <text x="485" y="221" fill="#f8fafc" font-size="24" font-weight="700">Forwards traffic</text>
+    <text x="485" y="253" fill="#cbd5e1" font-size="17">Can drop, delay, or observe</text>
+    <rect x="485" y="273" width="207" height="26" rx="13" fill="#312e81"/>
+    <text x="589" y="291" text-anchor="middle" fill="#c7d2fe" font-size="14" font-weight="700">no durable document copy</text>
+
+    <rect x="859" y="142" width="286" height="174" rx="20" fill="#102a2a" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="887" y="182" fill="#5eead4" font-size="16" font-weight="700">PEER B · BROWSER ORIGIN</text>
+    <text x="887" y="221" fill="#f8fafc" font-size="24" font-weight="700">Local IndexedDB</text>
+    <text x="887" y="253" fill="#cbd5e1" font-size="17">Payloads written or fetched here</text>
+    <rect x="887" y="273" width="177" height="26" rx="13" fill="#134e4a"/>
+    <text x="975" y="291" text-anchor="middle" fill="#99f6e4" font-size="14" font-weight="700">origin-scoped store</text>
+  </g>
+
+  <g fill="none" stroke="#818cf8" stroke-width="3" marker-start="url(#arrow)" marker-end="url(#arrow)">
+    <path d="M341 214 H457"/>
+    <path d="M743 244 H859"/>
+  </g>
+  <text x="399" y="199" text-anchor="middle" fill="#c7d2fe" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14">request / response</text>
+  <text x="801" y="229" text-anchor="middle" fill="#c7d2fe" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14">request / response</text>
+
+  <rect x="395" y="346" width="410" height="84" rx="18" fill="#2b2112" stroke="#fbbf24" stroke-width="2" stroke-dasharray="9 7"/>
+  <text x="423" y="380" fill="#fde68a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="18" font-weight="700">Remote pinning integration: incomplete</text>
+  <text x="423" y="407" fill="#e2e8f0" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="15">The listener exists; the normal commit path does not invoke it.</text>
+  <path d="M198 316 V388 H395" fill="none" stroke="#fbbf24" stroke-width="3" stroke-dasharray="7 7" marker-end="url(#arrow-amber)"/>
+  <text x="224" y="374" fill="#fde68a" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="15">missing publisher edge</text>
+
+  <text x="56" y="487" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="27" font-weight="700">Recovery is a stack, not a block download</text>
+  <text x="56" y="518" fill="#94a3b8" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="17">Each higher capability requires everything below it.</text>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+    <rect x="55" y="553" width="1090" height="86" rx="18" fill="#172033" stroke="#475569" stroke-width="2"/>
+    <rect x="55" y="553" width="151" height="86" rx="18" fill="#334155"/>
+    <text x="130" y="588" text-anchor="middle" fill="#f8fafc" font-size="19" font-weight="800">READ</text>
+    <text x="130" y="614" text-anchor="middle" fill="#cbd5e1" font-size="14">reconstruct</text>
+    <text x="234" y="582" fill="#f8fafc" font-size="18" font-weight="700">Blocks + keys + frontier/graph data</text>
+    <text x="234" y="607" fill="#cbd5e1" font-size="15">Authenticated envelope, snapshot, and ACL context when available;</text>
+    <text x="234" y="630" fill="#cbd5e1" font-size="15">reachable providers and configured connected-peer quorum may also be required.</text>
+
+    <rect x="165" y="655" width="980" height="66" rx="18" fill="#1e1b4b" stroke="#818cf8" stroke-width="2"/>
+    <rect x="165" y="655" width="151" height="66" rx="18" fill="#312e81"/>
+    <text x="240" y="695" text-anchor="middle" fill="#f8fafc" font-size="19" font-weight="800">WRITE</text>
+    <text x="344" y="695" fill="#f8fafc" font-size="18" font-weight="700">Everything above + current writer authorization + signing key if enabled</text>
+
+    <rect x="275" y="737" width="870" height="58" rx="18" fill="#102a2a" stroke="#2dd4bf" stroke-width="2"/>
+    <rect x="275" y="737" width="189" height="58" rx="18" fill="#134e4a"/>
+    <text x="369" y="765" text-anchor="middle" fill="#f8fafc" font-size="16" font-weight="800">READER MEMBERSHIP</text>
+    <text x="369" y="784" text-anchor="middle" fill="#cbd5e1" font-size="13" font-weight="700">AND REVOCATION</text>
+    <text x="492" y="773" fill="#f8fafc" font-size="18" font-weight="700">Everything above + BeeKEM state</text>
+  </g>
+</svg>

--- a/site/src/assets/diagrams/offline-boundary.svg
+++ b/site/src/assets/diagrams/offline-boundary.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+  <title id="title">Peerborne offline editing boundary</title>
+  <desc id="desc">A timeline shows that an open local replica can accept, encrypt, and store an edit while disconnected; prior network connectivity is not required for a new local document. Libp2p may redial keep-alive peers, but Peerborne has no durable reconnect-and-replay guarantee, outgoing retry queue, or delivery receipt.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 10 5 0 10z" fill="#64748b"/>
+    </marker>
+    <marker id="arrow-teal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 10 5 0 10z" fill="#2dd4bf"/>
+    </marker>
+    <marker id="arrow-amber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0 10 5 0 10z" fill="#fbbf24"/>
+    </marker>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="7" stdDeviation="8" flood-color="#020617" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="720" rx="28" fill="#0f172a"/>
+  <text x="56" y="62" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700">Offline works locally; delivery is a separate concern</text>
+  <text x="56" y="98" fill="#94a3b8" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="19">The replica must be open with its local key and state before the edit.</text>
+
+  <line x1="120" y1="195" x2="1080" y2="195" stroke="#334155" stroke-width="5"/>
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+    <circle cx="140" cy="195" r="19" fill="#2dd4bf"/>
+    <text x="140" y="201" text-anchor="middle" fill="#042f2e" font-size="17" font-weight="800">1</text>
+    <circle cx="442" cy="195" r="19" fill="#2dd4bf"/>
+    <text x="442" y="201" text-anchor="middle" fill="#042f2e" font-size="17" font-weight="800">2</text>
+    <circle cx="744" cy="195" r="19" fill="#fbbf24"/>
+    <text x="744" y="201" text-anchor="middle" fill="#422006" font-size="17" font-weight="800">3</text>
+    <circle cx="1046" cy="195" r="19" fill="#818cf8"/>
+    <text x="1046" y="201" text-anchor="middle" fill="#1e1b4b" font-size="17" font-weight="800">4</text>
+  </g>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif" filter="url(#shadow)">
+    <rect x="55" y="248" width="258" height="160" rx="20" fill="#102a2a" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="83" y="285" fill="#5eead4" font-size="16" font-weight="700">LOCAL · PRECONDITION</text>
+    <text x="83" y="323" fill="#f8fafc" font-size="23" font-weight="700">Replica is open</text>
+    <text x="83" y="355" fill="#cbd5e1" font-size="17">Document state and key</text>
+    <text x="83" y="381" fill="#cbd5e1" font-size="17">are available on this device</text>
+
+    <rect x="357" y="248" width="258" height="160" rx="20" fill="#102a2a" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="385" y="285" fill="#5eead4" font-size="16" font-weight="700">OFFLINE · LOCAL PATH</text>
+    <text x="385" y="323" fill="#f8fafc" font-size="23" font-weight="700">Edit immediately</text>
+    <text x="385" y="355" fill="#cbd5e1" font-size="17">Apply the CRDT mutation;</text>
+    <text x="385" y="381" fill="#cbd5e1" font-size="17">encrypt and store the change</text>
+
+    <rect x="659" y="248" width="258" height="160" rx="20" fill="#2b2112" stroke="#fbbf24" stroke-width="2"/>
+    <text x="687" y="285" fill="#fde68a" font-size="16" font-weight="700">RECONNECT · BEST EFFORT</text>
+    <text x="687" y="323" fill="#f8fafc" font-size="22" font-weight="700">Restore a peer path</text>
+    <text x="687" y="355" fill="#cbd5e1" font-size="17">libp2p may redial</text>
+    <text x="687" y="381" fill="#cbd5e1" font-size="17">no durable replay queue</text>
+
+    <rect x="961" y="248" width="184" height="160" rx="20" fill="#1e1b4b" stroke="#818cf8" stroke-width="2"/>
+    <text x="989" y="285" fill="#a5b4fc" font-size="16" font-weight="700">IF DELIVERED</text>
+    <text x="989" y="323" fill="#f8fafc" font-size="23" font-weight="700">Peer applies</text>
+    <text x="989" y="350" fill="#cbd5e1" font-size="17">after envelope</text>
+    <text x="989" y="374" fill="#cbd5e1" font-size="17">checks and needed</text>
+    <text x="989" y="398" fill="#cbd5e1" font-size="17">fetch + decrypt</text>
+  </g>
+
+  <g fill="none" stroke-width="3">
+    <path d="M313 328 H357" stroke="#2dd4bf" marker-end="url(#arrow-teal)"/>
+    <path d="M615 328 H659" stroke="#fbbf24" stroke-dasharray="8 7" marker-end="url(#arrow-amber)"/>
+    <path d="M917 328 H961" stroke="#818cf8" stroke-dasharray="8 7" marker-end="url(#arrow)"/>
+  </g>
+
+  <rect x="55" y="464" width="1090" height="104" rx="18" fill="#172033" stroke="#475569" stroke-width="2"/>
+  <text x="83" y="503" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="700">What the local write promise does not mean</text>
+  <text x="83" y="535" fill="#cbd5e1" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="17">It does not confirm that any remote peer received, verified, or applied the update.</text>
+  <text x="83" y="558" fill="#cbd5e1" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="17">A failed storage or publication step may also leave the local CRDT mutation visible.</text>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+    <rect x="55" y="605" width="357" height="60" rx="30" fill="#102a2a" stroke="#2dd4bf"/>
+    <text x="234" y="642" text-anchor="middle" fill="#99f6e4" font-size="16" font-weight="700">Open-replica local editing: implemented</text>
+    <rect x="429" y="605" width="337" height="60" rx="30" fill="#2b2112" stroke="#fbbf24"/>
+    <text x="598" y="632" text-anchor="middle" fill="#fde68a" font-size="17" font-weight="700">Offline → reconnect → deliver</text>
+    <text x="598" y="652" text-anchor="middle" fill="#fde68a" font-size="14">not verified end to end</text>
+    <rect x="783" y="605" width="362" height="60" rx="30" fill="#1e1b4b" stroke="#818cf8"/>
+    <text x="964" y="642" text-anchor="middle" fill="#c7d2fe" font-size="17" font-weight="700">Remote delivery: best effort</text>
+  </g>
+</svg>

--- a/site/src/content/docs/concepts/crdts.md
+++ b/site/src/content/docs/concepts/crdts.md
@@ -143,13 +143,17 @@ Peerborne does **not** provide:
 
 ### Snapshots
 
-Snapshots are **off by default**. A writer can create a signed, full-state snapshot:
+Automatic snapshots are **off by default**. A writer can create a full-state
+snapshot, signed when signing is enabled (the signature field is empty otherwise):
 
 ```ts
-await document.compact();
+await document.snapshot();
 ```
 
-A snapshot contains the complete CRDT state at that point, signed and encrypted like any other block. Peers loading the document can start from the snapshot instead of replaying the entire change history.
+A snapshot contains the complete CRDT state at that point plus boundary
+metadata. It is carried inside an encrypted load or snapshot-load response
+rather than stored as a CID-addressed Helia block. A peer that can authenticate
+and apply it can avoid replaying the entire change history.
 
 ### Compaction
 

--- a/site/src/content/docs/concepts/local-first.md
+++ b/site/src/content/docs/concepts/local-first.md
@@ -10,15 +10,28 @@ A local-first application stores its primary data on the user's device — not o
 Peerborne adopts these local-first principles:
 
 - **Local replica near the user.** The application reads and writes a local CRDT document. There is no server round-trip for reads or writes.
-- **Work offline.** Once a document is loaded, the local replica can be edited without network access. Changes are applied immediately to the CRDT and stored locally in IndexedDB.
+- **Work offline.** Once a replica is open—including a new local document—it can be edited without network access. Changes are applied immediately to the CRDT and stored locally in IndexedDB.
 - **No server-ordained write ordering.** Two peers can edit the same document concurrently. The CRDT layer merges their changes when they eventually exchange updates.
 - **Eventually consistent.** When peers reconnect, they may discover and fetch blocks that were created during the offline period. Delivery is not guaranteed — see limitations below.
 
+![An open local replica accepts and stores an edit while disconnected without requiring prior network connectivity; libp2p may redial, but reconnect-and-replay has no durable guarantee and later peer delivery remains best effort.](../../../assets/diagrams/offline-boundary.svg)
+
+**Evidence boundary:** open-replica editing and local storage are implemented.
+The complete offline edit → reconnect → remote delivery sequence is not verified
+end to end. Libp2p may redial keep-alive peers, but Peerborne supplies no
+durable outbox, delivery receipt, or guarantee that a connection is restored
+and missed announcements are replayed.
+
 ## What is implemented today
 
-### Offline editing (loaded replicas only)
+### Offline editing (open local replicas)
 
-A Peerborne document that has already been loaded can be edited offline. The `document.change()` call applies the mutation to the local Yjs or Automerge replica immediately and returns a promise that covers signing, encryption, storage to the local Helia blockstore, and publication to connected peers.
+An open Peerborne document with its local state and key material available can
+be edited offline. This includes a new document created locally without a peer
+connection. The `document.change()` call applies the mutation to the local Yjs
+or Automerge replica immediately. Its promise covers storing an encrypted
+change payload, building and optionally signing a separate sync message,
+encrypting that message, and attempting publication through GossipSub.
 
 ```ts
 await todos.change((state) => {
@@ -26,18 +39,21 @@ await todos.change((state) => {
 });
 ```
 
-If no peers are connected, the encrypted block is still stored locally in IndexedDB. When peers reconnect, they will discover and fetch the new blocks.
+The encrypted change payload is stored before publication is attempted, so it
+can remain in local IndexedDB even if publication later fails. Libp2p may
+restore some peer connections, but missed-update replay and delivery are not
+guaranteed.
 
 ### What `change()` covers
 
 The `document.change()` promise resolves when:
 
 1. The CRDT provider has applied the mutation to the local replica
-2. The update has been serialized into a `CRDTChangeBlock`
-3. The block has been signed with the writer's ECDSA P-384 key
-4. The signed block has been encrypted with the document's AES-GCM key
-5. The encrypted block has been stored in the local Helia blockstore
-6. The CID has been published to connected peers via GossipSub
+2. The change payload has been serialized and encrypted with the document key (AES-GCM by default)
+3. The ciphertext has been stored in the local Helia blockstore, producing its CID
+4. A separate `CRDTSyncMessage` has been built with that CID, inline history, and any deferred CID references
+5. The complete sync message has been signed when signing is enabled, then serialized and encrypted with the document key (AES-GCM by default)
+6. Publication of the full encrypted sync envelope through GossipSub has completed
 
 If storage or publication fails (e.g., IndexedDB quota exceeded, network error), the CRDT mutation **may already be applied**. The CRDT state reflects the mutation even if the remote sync path failed. There is no automatic rollback.
 
@@ -51,9 +67,14 @@ If a peer is unreachable when `change()` publishes to GossipSub, the update may 
 
 When a change is published, there is no confirmation that remote peers received, verified, or applied it. The application must implement its own acknowledgment protocol if it needs delivery guarantees.
 
-### No automatic reconnection
+### No durable reconnect-and-replay guarantee
 
-If the libp2p connection drops, Peerborne does not automatically reconnect. The application must detect disconnection and reinitialize the transport. See the [networking page](../networking/) for transport details.
+Libp2p can redial peers tagged for keep-alive, including relay reservation
+paths. Peerborne does not provide a durable reconnection/outbox protocol that
+guarantees connection restoration or replays announcements missed while a peer
+was offline. Applications that require recovery must observe connectivity and
+coordinate their own retry, resynchronization, or acknowledgment flow. See the
+[networking page](../networking/) for transport details.
 
 ### No close/restart recovery verified in CI
 
@@ -96,7 +117,7 @@ It is not a good fit for:
 These behaviors are verified by CI:
 
 - Document creation, local mutation, and retrieval in a single browser session
-- Encrypted block storage and retrieval through a Circuit Relay
+- Encrypted existing-history retrieval through Circuit Relay
 - Automerge and Yjs provider initialization and basic operation
 - Crypto operations (signing, encryption, key generation)
 
@@ -104,8 +125,8 @@ These behaviors are **not** verified:
 
 - Browser restart and document recovery
 - Multi-session persistence across browser closes
-- Offline editing with later reconnection
-- Automatic reconnection after transport failure
+- Offline editing with later reconnection and delivery
+- Guaranteed transport reconnection and missed-update replay
 
 ## Next steps
 

--- a/site/src/content/docs/concepts/storage.md
+++ b/site/src/content/docs/concepts/storage.md
@@ -5,40 +5,54 @@ description: How Peerborne stores documents — local IndexedDB persistence, the
 
 ## Overview
 
-Peerborne uses **Helia** (the JavaScript IPFS implementation) for content-addressed storage. Every document block — a signed, encrypted CRDT update — is stored in a local Helia blockstore backed by IndexedDB in the browser or the filesystem in Node.js. Blocks are addressed by their **CID** (Content Identifier), a SHA-256 hash of the encrypted content.
+Peerborne uses **Helia** (the JavaScript IPFS implementation) for
+content-addressed storage. For each change, it serializes the CRDT update,
+encrypts it with the document key (AES-GCM by default), and stores the resulting
+key ID, mode-specific encryption parameters, and ciphertext bytes in the local
+Helia blockstore. The CID addresses those encrypted bytes. A separate
+signed-when-enabled, encrypted `CRDTSyncMessage` carries the CID and shadow
+graph metadata; the stored payload itself has no writer signature or parent
+links.
 
 ## Implemented model
 
 ### Content-addressed blocks
 
-Every `CRDTChangeBlock` is stored as an opaque blob:
+Each stored change payload is an opaque blob:
 
 ```
 ┌─────────────────────────────────────┐
-│          CRDTChangeBlock             │
+│      Helia change payload bytes     │
 ├─────────────────────────────────────┤
-│  parent: CID of previous tip        │
-│  epoch:  current document epoch     │
-│  signature: ECDSA P-384             │
-│  payload: AES-GCM encrypted         │
-│    └── serialized CRDT update       │
+│  document-key ID                    │
+│  nonce / IV / counter               │
+│  encrypted change bytes             │
+│    └── serialized CRDT change       │
 ├─────────────────────────────────────┤
-│  CID: sha256(entire block)          │
+│  CID addresses all bytes above      │
 └─────────────────────────────────────┘
 ```
 
-Blocks are immutable. Once stored, a block's CID is stable forever. The document's current state is materialized by the CRDT layer from the **frontier** — the most recent block(s) at the head of the sync graph. New blocks added via `document.change()` extend the frontier, and the CRDT layer resolves any concurrent heads.
+Stored bytes are immutable under their CID. The document's current state is
+materialized by the CRDT layer using the separately exchanged shadow sync tree.
+Its **frontier** is the current set of unreferenced change CIDs. New local
+changes and delivered remote messages update that in-memory graph, while the
+CRDT layer resolves concurrent edits.
 
 ### Inline vs deferred payloads
 
-To reduce block size and improve deduplication, Peerborne can split payload content across referenced blocks:
+The encrypted wire message may carry history inline or defer it to Helia:
 
-- **Inline**: The full encrypted update is embedded in the `CRDTChangeBlock`.
-- **Deferred**: The encrypted update is stored as a separate block referenced by CID from the `CRDTChangeBlock`. Useful when the same encrypted payload appears in multiple sync contexts.
+- **Inline**: A `CRDTChangeNode` inside the encrypted `CRDTSyncMessage` carries the serialized CRDT change, allowing immediate application after any configured outer-signature check. A first load has no prior writer set for that check.
+- **Deferred**: A shadow-tree node carries its kind but omits the change bytes. If the receiver does not already know that CID, it fetches the separately encrypted stored payload and decrypts it.
 
-### No Merkle-DAG parent commitment
+### No graph links in stored payloads
 
-Peerborne's shadow sync graph does **not** use Merkle hash linking. Blocks reference parents by CID but do not commit to parent hashes. This means the graph structure can change after blocks are written (e.g., adding new parents during catch-up). This is intentional — it allows the sync layer to add concurrent parents discovered later without rewriting blocks.
+Peerborne's stored change payloads contain **no graph links**. Parent and
+cross-link relationships live in the separately signed-when-enabled,
+encrypted shadow tree, whose child map is keyed by stored-payload CIDs. Later
+sync messages can therefore add references to known CIDs without rewriting the
+stored ciphertext.
 
 ## Browser persistence
 
@@ -52,7 +66,10 @@ const blockstore = new IDBBlockstore('/collabswarm-blocks');
 // In practice, pass these via PeerborneConfig.helia to initialize()
 ```
 
-Encrypted blocks, IPNS records, and the libp2p peer store are all persisted to IndexedDB under the origin. This means a browser tab refresh should preserve document state.
+The configured blockstore, datastore, and libp2p peer store use IndexedDB under
+the browser origin. Those backends can retain bytes across a tab refresh, but
+complete Peerborne reconstruction from that persisted state is not yet an
+end-to-end guarantee.
 
 **Current status**: Local block storage works in single-session tests. Complete restart recovery (close browser → reopen → verify document state) has **not been proven in CI**. The blockstore persists, but Helia/libp2p reinitialization and document re-opening after a browser restart are not end-to-end tested.
 
@@ -64,17 +81,24 @@ Peerborne does not replicate blocks automatically. If you have 3 peers and one s
 
 Pinning is **incomplete**. What exists:
 
-- A `PeerborneNode` listener that fires when blocks are stored locally
-- No publisher in the core commit path (the listener is never notified)
+- A `PeerborneNode` listener API for document-publish announcements
+- No publisher invocation in the normal core commit path
 - No generic IPFS pinning client (e.g., to pin to a remote IPFS node, S3, or Filecoin)
 
 Without pinning:
 
-- The last online peer is the last surviving copy
-- If all peers go offline and their IndexedDB is cleared, the document is lost
+- No peer can serve its copy while every holder is offline
+- If every local copy is cleared or otherwise unrecoverable, the document is lost
 - A dedicated "pinning node" (always-on peer) can serve as a poor substitute, but is not integrated
 
 See the [pinning cookbook](../../cookbook/pinning/) for the integration checklist.
+
+![Two browser origins have separate local IndexedDB stores containing only payloads written or fetched there, while a relay forwards but does not retain document blocks; a recovery stack adds keys, graph and authentication context, writer authorization, and reader-membership state.](../../../assets/diagrams/durability-recovery.svg)
+
+**Evidence boundary:** a stored encrypted block is only one recovery input. Full
+restart recovery, remote pinning, cross-peer block fetch, and recovery after
+compaction are not verified end to end. Clearing the last local copy or running
+garbage collection can make data unrecoverable.
 
 ## Recovery requirements
 
@@ -82,18 +106,23 @@ The components a peer needs depend on what it needs to do:
 
 ### Read-only recovery
 
-A reader that only needs to reconstruct and verify existing document history requires:
+A reader that needs to reconstruct document history may require:
 
-1. **The block data** — encrypted CRDT change blocks (from any peer or pinning service)
+1. **The block data** — encrypted stored change payloads (from any peer or pinning service)
 2. **The graph structure** — which CIDs form the frontier and its ancestor chain (from the shadow sync graph)
-3. **The document key history** — AES-GCM keys to decrypt blocks for each epoch
-4. **The writers' public keys** — to verify signatures on existing blocks
+3. **The document key history** — per-epoch document encryption keys (AES-GCM by default)
+4. **Authentication context** — the relevant writer ACL/public keys together with a signed sync envelope or snapshot when that verification is available
+
+These inputs do not by themselves authenticate responder-supplied shadow-tree
+node kinds or interior topology, nor do they prove that served history is
+complete. A quorum-bound first load has no prior writer set for authenticating
+the selected outer response and relies on its narrower frontier/CID checks.
 
 ### Write recovery
 
 To issue new changes, a peer additionally needs:
 
-5. **The identity key** — ECDSA P-384 signing key to prove authorship
+5. **Writer capability** — current writer authorization, plus the ECDSA P-384 private key when ordinary document signing is enabled
 
 ### Membership recovery
 
@@ -103,8 +132,8 @@ To participate in dynamic group membership (add/remove readers), a peer addition
 
 ### Configurable prerequisites
 
-7. **Network reachability** — connection to at least one peer or bootstrap node (needed to fetch missing blocks)
-8. **Q-of-K quorum** — agreement from bootstrap peers on the current frontier hash (enabled by default but configurable via `loadQuorumK`/`loadQuorumQ`)
+7. **Network reachability** — connection to at least one peer that can serve missing blocks
+8. **Q-of-K quorum** — agreement from distinct currently connected peers on the served-frontier hash (enabled by default but configurable)
 
 Losing any of these components may make the corresponding recovery path impossible. Key management and backup are application responsibilities.
 
@@ -112,35 +141,41 @@ Losing any of these components may make the corresponding recovery path impossib
 
 ### Compaction
 
-Compaction replaces a chain of blocks with a full-state snapshot. It is **off by default**:
-
-```ts
-await document.compact();
-```
+Compaction summarizes the current CRDT state in a full-state snapshot and can
+prune older nodes from the in-memory shadow tree. Automatic compaction is **off
+by default**; writers can still request one directly with
+`await document.snapshot();`.
 
 When compaction runs:
 1. The current CRDT state is serialized as a full snapshot
-2. The snapshot is signed and encrypted like any other block
-3. Older blocks in the chain may be pruned (removed from the local blockstore)
+2. Its state and boundary metadata are signed when signing is enabled
+3. It is included in a signed-when-enabled, encrypted load response rather than stored as a CID-addressed change payload
+4. Older nodes are pruned from the in-memory sync tree only when `pruneAfterSnapshot` is enabled
+5. Eligible pruned blocks are scheduled for deletion only when both `pruneAfterSnapshot` and `gcAfterPrune` are enabled
 
-Compaction reduces storage and load time (starting from a snapshot instead of replaying all history), but:
-- Pruned blocks cannot be recovered
-- Peers that only have pruned blocks cannot reconstruct the document
-- Snapshot-only bootstrap can fail if snapshots reference pruned data
+Snapshots can reduce replay work, but:
+
+- With pruning enabled, in-memory pruning does not delete Helia blocks unless `gcAfterPrune` is also enabled
+- A locally deleted block may still be fetchable from another provider, but there is no replication guarantee
+- A quorum-bound first load rejects a snapshot-only response because it has no prior writer set with which to authenticate the snapshot
 
 ### Garbage collection
 
-GC removes blocks that are no longer referenced by any document. It is **destructive**:
-- Pruned blocks are deleted from IndexedDB
-- Recovery from GC is impossible — the data is gone
-- GC is not automatic; the application must trigger it
+When `pruneAfterSnapshot` and the opt-in `gcAfterPrune` setting are both enabled,
+Peerborne asynchronously deletes eligible pruned blocks from the local Helia
+blockstore. It protects blocks still reachable from the retained tree and the
+snapshot boundary, but deletion is **destructive for that local copy**:
+
+- Deleted blocks disappear from that origin's IndexedDB-backed blockstore
+- Recovery then depends on another reachable provider still holding the bytes
+- GC is disabled by default
 
 ## CI-backed evidence
 
 Verified in CI:
 
 - Block creation, storage, and retrieval in a single browser session
-- Encrypted blocks transmitted through Circuit Relay and stored in the recipient's blockstore
+- Encrypted existing history loaded through Circuit Relay
 - IndexedDB blockstore initialization and basic read/write
 
 Not verified:


### PR DESCRIPTION
Adds diagrams for loaded-replica offline editing and the material required for read, write, and membership recovery. The visuals make best-effort delivery, missing pinning integration, and restart-recovery limits explicit.

Stacked on visual-network-security.

Validation:
- Site build
- Site tooling tests
- Link checker
- SVG XML and visual inspection
- git diff --check