### PR TITLE
ci: upload benchmark results for manual comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,3 +180,28 @@ jobs:
       - name: Stop services
         if: always()
         run: docker compose -f docker-compose.peerborne-nat.yaml down -v
+
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - id: nodeversion
+        run: echo "version=$(grep nodejs .tool-versions | sed -e 's/[^[:space:]]*[[:space:]]*//')" >> $GITHUB_OUTPUT
+      - run: corepack enable
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ steps.nodeversion.outputs.version }}
+          cache: 'yarn'
+      - run: yarn install --immutable
+      - name: Build workspace packages
+        run: yarn build
+      - name: Run benchmarks
+        run: yarn benchmark:ci
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: benchmark-results
+          path: benchmark-results.json
+          retention-days: 30

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "uint8arraylist": "^3.0.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2"
+    "@playwright/test": "^1.58.2",
+    "tsx": "4.23.12"
   },
   "engines": {
     "node": ">=22.19.0"
@@ -40,6 +41,7 @@
     "release:prepare": "node scripts/prepare-release.mjs",
     "release:validate-consumer": "node scripts/validate-release-consumer.mjs",
     "benchmark:all": "yarn workspaces foreach -Apvi --include '@peerborne/core' --include '@peerborne/index' run benchmark",
+    "benchmark:ci": "tsx scripts/benchmark-ci.mjs",
     "visuals:generate": "node scripts/render-peerborne-hook.mjs",
     "visuals:check": "node scripts/render-peerborne-hook.mjs --check",
     "visuals:test": "node --test scripts/render-peerborne-hook.test.mjs && yarn visuals:check"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "release:prepare": "node scripts/prepare-release.mjs",
     "release:validate-consumer": "node scripts/validate-release-consumer.mjs",
     "benchmark:all": "yarn workspaces foreach -Apvi --include '@peerborne/core' --include '@peerborne/index' run benchmark",
-    "benchmark:ci": "tsx scripts/benchmark-ci.mjs",
+    "benchmark:ci": "tsx --expose-gc scripts/benchmark-ci.mjs",
     "visuals:generate": "node scripts/render-peerborne-hook.mjs",
     "visuals:check": "node scripts/render-peerborne-hook.mjs --check",
     "visuals:test": "node --test scripts/render-peerborne-hook.test.mjs && yarn visuals:check"

--- a/scripts/benchmark-ci.mjs
+++ b/scripts/benchmark-ci.mjs
@@ -1,0 +1,40 @@
+import { runCrdtSyncLatencyBenchmarks } from '../packages/core/src/__benchmarks__/crdt-sync-latency.js';
+import { runCryptoOverheadBenchmarks } from '../packages/core/src/__benchmarks__/crypto-overhead.js';
+import * as fs from 'fs';
+
+const ITERATIONS = 50;
+
+async function main() {
+  console.log('CI benchmarks: ' + ITERATIONS + ' iterations per test...\n');
+
+  const results = [
+    await runCrdtSyncLatencyBenchmarks(ITERATIONS),
+    await runCryptoOverheadBenchmarks(ITERATIONS),
+  ];
+
+  const report = results.map((suite) => ({
+    benchmark: suite.benchmark,
+    timestamp: suite.timestamp,
+    system: suite.system,
+    results: suite.results.map((r) => ({
+      name: r.name,
+      iterations: r.iterations,
+      min: r.stats.min,
+      mean: r.stats.mean,
+      median: r.stats.median,
+      p99: r.stats.p99,
+      max: r.stats.max,
+      stddev: r.stats.stddev,
+      unit: r.unit,
+      memoryDeltaBytes: r.memoryDeltaBytes ?? null,
+    })),
+  }));
+
+  fs.writeFileSync('benchmark-results.json', JSON.stringify(report, null, 2));
+  console.log('\nResults written to benchmark-results.json');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -13761,6 +13761,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@playwright/test": "npm:^1.58.2"
+    tsx: "npm:4.23.12"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Adds a CI benchmark artifact for manual performance comparison during review.

- Run the core sync-latency and crypto-overhead suites with 50 measured iterations per case
- Use a lockfile-pinned `tsx` runner
- Record the timestamp, runtime platform, iteration count, complete timing statistics, units, and memory delta
- Retain the JSON artifact for 30 days

This workflow does not enforce performance thresholds or compare results against a baseline.