### PR TITLE
fix(benchmark): use a pinned TypeScript runner

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "test": "jest",
     "tsc-watch": "tsc -w -p tsconfig.json",
     "doc": "typedoc --excludePrivate --excludeProtected --excludeInternal",
-    "benchmark": "tsc -p tsconfig.benchmark.json && node -e \"require('fs').writeFileSync('dist-bench/package.json', JSON.stringify({type:'module'}))\" && node dist-bench/__benchmarks__/run.js",
+    "benchmark": "tsx src/__benchmarks__/run.ts",
     "test:coverage": "jest --coverage"
   },
   "main": "dist/cjs/src/index.js",
@@ -77,6 +77,7 @@
     "jest": "^29.2.5",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.1.0",
+    "tsx": "4.23.12",
     "typedoc": "^0.28.19",
     "typescript": "^5.9.3"
   },

--- a/packages/core/src/__benchmarks__/run.ts
+++ b/packages/core/src/__benchmarks__/run.ts
@@ -6,12 +6,14 @@
  *   yarn workspace @peerborne/core benchmark --iterations 500
  */
 import * as fs from 'fs';
-import { dirname, join } from 'path';
+import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { PaperBenchmarkRunner, BenchmarkSuiteResult } from './benchmark-runner.js';
 import { runCrdtSyncLatencyBenchmarks } from './crdt-sync-latency.js';
 import { runCryptoOverheadBenchmarks } from './crypto-overhead.js';
 import { runConvergenceSimulationBenchmarks } from './convergence-simulation.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 function parseIterations(): number {
   const idx = process.argv.indexOf('--iterations');
@@ -50,7 +52,7 @@ async function main() {
   console.log();
 
   // Write JSON results
-  const outPath = join(dirname(fileURLToPath(import.meta.url)), 'results.json');
+  const outPath = join(__dirname, 'results.json');
   fs.writeFileSync(outPath, JSON.stringify(allSuites, null, 2));
   console.log(`Results written to ${outPath}`);
 }

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -16,7 +16,7 @@
     "prepublishOnly": "yarn tsc",
     "test": "jest",
     "tsc-watch": "tsc -w -p tsconfig.json",
-    "benchmark": "tsc -p tsconfig.benchmark.json && node -e \"require('fs').writeFileSync('dist-bench/package.json', JSON.stringify({type:'module'}))\" && node dist-bench/__benchmarks__/run.js"
+    "benchmark": "tsx src/__benchmarks__/run.ts"
   },
   "main": "dist/cjs/src/index.js",
   "types": "dist/esm/src/index.d.ts",
@@ -58,6 +58,7 @@
     "jest": "^29.2.5",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.1.0",
+    "tsx": "4.23.12",
     "typescript": "^5.9.3"
   },
   "dependencies": {

--- a/packages/index/src/__benchmarks__/run.ts
+++ b/packages/index/src/__benchmarks__/run.ts
@@ -6,9 +6,11 @@
  *   yarn workspace @peerborne/index benchmark --iterations 500
  */
 import * as fs from 'fs';
-import { dirname, join } from 'path';
+import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { Crypto } from '@peculiar/webcrypto';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 // Install WebCrypto polyfill for Node.js
 if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.subtle === 'undefined') {
@@ -67,7 +69,7 @@ async function main() {
   console.log();
 
   // Write JSON results (paper-quality format)
-  const outPath = join(dirname(fileURLToPath(import.meta.url)), 'results.json');
+  const outPath = join(__dirname, 'results.json');
   fs.writeFileSync(outPath, JSON.stringify(allSuites, null, 2));
   console.log(`Results written to ${outPath}`);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4087,6 +4087,7 @@ __metadata:
     multiformats: "npm:^14.0.5"
     ts-jest: "npm:^29.2.5"
     ts-node: "npm:^10.1.0"
+    tsx: "npm:4.23.12"
     typedoc: "npm:^0.28.19"
     typescript: "npm:^5.9.3"
     uint8arraylist: "npm:^3.0.2"
@@ -4105,6 +4106,7 @@ __metadata:
     jest: "npm:^29.2.5"
     ts-jest: "npm:^29.2.5"
     ts-node: "npm:^10.1.0"
+    tsx: "npm:4.23.12"
     typescript: "npm:^5.9.3"
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
@@ -7452,7 +7454,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.28.0":
+"esbuild@npm:^0.28.0, esbuild@npm:~0.28.0":
   version: 0.28.2
   resolution: "esbuild@npm:0.28.2"
   dependencies:
@@ -14813,6 +14815,21 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
+  languageName: node
+  linkType: hard
+
+"tsx@npm:4.23.12":
+  version: 4.23.12
+  resolution: "tsx@npm:4.23.12"
+  dependencies:
+    esbuild: "npm:~0.28.0"
+    fsevents: "npm:~2.3.3"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10/167a5571cb211aff257d200cd75a1003b1e0e59d641c1e6ff99f6cdfada46ff6ce311e105722699b4763feb1371b2d8084bcc413c7e54aae3761c852817dc0b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Restores the benchmark commands by running their TypeScript entrypoints with a lockfile-pinned `tsx` dependency instead of compiling a separate benchmark tree.

- Pin `tsx` in the core and index workspaces
- Run both benchmark entrypoints through the workspace-local binary
- Derive the source directory from `import.meta.url` before writing `results.json`

Validated with one-iteration core and index benchmark runs and both workspace TypeScript builds.