### PR TITLE
fix(core): merge compaction config safely

### DIFF
--- a/packages/core/src/compaction-config.test.ts
+++ b/packages/core/src/compaction-config.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from '@jest/globals';
+import type { CompactionConfig } from './compaction-config.js';
+import {
+  defaultCompactionConfig,
+  mergeCompactionConfig,
+} from './compaction-config.js';
+
+describe('mergeCompactionConfig', () => {
+  test('keeps automatic compaction disabled by default', () => {
+    expect(defaultCompactionConfig.enabled).toBe(false);
+    expect(mergeCompactionConfig().enabled).toBe(false);
+  });
+
+  test('returns a copy of the default values', () => {
+    const config = mergeCompactionConfig();
+
+    expect(config).toEqual(defaultCompactionConfig);
+  });
+
+  test('returns a fresh config object', () => {
+    expect(mergeCompactionConfig()).not.toBe(defaultCompactionConfig);
+    expect(mergeCompactionConfig()).not.toBe(mergeCompactionConfig());
+  });
+
+  test('treats null overrides as no overrides', () => {
+    expect(mergeCompactionConfig(null)).toEqual(defaultCompactionConfig);
+  });
+
+  test('treats nullish fields as no override', () => {
+    const overrides = {
+      enabled: undefined,
+      snapshotInterval: null,
+    } as unknown as Partial<CompactionConfig>;
+
+    expect(mergeCompactionConfig(overrides)).toEqual(defaultCompactionConfig);
+  });
+
+  test('applies partial overrides while preserving unspecified defaults', () => {
+    const partial: Partial<CompactionConfig> = {
+      enabled: true,
+      snapshotInterval: 200,
+      minChangesBeforeSnapshot: 50,
+    };
+    const merged = mergeCompactionConfig(partial);
+
+    expect(merged).toEqual({
+      ...defaultCompactionConfig,
+      ...partial,
+    });
+  });
+
+  test('applies a complete set of overrides', () => {
+    const overrides: CompactionConfig = {
+      enabled: true,
+      snapshotInterval: 100,
+      minChangesBeforeSnapshot: 25,
+      pruneAfterSnapshot: false,
+      gcAfterPrune: true,
+      keepRecentNodes: 10,
+    };
+
+    expect(mergeCompactionConfig(overrides)).toEqual(overrides);
+  });
+});

--- a/packages/core/src/compaction-config.ts
+++ b/packages/core/src/compaction-config.ts
@@ -48,3 +48,16 @@ export const defaultCompactionConfig: CompactionConfig = {
   gcAfterPrune: false,
   keepRecentNodes: 50,
 };
+
+export function mergeCompactionConfig(
+  overrides?: Partial<CompactionConfig> | null,
+): CompactionConfig {
+  const definedOverrides = Object.entries(overrides ?? {}).filter(
+    ([, value]) => value != null,
+  );
+
+  return {
+    ...defaultCompactionConfig,
+    ...Object.fromEntries(definedOverrides),
+  };
+}

--- a/packages/core/src/compaction.test.ts
+++ b/packages/core/src/compaction.test.ts
@@ -9,41 +9,6 @@ import {
   loadChangeBlock,
 } from './blockstore-gc.js';
 
-describe('CompactionConfig', () => {
-  test('default config has compaction disabled', () => {
-    expect(defaultCompactionConfig.enabled).toBe(false);
-  });
-
-  test('default config has reasonable defaults', () => {
-    expect(defaultCompactionConfig.snapshotInterval).toBe(500);
-    expect(defaultCompactionConfig.minChangesBeforeSnapshot).toBe(100);
-    expect(defaultCompactionConfig.pruneAfterSnapshot).toBe(true);
-    expect(defaultCompactionConfig.keepRecentNodes).toBe(50);
-  });
-
-  test('default config has gcAfterPrune disabled', () => {
-    expect(defaultCompactionConfig.gcAfterPrune).toBe(false);
-  });
-
-  test('custom config overrides defaults', () => {
-    const custom: CompactionConfig = {
-      enabled: true,
-      snapshotInterval: 100,
-      minChangesBeforeSnapshot: 50,
-      pruneAfterSnapshot: false,
-      gcAfterPrune: true,
-      keepRecentNodes: 10,
-    };
-
-    expect(custom.enabled).toBe(true);
-    expect(custom.snapshotInterval).toBe(100);
-    expect(custom.minChangesBeforeSnapshot).toBe(50);
-    expect(custom.pruneAfterSnapshot).toBe(false);
-    expect(custom.gcAfterPrune).toBe(true);
-    expect(custom.keepRecentNodes).toBe(10);
-  });
-});
-
 describe('Compaction trigger logic', () => {
   /**
    * Simulates the _maybeCompact() logic without needing the full

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,7 +121,10 @@ import {
 import { documentTopic, DEFAULT_DOCUMENT_TOPIC_PREFIX } from './document-topic.js';
 import type { CRDTSnapshotNode } from './snapshot-node.js';
 import type { CompactionConfig } from './compaction-config.js';
-import { defaultCompactionConfig } from './compaction-config.js';
+import {
+  defaultCompactionConfig,
+  mergeCompactionConfig,
+} from './compaction-config.js';
 
 export * from './beekem/index.js';
 
@@ -224,6 +227,7 @@ export {
   validateLoadQuorumConfig,
   // Compaction
   defaultCompactionConfig,
+  mergeCompactionConfig,
   // Network statistics
   NetworkStats,
   // Utilities

--- a/packages/core/src/peerborne-document.ts
+++ b/packages/core/src/peerborne-document.ts
@@ -79,7 +79,8 @@ import {
 } from './load-quorum.js';
 import { runLoadQuorum } from './load-quorum-orchestrator.js';
 import { CRDTSnapshotNode } from './snapshot-node.js';
-import { CompactionConfig, defaultCompactionConfig } from './compaction-config.js';
+import type { CompactionConfig } from './compaction-config.js';
+import { mergeCompactionConfig } from './compaction-config.js';
 import {
   filterDeletableCIDs,
   loadChangeBlock as lazyLoadChangeBlock,
@@ -733,10 +734,9 @@ export class PeerborneDocument<
     this._readers = this._aclProvider.initialize();
     this._writers = this._aclProvider.initialize();
     this._keychain = this._keychainProvider.initialize();
-    this._compactionConfig = {
-      ...defaultCompactionConfig,
-      ...(this.swarm.config?.compaction ?? {}),
-    };
+    this._compactionConfig = mergeCompactionConfig(
+      this.swarm.config?.compaction,
+    );
 
     // Provide a valid default topic so that _makeChange() works even before
     // open() is called (e.g. when load() triggers a change). open() will


### PR DESCRIPTION
Centralizes compaction configuration resolution and uses it from `PeerborneDocument`.

- preserves defaults for nullish override values
- automatically carries future default fields into resolved configs
- exports the shared resolver and adds focused regression coverage

Validation: core typecheck and full core test suite (941 tests).