### PR TITLE
docs: add generated benchmark charts

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build site
         run: yarn workspace @peerborne/site build
       - name: Test site tooling
-        run: node --test site/scripts/check-links.test.mjs site/scripts/generate-llms-full.test.mjs
+        run: node --test site/scripts/check-links.test.mjs site/scripts/generate-benchmark-charts.test.mjs site/scripts/generate-llms-full.test.mjs
       - name: Check site and agent index links
         run: node site/scripts/check-links.mjs
       - uses: actions/configure-pages@v6

--- a/site/package.json
+++ b/site/package.json
@@ -4,9 +4,13 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "benchmarks:snapshot": "node scripts/collect-benchmark-snapshot.mjs",
     "build:dependencies": "yarn workspace @peerborne/core tsc && yarn workspace @peerborne/yjs tsc",
     "dev": "yarn run build:dependencies && astro dev",
-    "build": "yarn run build:dependencies && astro build && node scripts/generate-llms-full.mjs",
+    "build": "yarn charts:check && yarn run build:dependencies && astro build && node scripts/generate-llms-full.mjs",
+    "charts:generate": "node scripts/generate-benchmark-charts.mjs",
+    "charts:check": "node scripts/generate-benchmark-charts.mjs --check",
+    "charts:test": "node --test scripts/generate-benchmark-charts.test.mjs && yarn charts:check",
     "preview": "astro preview"
   },
   "dependencies": {

--- a/site/scripts/collect-benchmark-snapshot.mjs
+++ b/site/scripts/collect-benchmark-snapshot.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { cpus, totalmem } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(import.meta.url);
+const root = resolve(dirname(scriptPath), '../..');
+const outputPath = resolve(root, 'site/src/data/benchmark-snapshot.json');
+const chartMetricNames = {
+  'crdt-sync-latency': ['sign-encrypt', 'decrypt-verify'].flatMap((prefix) =>
+    ['1kb', '10kb', '100kb', '1mb'].map((size) => `${prefix}-${size}`),
+  ),
+  'crypto-overhead': ['plaintext-pipeline', 'encrypted-pipeline'].flatMap(
+    (prefix) =>
+      ['1kb', '10kb', '100kb', '1mb'].map((size) => `${prefix}-${size}`),
+  ),
+  'convergence-simulation': ['2', '4', '8', '16', '32'].map(
+    (peers) => `convergence-${peers}-peers`,
+  ),
+  'index-query-scaling': ['exact-match', 'prefix-query', 'compound-query'].flatMap(
+    (prefix) => ['100', '1000', '10000'].map((count) => `${prefix}-${count}`),
+  ),
+  'bloom-filter-scaling': ['insert-1000-into', 'merge'].flatMap((prefix) =>
+    ['1k-bits', '8k-bits', '64k-bits', '256k-bits', '1m-bits'].map(
+      (size) => `${prefix}-${size}`,
+    ),
+  ),
+  'blind-index-perf': ['1', '2', '4', '8', '16'].map(
+    (fields) => `derive-and-tokenize-${fields}-fields`,
+  ),
+};
+
+function option(name, fallback) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+function positiveInteger(name, fallback) {
+  const raw = option(name, String(fallback));
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function readSuites(path) {
+  const suites = JSON.parse(readFileSync(path, 'utf8'));
+  if (!Array.isArray(suites) || suites.length === 0) {
+    throw new Error(`Expected benchmark suites in ${path}`);
+  }
+  return suites;
+}
+
+function currentCommit() {
+  const result = spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`Could not determine source commit: ${result.stderr}`);
+  }
+  return result.stdout.trim();
+}
+
+function selectChartMetrics(suites) {
+  return Object.entries(chartMetricNames).map(([benchmark, names]) => {
+    const source = suites.find((suite) => suite.benchmark === benchmark);
+    if (!source) throw new Error(`Missing benchmark suite: ${benchmark}`);
+    return {
+      benchmark,
+      timestamp: source.timestamp,
+      system: source.system,
+      results: names.map((name) => {
+        const result = source.results.find((candidate) => candidate.name === name);
+        if (!result) throw new Error(`Missing benchmark metric: ${benchmark}/${name}`);
+        return {
+          name: result.name,
+          iterations: result.iterations,
+          unit: result.unit,
+          stats: {
+            mean: result.stats.mean,
+            p99: result.stats.p99,
+          },
+        };
+      }),
+    };
+  });
+}
+
+function collect() {
+  const coreIterations = positiveInteger('--core-iterations', 100);
+  const indexIterations = positiveInteger('--index-iterations', 100);
+  const maxDocuments = positiveInteger('--max-documents', 100_000);
+  const corePath = resolve(
+    root,
+    'packages/core/src/__benchmarks__/results.json',
+  );
+  const indexPath = resolve(
+    root,
+    'packages/index/src/__benchmarks__/results.json',
+  );
+  const suites = [...readSuites(corePath), ...readSuites(indexPath)];
+  const systems = new Set(suites.map((suite) => JSON.stringify(suite.system)));
+  if (systems.size !== 1) {
+    throw new Error('Core and index benchmark system metadata do not match');
+  }
+
+  const snapshot = {
+    schemaVersion: 1,
+    sourceCommit: currentCommit(),
+    collectedAt: suites
+      .map((suite) => suite.timestamp)
+      .sort()
+      .at(-1),
+    system: {
+      ...suites[0].system,
+      cpu: cpus()[0]?.model ?? 'unknown',
+      memoryBytes: totalmem(),
+    },
+    commands: [
+      `yarn workspace @peerborne/core benchmark --iterations ${coreIterations}`,
+      `yarn workspace @peerborne/index benchmark --iterations ${indexIterations} --max-documents ${maxDocuments}`,
+    ],
+    parameters: {
+      coreIterations,
+      convergenceIterations: Math.max(1, Math.floor(coreIterations / 5)),
+      indexIterations,
+      maxDocuments,
+    },
+    suites: selectChartMetrics(suites),
+  };
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+  console.log(`Wrote ${outputPath}`);
+}
+
+if (resolve(process.argv[1] ?? '') === scriptPath) {
+  collect();
+}

--- a/site/scripts/generate-benchmark-charts.mjs
+++ b/site/scripts/generate-benchmark-charts.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(import.meta.url);
+const root = resolve(dirname(scriptPath), '../..');
+const snapshotPath = resolve(root, 'site/src/data/benchmark-snapshot.json');
+const outputDirectory = resolve(root, 'site/src/assets/charts');
+const chartWidth = 1120;
+const chartHeight = 620;
+const plot = { x: 92, y: 135, width: 978, height: 350 };
+const palette = ['#2dd4bf', '#818cf8', '#f59e0b', '#f472b6'];
+
+function escapeXml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function readSnapshot() {
+  return JSON.parse(readFileSync(snapshotPath, 'utf8'));
+}
+
+function validateSnapshot(snapshot) {
+  if (snapshot.schemaVersion !== 1) {
+    throw new Error(`Unsupported benchmark snapshot schema: ${snapshot.schemaVersion}`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(snapshot.sourceCommit)) {
+    throw new Error('Benchmark snapshot requires a full source commit SHA');
+  }
+  if (!Array.isArray(snapshot.suites) || snapshot.suites.length !== 6) {
+    throw new Error('Benchmark snapshot must contain all six suites');
+  }
+  for (const suite of snapshot.suites) {
+    if (!Array.isArray(suite.results) || suite.results.length === 0) {
+      throw new Error(`Benchmark suite ${suite.benchmark} has no results`);
+    }
+  }
+}
+
+function suite(snapshot, name) {
+  const match = snapshot.suites.find((candidate) => candidate.benchmark === name);
+  if (!match) throw new Error(`Missing benchmark suite: ${name}`);
+  return match;
+}
+
+function metric(snapshot, suiteName, name) {
+  const result = suite(snapshot, suiteName).results.find(
+    (candidate) => candidate.name === name,
+  );
+  if (!result) throw new Error(`Missing benchmark metric: ${suiteName}/${name}`);
+  if (result.unit !== 'ms') {
+    throw new Error(`Expected millisecond metric: ${suiteName}/${name}`);
+  }
+  for (const field of ['mean', 'p99']) {
+    if (!Number.isFinite(result.stats?.[field]) || result.stats[field] < 0) {
+      throw new Error(`Invalid ${field}: ${suiteName}/${name}`);
+    }
+  }
+  if (!Number.isInteger(result.iterations) || result.iterations <= 0) {
+    throw new Error(`Invalid iterations: ${suiteName}/${name}`);
+  }
+  return {
+    mean: result.stats.mean,
+    p99: result.stats.p99,
+    iterations: result.iterations,
+  };
+}
+
+function series(snapshot, suiteName, label, prefix, labels) {
+  return {
+    label,
+    points: labels.map((name) => metric(snapshot, suiteName, `${prefix}${name}`)),
+  };
+}
+
+export function chartDefinitions(snapshot) {
+  validateSnapshot(snapshot);
+  const payloads = ['1kb', '10kb', '100kb', '1mb'];
+  const documents = ['100', '1000', '10000'];
+  const peers = ['2', '4', '8', '16', '32'];
+  const filters = ['1k-bits', '8k-bits', '64k-bits', '256k-bits', '1m-bits'];
+  const fields = ['1', '2', '4', '8', '16'];
+
+  return [
+    {
+      filename: 'crdt-pipeline-latency.svg',
+      title: 'Signed and encrypted change pipeline',
+      subtitle: 'Mean local operation latency by payload size; whiskers show p99',
+      description:
+        'Line chart of mean sign-and-encrypt and decrypt-and-verify latency from one kilobyte to one megabyte, with p99 whiskers.',
+      xLabel: 'Payload size (log-spaced categories)',
+      xLabels: ['1 KB', '10 KB', '100 KB', '1 MB'],
+      yLabel: 'Latency (ms)',
+      scale: 'linear',
+      series: [
+        series(snapshot, 'crdt-sync-latency', 'Sign + encrypt', 'sign-encrypt-', payloads),
+        series(snapshot, 'crdt-sync-latency', 'Decrypt + verify', 'decrypt-verify-', payloads),
+      ],
+    },
+    {
+      filename: 'crypto-pipeline-overhead.svg',
+      title: 'Plaintext and encrypted pipeline cost',
+      subtitle: 'Local synthetic pipeline comparison; mean with p99 whiskers',
+      description:
+        'Line chart comparing plaintext and encrypted local synthetic pipeline latency across four payload sizes.',
+      xLabel: 'Payload size (log-spaced categories)',
+      xLabels: ['1 KB', '10 KB', '100 KB', '1 MB'],
+      yLabel: 'Latency (ms)',
+      scale: 'linear',
+      series: [
+        series(snapshot, 'crypto-overhead', 'Plaintext pipeline', 'plaintext-pipeline-', payloads),
+        series(snapshot, 'crypto-overhead', 'Encrypted pipeline', 'encrypted-pipeline-', payloads),
+      ],
+    },
+    {
+      filename: 'convergence-scaling.svg',
+      title: 'Simulated convergence scaling',
+      subtitle: 'Full local sign/encrypt/broadcast/decrypt/verify simulation; log latency axis',
+      description:
+        'Line chart of simulated convergence latency from two to 32 peers on a logarithmic latency axis.',
+      xLabel: 'Simulated peers',
+      xLabels: peers,
+      yLabel: 'Latency (ms, log scale)',
+      scale: 'log',
+      series: [
+        series(snapshot, 'convergence-simulation', 'Convergence', 'convergence-', peers.map((value) => `${value}-peers`)),
+      ],
+    },
+    {
+      filename: 'index-query-scaling.svg',
+      title: 'In-memory index query scaling',
+      subtitle: 'Mean local query latency by indexed document count; p99 whiskers',
+      description:
+        'Line chart comparing exact-match, prefix, and compound local in-memory index query latency from 100 to 10,000 documents.',
+      xLabel: 'Indexed documents (log-spaced categories)',
+      xLabels: ['100', '1K', '10K'],
+      yLabel: 'Latency (ms)',
+      scale: 'linear',
+      series: [
+        series(snapshot, 'index-query-scaling', 'Exact match', 'exact-match-', documents),
+        series(snapshot, 'index-query-scaling', 'Prefix query', 'prefix-query-', documents),
+        series(snapshot, 'index-query-scaling', 'Compound query', 'compound-query-', documents),
+      ],
+    },
+    {
+      filename: 'bloom-filter-scaling.svg',
+      title: 'Bloom filter operation scaling',
+      subtitle: 'Insert 1,000 items and merge two filters; mean with p99 whiskers',
+      description:
+        'Line chart comparing insertion and merge latency across Bloom filter sizes from one kilobit to one megabit.',
+      xLabel: 'Filter size (log-spaced categories)',
+      xLabels: ['1 Kb', '8 Kb', '64 Kb', '256 Kb', '1 Mb'],
+      yLabel: 'Latency (ms)',
+      scale: 'linear',
+      series: [
+        series(snapshot, 'bloom-filter-scaling', 'Insert 1,000', 'insert-1000-into-', filters),
+        series(snapshot, 'bloom-filter-scaling', 'Merge filters', 'merge-', filters),
+      ],
+    },
+    {
+      filename: 'blind-index-scaling.svg',
+      title: 'Blind-index field scaling',
+      subtitle: 'Derive field keys and compute tokens locally; mean with p99 whiskers',
+      description:
+        'Line chart of blind-index key derivation and tokenization latency from one to 16 fields.',
+      xLabel: 'Fields tokenized',
+      xLabels: fields,
+      yLabel: 'Latency (ms)',
+      scale: 'linear',
+      series: [
+        series(snapshot, 'blind-index-perf', 'Derive + tokenize', 'derive-and-tokenize-', fields.map((value) => `${value}-fields`)),
+      ],
+    },
+  ];
+}
+
+function niceMaximum(value) {
+  const exponent = 10 ** Math.floor(Math.log10(value || 1));
+  const normalized = value / exponent;
+  const step = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  return step * exponent;
+}
+
+function formatNumber(value) {
+  if (value >= 1000) return `${Number((value / 1000).toPrecision(3))}k`;
+  if (value >= 10) return String(Number(value.toPrecision(3)));
+  if (value >= 1) return value.toFixed(1).replace(/\.0$/, '');
+  if (value >= 0.01) return value.toFixed(2).replace(/0+$/, '').replace(/\.$/, '');
+  return value.toFixed(3).replace(/0+$/, '').replace(/\.$/, '');
+}
+
+function scaleFor(chart) {
+  const values = chart.series.flatMap((item) =>
+    item.points.flatMap((point) => [point.mean, point.p99]),
+  );
+  const maximum = Math.max(...values);
+  if (chart.scale === 'log') {
+    const positive = values.filter((value) => value > 0);
+    const minimumPower = Math.floor(Math.log10(Math.min(...positive)));
+    const maximumPower = Math.ceil(Math.log10(maximum));
+    const ticks = Array.from(
+      { length: maximumPower - minimumPower + 1 },
+      (_, index) => 10 ** (minimumPower + index),
+    );
+    return {
+      ticks,
+      y(value) {
+        const ratio =
+          (Math.log10(Math.max(value, ticks[0])) - minimumPower) /
+          (maximumPower - minimumPower);
+        return plot.y + plot.height - ratio * plot.height;
+      },
+    };
+  }
+
+  const top = niceMaximum(maximum * 1.08);
+  const ticks = Array.from({ length: 6 }, (_, index) => (top * index) / 5);
+  return {
+    ticks,
+    y(value) {
+      return plot.y + plot.height - (value / top) * plot.height;
+    },
+  };
+}
+
+function xPosition(index, count) {
+  if (count === 1) return plot.x + plot.width / 2;
+  return plot.x + (plot.width * index) / (count - 1);
+}
+
+function iterationSummary(chart) {
+  const iterations = [
+    ...new Set(chart.series.flatMap((item) => item.points.map((point) => point.iterations))),
+  ].sort((a, b) => a - b);
+  return iterations.length === 1
+    ? `${iterations[0]} timed iterations per point`
+    : `${iterations.join('–')} timed iterations per point`;
+}
+
+export function renderChart(chart, snapshot) {
+  const scale = scaleFor(chart);
+  const grid = scale.ticks
+    .map((tick) => {
+      const y = scale.y(tick);
+      return `    <line x1="${plot.x}" y1="${y.toFixed(2)}" x2="${plot.x + plot.width}" y2="${y.toFixed(2)}" stroke="#334155" stroke-width="1"/>
+    <text x="${plot.x - 14}" y="${(y + 5).toFixed(2)}" fill="#94a3b8" font-size="13" text-anchor="end">${escapeXml(formatNumber(tick))}</text>`;
+    })
+    .join('\n');
+  const xAxis = chart.xLabels
+    .map((label, index) => {
+      const x = xPosition(index, chart.xLabels.length);
+      return `    <line x1="${x.toFixed(2)}" y1="${plot.y + plot.height}" x2="${x.toFixed(2)}" y2="${plot.y + plot.height + 7}" stroke="#64748b"/>
+    <text x="${x.toFixed(2)}" y="${plot.y + plot.height + 27}" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">${escapeXml(label)}</text>`;
+    })
+    .join('\n');
+  const renderedSeries = chart.series
+    .map((item, seriesIndex) => {
+      const color = palette[seriesIndex];
+      const points = item.points.map((point, index) => ({
+        ...point,
+        x: xPosition(index, item.points.length),
+        meanY: scale.y(point.mean),
+        p99Y: scale.y(point.p99),
+      }));
+      const path = points
+        .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x.toFixed(2)} ${point.meanY.toFixed(2)}`)
+        .join(' ');
+      const marks = points
+        .map((point) => {
+          const preferredOffset = seriesIndex === 0 ? -12 : 20 + seriesIndex * 14;
+          const labelY =
+            point.meanY + preferredOffset > plot.y + plot.height - 5
+              ? point.meanY - 12 - seriesIndex * 15
+              : point.meanY + preferredOffset;
+          return `      <line x1="${point.x.toFixed(2)}" y1="${point.meanY.toFixed(2)}" x2="${point.x.toFixed(2)}" y2="${point.p99Y.toFixed(2)}" stroke="${color}" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="${(point.x - 6).toFixed(2)}" y1="${point.p99Y.toFixed(2)}" x2="${(point.x + 6).toFixed(2)}" y2="${point.p99Y.toFixed(2)}" stroke="${color}" stroke-width="2"/>
+      <circle cx="${point.x.toFixed(2)}" cy="${point.meanY.toFixed(2)}" r="6" fill="#0f172a" stroke="${color}" stroke-width="3"/>
+      <text x="${point.x.toFixed(2)}" y="${labelY.toFixed(2)}" fill="${color}" font-size="11.5" font-weight="750" text-anchor="middle">${escapeXml(formatNumber(point.mean))}</text>`;
+        })
+        .join('\n');
+      return `    <g aria-label="${escapeXml(item.label)}">
+      <path d="${path}" fill="none" stroke="${color}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+${marks}
+    </g>`;
+    })
+    .join('\n');
+  const legend = chart.series
+    .map((item, index) => {
+      const x = plot.x + index * 245;
+      return `    <line x1="${x}" y1="107" x2="${x + 28}" y2="107" stroke="${palette[index]}" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="${x + 14}" cy="107" r="5" fill="#0f172a" stroke="${palette[index]}" stroke-width="2"/>
+    <text x="${x + 38}" y="112" fill="#e2e8f0" font-size="14" font-weight="650">${escapeXml(item.label)}</text>`;
+    })
+    .join('\n');
+  const commit = snapshot.sourceCommit.slice(0, 8);
+  const date = snapshot.collectedAt.slice(0, 10);
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${chartWidth}" height="${chartHeight}" viewBox="0 0 ${chartWidth} ${chartHeight}" role="img" aria-labelledby="title description">
+  <title id="title">${escapeXml(chart.title)}</title>
+  <desc id="description">${escapeXml(chart.description)} Dots show means and capped whiskers show p99. This is a directional single-machine snapshot, not a performance guarantee.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#94a3b8" stroke-opacity=".035"/>
+    </pattern>
+    <style>text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }</style>
+  </defs>
+  <rect width="${chartWidth}" height="${chartHeight}" rx="26" fill="url(#background)"/>
+  <rect width="${chartWidth}" height="${chartHeight}" rx="26" fill="url(#grid)"/>
+  <path d="M0 26A26 26 0 0 1 26 0H1094A26 26 0 0 1 1120 26V32H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="42" y="59" fill="#f8fafc" font-size="29" font-weight="780">${escapeXml(chart.title)}</text>
+    <text x="42" y="84" fill="#94a3b8" font-size="15">${escapeXml(chart.subtitle)}</text>
+${legend}
+${grid}
+    <line x1="${plot.x}" y1="${plot.y}" x2="${plot.x}" y2="${plot.y + plot.height}" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="${plot.x}" y1="${plot.y + plot.height}" x2="${plot.x + plot.width}" y2="${plot.y + plot.height}" stroke="#64748b" stroke-width="1.5"/>
+${xAxis}
+${renderedSeries}
+    <text x="${plot.x + plot.width / 2}" y="538" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">${escapeXml(chart.xLabel)}</text>
+    <text x="24" y="${plot.y + plot.height / 2}" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle" transform="rotate(-90 24 ${plot.y + plot.height / 2})">${escapeXml(chart.yLabel)}</text>
+    <rect x="42" y="557" width="1036" height="43" rx="12" fill="#0b1524" stroke="#334155"/>
+    <text x="560" y="575" fill="#94a3b8" font-size="11.5" text-anchor="middle">Directional snapshot · ${escapeXml(snapshot.system.cpu)} · ${escapeXml(snapshot.system.node)} · ${escapeXml(snapshot.system.platform)}/${escapeXml(snapshot.system.arch)} · commit ${commit} · ${date}</text>
+    <text x="560" y="591" fill="#94a3b8" font-size="11.5" text-anchor="middle">Mean dots + p99 whiskers · ${escapeXml(iterationSummary(chart))} · no pass/fail budget</text>
+  </g>
+</svg>
+`;
+}
+
+export function generateCharts(snapshot) {
+  return new Map(
+    chartDefinitions(snapshot).map((chart) => [
+      chart.filename,
+      renderChart(chart, snapshot),
+    ]),
+  );
+}
+
+function run() {
+  const charts = generateCharts(readSnapshot());
+  const checking = process.argv.includes('--check');
+  if (!checking) mkdirSync(outputDirectory, { recursive: true });
+
+  for (const [filename, svg] of charts) {
+    const path = resolve(outputDirectory, filename);
+    if (checking) {
+      let current;
+      try {
+        current = readFileSync(path, 'utf8');
+      } catch {
+        throw new Error(`Missing generated chart: ${path}`);
+      }
+      if (current !== svg) {
+        throw new Error(`Generated chart is stale: ${path}`);
+      }
+    } else {
+      writeFileSync(path, svg);
+    }
+  }
+
+  console.log(`${checking ? 'Verified' : 'Generated'} ${charts.size} benchmark charts`);
+}
+
+if (resolve(process.argv[1] ?? '') === scriptPath) {
+  run();
+}

--- a/site/scripts/generate-benchmark-charts.test.mjs
+++ b/site/scripts/generate-benchmark-charts.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  chartDefinitions,
+  generateCharts,
+} from './generate-benchmark-charts.mjs';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const snapshot = JSON.parse(
+  readFileSync(resolve(root, 'site/src/data/benchmark-snapshot.json'), 'utf8'),
+);
+
+test('all six charts are deterministic and current', () => {
+  const first = generateCharts(snapshot);
+  const second = generateCharts(snapshot);
+
+  assert.equal(first.size, 6);
+  assert.deepEqual(first, second);
+  for (const [filename, svg] of first) {
+    const output = readFileSync(
+      resolve(root, 'site/src/assets/charts', filename),
+      'utf8',
+    );
+    assert.equal(output, svg, filename);
+  }
+});
+
+test('charts are accessible, self-contained SVG without invalid values', () => {
+  for (const [filename, svg] of generateCharts(snapshot)) {
+    assert.match(svg, /^<svg[^>]+viewBox="0 0 1120 620"/, filename);
+    assert.match(svg, /<title id="title">/, filename);
+    assert.match(svg, /<desc id="description">/, filename);
+    assert.doesNotMatch(svg, /(?:NaN|Infinity|\[object Object\])/, filename);
+    assert.doesNotMatch(svg, /<(?:image|foreignObject|script)\b/i, filename);
+    assert.doesNotMatch(svg, /(?:href|src)=["'](?:https?:|data:)/i, filename);
+  }
+});
+
+test('missing metrics fail generation instead of becoming zero', () => {
+  const incomplete = structuredClone(snapshot);
+  incomplete.suites.find(
+    (suite) => suite.benchmark === 'crdt-sync-latency',
+  ).results = [];
+
+  assert.throws(() => chartDefinitions(incomplete), /has no results/);
+});

--- a/site/src/assets/charts/blind-index-scaling.svg
+++ b/site/src/assets/charts/blind-index-scaling.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="620" viewBox="0 0 1120 620" role="img" aria-labelledby="title description">
+  <title id="title">Blind-index field scaling</title>
+  <desc id="description">Line chart of blind-index key derivation and tokenization latency from one to 16 fields. Dots show means and capped whiskers show p99. This is a directional single-machine snapshot, not a performance guarantee.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#94a3b8" stroke-opacity=".035"/>
+    </pattern>
+    <style>text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }</style>
+  </defs>
+  <rect width="1120" height="620" rx="26" fill="url(#background)"/>
+  <rect width="1120" height="620" rx="26" fill="url(#grid)"/>
+  <path d="M0 26A26 26 0 0 1 26 0H1094A26 26 0 0 1 1120 26V32H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="42" y="59" fill="#f8fafc" font-size="29" font-weight="780">Blind-index field scaling</text>
+    <text x="42" y="84" fill="#94a3b8" font-size="15">Derive field keys and compute tokens locally; mean with p99 whiskers</text>
+    <line x1="92" y1="107" x2="120" y2="107" stroke="#2dd4bf" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="106" cy="107" r="5" fill="#0f172a" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="130" y="112" fill="#e2e8f0" font-size="14" font-weight="650">Derive + tokenize</text>
+    <line x1="92" y1="485.00" x2="1070" y2="485.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="490.00" fill="#94a3b8" font-size="13" text-anchor="end">0</text>
+    <line x1="92" y1="415.00" x2="1070" y2="415.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="420.00" fill="#94a3b8" font-size="13" text-anchor="end">0.4</text>
+    <line x1="92" y1="345.00" x2="1070" y2="345.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="350.00" fill="#94a3b8" font-size="13" text-anchor="end">0.8</text>
+    <line x1="92" y1="275.00" x2="1070" y2="275.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="280.00" fill="#94a3b8" font-size="13" text-anchor="end">1.2</text>
+    <line x1="92" y1="205.00" x2="1070" y2="205.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="210.00" fill="#94a3b8" font-size="13" text-anchor="end">1.6</text>
+    <line x1="92" y1="135.00" x2="1070" y2="135.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="140.00" fill="#94a3b8" font-size="13" text-anchor="end">2</text>
+    <line x1="92" y1="135" x2="92" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92" y1="485" x2="1070" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92.00" y1="485" x2="92.00" y2="492" stroke="#64748b"/>
+    <text x="92.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">1</text>
+    <line x1="336.50" y1="485" x2="336.50" y2="492" stroke="#64748b"/>
+    <text x="336.50" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">2</text>
+    <line x1="581.00" y1="485" x2="581.00" y2="492" stroke="#64748b"/>
+    <text x="581.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">4</text>
+    <line x1="825.50" y1="485" x2="825.50" y2="492" stroke="#64748b"/>
+    <text x="825.50" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">8</text>
+    <line x1="1070.00" y1="485" x2="1070.00" y2="492" stroke="#64748b"/>
+    <text x="1070.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">16</text>
+    <g aria-label="Derive + tokenize">
+      <path d="M92.00 474.66 L336.50 465.65 L581.00 445.02 L825.50 424.00 L1070.00 351.35" fill="none" stroke="#2dd4bf" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="92.00" y1="474.66" x2="92.00" y2="471.77" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="86.00" y1="471.77" x2="98.00" y2="471.77" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="92.00" cy="474.66" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="92.00" y="462.66" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.06</text>
+      <line x1="336.50" y1="465.65" x2="336.50" y2="455.95" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="330.50" y1="455.95" x2="342.50" y2="455.95" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="336.50" cy="465.65" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="336.50" y="453.65" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.11</text>
+      <line x1="581.00" y1="445.02" x2="581.00" y2="419.99" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="575.00" y1="419.99" x2="587.00" y2="419.99" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="581.00" cy="445.02" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="581.00" y="433.02" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.23</text>
+      <line x1="825.50" y1="424.00" x2="825.50" y2="414.60" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="819.50" y1="414.60" x2="831.50" y2="414.60" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="825.50" cy="424.00" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="825.50" y="412.00" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.35</text>
+      <line x1="1070.00" y1="351.35" x2="1070.00" y2="232.12" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="1064.00" y1="232.12" x2="1076.00" y2="232.12" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="1070.00" cy="351.35" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="1070.00" y="339.35" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.76</text>
+    </g>
+    <text x="581" y="538" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">Fields tokenized</text>
+    <text x="24" y="310" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle" transform="rotate(-90 24 310)">Latency (ms)</text>
+    <rect x="42" y="557" width="1036" height="43" rx="12" fill="#0b1524" stroke="#334155"/>
+    <text x="560" y="575" fill="#94a3b8" font-size="11.5" text-anchor="middle">Directional snapshot · Apple M5 · v22.19.0 · darwin/arm64 · commit 414d4bf7 · 2026-08-29</text>
+    <text x="560" y="591" fill="#94a3b8" font-size="11.5" text-anchor="middle">Mean dots + p99 whiskers · 10 timed iterations per point · no pass/fail budget</text>
+  </g>
+</svg>

--- a/site/src/assets/charts/bloom-filter-scaling.svg
+++ b/site/src/assets/charts/bloom-filter-scaling.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="620" viewBox="0 0 1120 620" role="img" aria-labelledby="title description">
+  <title id="title">Bloom filter operation scaling</title>
+  <desc id="description">Line chart comparing insertion and merge latency across Bloom filter sizes from one kilobit to one megabit. Dots show means and capped whiskers show p99. This is a directional single-machine snapshot, not a performance guarantee.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#94a3b8" stroke-opacity=".035"/>
+    </pattern>
+    <style>text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }</style>
+  </defs>
+  <rect width="1120" height="620" rx="26" fill="url(#background)"/>
+  <rect width="1120" height="620" rx="26" fill="url(#grid)"/>
+  <path d="M0 26A26 26 0 0 1 26 0H1094A26 26 0 0 1 1120 26V32H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="42" y="59" fill="#f8fafc" font-size="29" font-weight="780">Bloom filter operation scaling</text>
+    <text x="42" y="84" fill="#94a3b8" font-size="15">Insert 1,000 items and merge two filters; mean with p99 whiskers</text>
+    <line x1="92" y1="107" x2="120" y2="107" stroke="#2dd4bf" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="106" cy="107" r="5" fill="#0f172a" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="130" y="112" fill="#e2e8f0" font-size="14" font-weight="650">Insert 1,000</text>
+    <line x1="337" y1="107" x2="365" y2="107" stroke="#818cf8" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="351" cy="107" r="5" fill="#0f172a" stroke="#818cf8" stroke-width="2"/>
+    <text x="375" y="112" fill="#e2e8f0" font-size="14" font-weight="650">Merge filters</text>
+    <line x1="92" y1="485.00" x2="1070" y2="485.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="490.00" fill="#94a3b8" font-size="13" text-anchor="end">0</text>
+    <line x1="92" y1="415.00" x2="1070" y2="415.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="420.00" fill="#94a3b8" font-size="13" text-anchor="end">0.2</text>
+    <line x1="92" y1="345.00" x2="1070" y2="345.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="350.00" fill="#94a3b8" font-size="13" text-anchor="end">0.4</text>
+    <line x1="92" y1="275.00" x2="1070" y2="275.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="280.00" fill="#94a3b8" font-size="13" text-anchor="end">0.6</text>
+    <line x1="92" y1="205.00" x2="1070" y2="205.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="210.00" fill="#94a3b8" font-size="13" text-anchor="end">0.8</text>
+    <line x1="92" y1="135.00" x2="1070" y2="135.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="140.00" fill="#94a3b8" font-size="13" text-anchor="end">1</text>
+    <line x1="92" y1="135" x2="92" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92" y1="485" x2="1070" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92.00" y1="485" x2="92.00" y2="492" stroke="#64748b"/>
+    <text x="92.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">1 Kb</text>
+    <line x1="336.50" y1="485" x2="336.50" y2="492" stroke="#64748b"/>
+    <text x="336.50" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">8 Kb</text>
+    <line x1="581.00" y1="485" x2="581.00" y2="492" stroke="#64748b"/>
+    <text x="581.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">64 Kb</text>
+    <line x1="825.50" y1="485" x2="825.50" y2="492" stroke="#64748b"/>
+    <text x="825.50" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">256 Kb</text>
+    <line x1="1070.00" y1="485" x2="1070.00" y2="492" stroke="#64748b"/>
+    <text x="1070.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">1 Mb</text>
+    <g aria-label="Insert 1,000">
+      <path d="M92.00 403.00 L336.50 417.73 L581.00 422.77 L825.50 435.08 L1070.00 438.58" fill="none" stroke="#2dd4bf" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="92.00" y1="403.00" x2="92.00" y2="335.49" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="86.00" y1="335.49" x2="98.00" y2="335.49" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="92.00" cy="403.00" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="92.00" y="391.00" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.23</text>
+      <line x1="336.50" y1="417.73" x2="336.50" y2="410.92" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="330.50" y1="410.92" x2="342.50" y2="410.92" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="336.50" cy="417.73" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="336.50" y="405.73" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.19</text>
+      <line x1="581.00" y1="422.77" x2="581.00" y2="282.71" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="575.00" y1="282.71" x2="587.00" y2="282.71" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="581.00" cy="422.77" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="581.00" y="410.77" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.18</text>
+      <line x1="825.50" y1="435.08" x2="825.50" y2="429.99" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="819.50" y1="429.99" x2="831.50" y2="429.99" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="825.50" cy="435.08" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="825.50" y="423.08" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.14</text>
+      <line x1="1070.00" y1="438.58" x2="1070.00" y2="431.74" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="1064.00" y1="431.74" x2="1076.00" y2="431.74" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="1070.00" cy="438.58" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="1070.00" y="426.58" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.13</text>
+    </g>
+    <g aria-label="Merge filters">
+      <path d="M92.00 483.53 L336.50 475.64 L581.00 481.82 L825.50 473.20 L1070.00 438.85" fill="none" stroke="#818cf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="92.00" y1="483.53" x2="92.00" y2="482.90" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="86.00" y1="482.90" x2="98.00" y2="482.90" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="92.00" cy="483.53" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="92.00" y="456.53" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.004</text>
+      <line x1="336.50" y1="475.64" x2="336.50" y2="458.27" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="330.50" y1="458.27" x2="342.50" y2="458.27" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="336.50" cy="475.64" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="336.50" y="448.64" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.03</text>
+      <line x1="581.00" y1="481.82" x2="581.00" y2="481.56" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="575.00" y1="481.56" x2="587.00" y2="481.56" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="581.00" cy="481.82" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="581.00" y="454.82" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.009</text>
+      <line x1="825.50" y1="473.20" x2="825.50" y2="472.40" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="819.50" y1="472.40" x2="831.50" y2="472.40" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="825.50" cy="473.20" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="825.50" y="446.20" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.03</text>
+      <line x1="1070.00" y1="438.85" x2="1070.00" y2="435.40" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="1064.00" y1="435.40" x2="1076.00" y2="435.40" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="1070.00" cy="438.85" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="1070.00" y="472.85" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.13</text>
+    </g>
+    <text x="581" y="538" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">Filter size (log-spaced categories)</text>
+    <text x="24" y="310" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle" transform="rotate(-90 24 310)">Latency (ms)</text>
+    <rect x="42" y="557" width="1036" height="43" rx="12" fill="#0b1524" stroke="#334155"/>
+    <text x="560" y="575" fill="#94a3b8" font-size="11.5" text-anchor="middle">Directional snapshot · Apple M5 · v22.19.0 · darwin/arm64 · commit 414d4bf7 · 2026-08-29</text>
+    <text x="560" y="591" fill="#94a3b8" font-size="11.5" text-anchor="middle">Mean dots + p99 whiskers · 20 timed iterations per point · no pass/fail budget</text>
+  </g>
+</svg>

--- a/site/src/assets/charts/convergence-scaling.svg
+++ b/site/src/assets/charts/convergence-scaling.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="620" viewBox="0 0 1120 620" role="img" aria-labelledby="title description">
+  <title id="title">Simulated convergence scaling</title>
+  <desc id="description">Line chart of simulated convergence latency from two to 32 peers on a logarithmic latency axis. Dots show means and capped whiskers show p99. This is a directional single-machine snapshot, not a performance guarantee.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#94a3b8" stroke-opacity=".035"/>
+    </pattern>
+    <style>text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }</style>
+  </defs>
+  <rect width="1120" height="620" rx="26" fill="url(#background)"/>
+  <rect width="1120" height="620" rx="26" fill="url(#grid)"/>
+  <path d="M0 26A26 26 0 0 1 26 0H1094A26 26 0 0 1 1120 26V32H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="42" y="59" fill="#f8fafc" font-size="29" font-weight="780">Simulated convergence scaling</text>
+    <text x="42" y="84" fill="#94a3b8" font-size="15">Full local sign/encrypt/broadcast/decrypt/verify simulation; log latency axis</text>
+    <line x1="92" y1="107" x2="120" y2="107" stroke="#2dd4bf" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="106" cy="107" r="5" fill="#0f172a" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="130" y="112" fill="#e2e8f0" font-size="14" font-weight="650">Convergence</text>
+    <line x1="92" y1="485.00" x2="1070" y2="485.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="490.00" fill="#94a3b8" font-size="13" text-anchor="end">10</text>
+    <line x1="92" y1="368.33" x2="1070" y2="368.33" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="373.33" fill="#94a3b8" font-size="13" text-anchor="end">100</text>
+    <line x1="92" y1="251.67" x2="1070" y2="251.67" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="256.67" fill="#94a3b8" font-size="13" text-anchor="end">1k</text>
+    <line x1="92" y1="135.00" x2="1070" y2="135.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="140.00" fill="#94a3b8" font-size="13" text-anchor="end">10k</text>
+    <line x1="92" y1="135" x2="92" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92" y1="485" x2="1070" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92.00" y1="485" x2="92.00" y2="492" stroke="#64748b"/>
+    <text x="92.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">2</text>
+    <line x1="336.50" y1="485" x2="336.50" y2="492" stroke="#64748b"/>
+    <text x="336.50" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">4</text>
+    <line x1="581.00" y1="485" x2="581.00" y2="492" stroke="#64748b"/>
+    <text x="581.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">8</text>
+    <line x1="825.50" y1="485" x2="825.50" y2="492" stroke="#64748b"/>
+    <text x="825.50" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">16</text>
+    <line x1="1070.00" y1="485" x2="1070.00" y2="492" stroke="#64748b"/>
+    <text x="1070.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">32</text>
+    <g aria-label="Convergence">
+      <path d="M92.00 466.78 L336.50 398.55 L581.00 328.54 L825.50 259.42 L1070.00 186.95" fill="none" stroke="#2dd4bf" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="92.00" y1="466.78" x2="92.00" y2="465.52" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="86.00" y1="465.52" x2="98.00" y2="465.52" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="92.00" cy="466.78" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="92.00" y="454.78" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">14.3</text>
+      <line x1="336.50" y1="398.55" x2="336.50" y2="396.70" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="330.50" y1="396.70" x2="342.50" y2="396.70" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="336.50" cy="398.55" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="336.50" y="386.55" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">55.1</text>
+      <line x1="581.00" y1="328.54" x2="581.00" y2="327.25" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="575.00" y1="327.25" x2="587.00" y2="327.25" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="581.00" cy="328.54" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="581.00" y="316.54" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">219</text>
+      <line x1="825.50" y1="259.42" x2="825.50" y2="256.44" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="819.50" y1="256.44" x2="831.50" y2="256.44" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="825.50" cy="259.42" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="825.50" y="247.42" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">858</text>
+      <line x1="1070.00" y1="186.95" x2="1070.00" y2="182.83" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="1064.00" y1="182.83" x2="1076.00" y2="182.83" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="1070.00" cy="186.95" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="1070.00" y="174.95" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">3.59k</text>
+    </g>
+    <text x="581" y="538" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">Simulated peers</text>
+    <text x="24" y="310" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle" transform="rotate(-90 24 310)">Latency (ms, log scale)</text>
+    <rect x="42" y="557" width="1036" height="43" rx="12" fill="#0b1524" stroke="#334155"/>
+    <text x="560" y="575" fill="#94a3b8" font-size="11.5" text-anchor="middle">Directional snapshot · Apple M5 · v22.19.0 · darwin/arm64 · commit 414d4bf7 · 2026-08-29</text>
+    <text x="560" y="591" fill="#94a3b8" font-size="11.5" text-anchor="middle">Mean dots + p99 whiskers · 4 timed iterations per point · no pass/fail budget</text>
+  </g>
+</svg>

--- a/site/src/assets/charts/crdt-pipeline-latency.svg
+++ b/site/src/assets/charts/crdt-pipeline-latency.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="620" viewBox="0 0 1120 620" role="img" aria-labelledby="title description">
+  <title id="title">Signed and encrypted change pipeline</title>
+  <desc id="description">Line chart of mean sign-and-encrypt and decrypt-and-verify latency from one kilobyte to one megabyte, with p99 whiskers. Dots show means and capped whiskers show p99. This is a directional single-machine snapshot, not a performance guarantee.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#94a3b8" stroke-opacity=".035"/>
+    </pattern>
+    <style>text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }</style>
+  </defs>
+  <rect width="1120" height="620" rx="26" fill="url(#background)"/>
+  <rect width="1120" height="620" rx="26" fill="url(#grid)"/>
+  <path d="M0 26A26 26 0 0 1 26 0H1094A26 26 0 0 1 1120 26V32H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="42" y="59" fill="#f8fafc" font-size="29" font-weight="780">Signed and encrypted change pipeline</text>
+    <text x="42" y="84" fill="#94a3b8" font-size="15">Mean local operation latency by payload size; whiskers show p99</text>
+    <line x1="92" y1="107" x2="120" y2="107" stroke="#2dd4bf" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="106" cy="107" r="5" fill="#0f172a" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="130" y="112" fill="#e2e8f0" font-size="14" font-weight="650">Sign + encrypt</text>
+    <line x1="337" y1="107" x2="365" y2="107" stroke="#818cf8" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="351" cy="107" r="5" fill="#0f172a" stroke="#818cf8" stroke-width="2"/>
+    <text x="375" y="112" fill="#e2e8f0" font-size="14" font-weight="650">Decrypt + verify</text>
+    <line x1="92" y1="485.00" x2="1070" y2="485.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="490.00" fill="#94a3b8" font-size="13" text-anchor="end">0</text>
+    <line x1="92" y1="415.00" x2="1070" y2="415.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="420.00" fill="#94a3b8" font-size="13" text-anchor="end">1</text>
+    <line x1="92" y1="345.00" x2="1070" y2="345.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="350.00" fill="#94a3b8" font-size="13" text-anchor="end">2</text>
+    <line x1="92" y1="275.00" x2="1070" y2="275.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="280.00" fill="#94a3b8" font-size="13" text-anchor="end">3</text>
+    <line x1="92" y1="205.00" x2="1070" y2="205.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="210.00" fill="#94a3b8" font-size="13" text-anchor="end">4</text>
+    <line x1="92" y1="135.00" x2="1070" y2="135.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="140.00" fill="#94a3b8" font-size="13" text-anchor="end">5</text>
+    <line x1="92" y1="135" x2="92" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92" y1="485" x2="1070" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92.00" y1="485" x2="92.00" y2="492" stroke="#64748b"/>
+    <text x="92.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">1 KB</text>
+    <line x1="418.00" y1="485" x2="418.00" y2="492" stroke="#64748b"/>
+    <text x="418.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">10 KB</text>
+    <line x1="744.00" y1="485" x2="744.00" y2="492" stroke="#64748b"/>
+    <text x="744.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">100 KB</text>
+    <line x1="1070.00" y1="485" x2="1070.00" y2="492" stroke="#64748b"/>
+    <text x="1070.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">1 MB</text>
+    <g aria-label="Sign + encrypt">
+      <path d="M92.00 457.72 L418.00 451.81 L744.00 452.28 L1070.00 405.54" fill="none" stroke="#2dd4bf" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="92.00" y1="457.72" x2="92.00" y2="456.53" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="86.00" y1="456.53" x2="98.00" y2="456.53" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="92.00" cy="457.72" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="92.00" y="445.72" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.39</text>
+      <line x1="418.00" y1="451.81" x2="418.00" y2="364.60" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="412.00" y1="364.60" x2="424.00" y2="364.60" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="418.00" cy="451.81" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="418.00" y="439.81" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.47</text>
+      <line x1="744.00" y1="452.28" x2="744.00" y2="450.27" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="738.00" y1="450.27" x2="750.00" y2="450.27" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="744.00" cy="452.28" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="744.00" y="440.28" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.47</text>
+      <line x1="1070.00" y1="405.54" x2="1070.00" y2="402.39" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="1064.00" y1="402.39" x2="1076.00" y2="402.39" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="1070.00" cy="405.54" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="1070.00" y="393.54" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">1.1</text>
+    </g>
+    <g aria-label="Decrypt + verify">
+      <path d="M92.00 461.58 L418.00 461.48 L744.00 455.50 L1070.00 401.09" fill="none" stroke="#818cf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="92.00" y1="461.58" x2="92.00" y2="459.62" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="86.00" y1="459.62" x2="98.00" y2="459.62" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="92.00" cy="461.58" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="92.00" y="434.58" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.33</text>
+      <line x1="418.00" y1="461.48" x2="418.00" y2="460.33" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="412.00" y1="460.33" x2="424.00" y2="460.33" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="418.00" cy="461.48" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="418.00" y="434.48" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.34</text>
+      <line x1="744.00" y1="455.50" x2="744.00" y2="454.09" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="738.00" y1="454.09" x2="750.00" y2="454.09" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="744.00" cy="455.50" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="744.00" y="428.50" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.42</text>
+      <line x1="1070.00" y1="401.09" x2="1070.00" y2="269.18" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="1064.00" y1="269.18" x2="1076.00" y2="269.18" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="1070.00" cy="401.09" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="1070.00" y="435.09" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">1.2</text>
+    </g>
+    <text x="581" y="538" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">Payload size (log-spaced categories)</text>
+    <text x="24" y="310" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle" transform="rotate(-90 24 310)">Latency (ms)</text>
+    <rect x="42" y="557" width="1036" height="43" rx="12" fill="#0b1524" stroke="#334155"/>
+    <text x="560" y="575" fill="#94a3b8" font-size="11.5" text-anchor="middle">Directional snapshot · Apple M5 · v22.19.0 · darwin/arm64 · commit 414d4bf7 · 2026-08-29</text>
+    <text x="560" y="591" fill="#94a3b8" font-size="11.5" text-anchor="middle">Mean dots + p99 whiskers · 20 timed iterations per point · no pass/fail budget</text>
+  </g>
+</svg>

--- a/site/src/assets/charts/crypto-pipeline-overhead.svg
+++ b/site/src/assets/charts/crypto-pipeline-overhead.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="620" viewBox="0 0 1120 620" role="img" aria-labelledby="title description">
+  <title id="title">Plaintext and encrypted pipeline cost</title>
+  <desc id="description">Line chart comparing plaintext and encrypted local synthetic pipeline latency across four payload sizes. Dots show means and capped whiskers show p99. This is a directional single-machine snapshot, not a performance guarantee.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#94a3b8" stroke-opacity=".035"/>
+    </pattern>
+    <style>text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }</style>
+  </defs>
+  <rect width="1120" height="620" rx="26" fill="url(#background)"/>
+  <rect width="1120" height="620" rx="26" fill="url(#grid)"/>
+  <path d="M0 26A26 26 0 0 1 26 0H1094A26 26 0 0 1 1120 26V32H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="42" y="59" fill="#f8fafc" font-size="29" font-weight="780">Plaintext and encrypted pipeline cost</text>
+    <text x="42" y="84" fill="#94a3b8" font-size="15">Local synthetic pipeline comparison; mean with p99 whiskers</text>
+    <line x1="92" y1="107" x2="120" y2="107" stroke="#2dd4bf" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="106" cy="107" r="5" fill="#0f172a" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="130" y="112" fill="#e2e8f0" font-size="14" font-weight="650">Plaintext pipeline</text>
+    <line x1="337" y1="107" x2="365" y2="107" stroke="#818cf8" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="351" cy="107" r="5" fill="#0f172a" stroke="#818cf8" stroke-width="2"/>
+    <text x="375" y="112" fill="#e2e8f0" font-size="14" font-weight="650">Encrypted pipeline</text>
+    <line x1="92" y1="485.00" x2="1070" y2="485.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="490.00" fill="#94a3b8" font-size="13" text-anchor="end">0</text>
+    <line x1="92" y1="415.00" x2="1070" y2="415.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="420.00" fill="#94a3b8" font-size="13" text-anchor="end">2</text>
+    <line x1="92" y1="345.00" x2="1070" y2="345.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="350.00" fill="#94a3b8" font-size="13" text-anchor="end">4</text>
+    <line x1="92" y1="275.00" x2="1070" y2="275.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="280.00" fill="#94a3b8" font-size="13" text-anchor="end">6</text>
+    <line x1="92" y1="205.00" x2="1070" y2="205.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="210.00" fill="#94a3b8" font-size="13" text-anchor="end">8</text>
+    <line x1="92" y1="135.00" x2="1070" y2="135.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="140.00" fill="#94a3b8" font-size="13" text-anchor="end">10</text>
+    <line x1="92" y1="135" x2="92" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92" y1="485" x2="1070" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92.00" y1="485" x2="92.00" y2="492" stroke="#64748b"/>
+    <text x="92.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">1 KB</text>
+    <line x1="418.00" y1="485" x2="418.00" y2="492" stroke="#64748b"/>
+    <text x="418.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">10 KB</text>
+    <line x1="744.00" y1="485" x2="744.00" y2="492" stroke="#64748b"/>
+    <text x="744.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">100 KB</text>
+    <line x1="1070.00" y1="485" x2="1070.00" y2="492" stroke="#64748b"/>
+    <text x="1070.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">1 MB</text>
+    <g aria-label="Plaintext pipeline">
+      <path d="M92.00 484.90 L418.00 484.17 L744.00 476.96 L1070.00 400.08" fill="none" stroke="#2dd4bf" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="92.00" y1="484.90" x2="92.00" y2="484.86" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="86.00" y1="484.86" x2="98.00" y2="484.86" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="92.00" cy="484.90" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="92.00" y="472.90" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.003</text>
+      <line x1="418.00" y1="484.17" x2="418.00" y2="484.09" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="412.00" y1="484.09" x2="424.00" y2="484.09" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="418.00" cy="484.17" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="418.00" y="472.17" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.02</text>
+      <line x1="744.00" y1="476.96" x2="744.00" y2="476.35" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="738.00" y1="476.35" x2="750.00" y2="476.35" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="744.00" cy="476.96" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="744.00" y="464.96" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.23</text>
+      <line x1="1070.00" y1="400.08" x2="1070.00" y2="387.83" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="1064.00" y1="387.83" x2="1076.00" y2="387.83" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="1070.00" cy="400.08" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="1070.00" y="388.08" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">2.4</text>
+    </g>
+    <g aria-label="Encrypted pipeline">
+      <path d="M92.00 460.15 L418.00 459.09 L744.00 445.99 L1070.00 324.05" fill="none" stroke="#818cf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="92.00" y1="460.15" x2="92.00" y2="458.85" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="86.00" y1="458.85" x2="98.00" y2="458.85" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="92.00" cy="460.15" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="92.00" y="433.15" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.71</text>
+      <line x1="418.00" y1="459.09" x2="418.00" y2="458.42" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="412.00" y1="458.42" x2="424.00" y2="458.42" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="418.00" cy="459.09" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="418.00" y="432.09" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.74</text>
+      <line x1="744.00" y1="445.99" x2="744.00" y2="444.63" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="738.00" y1="444.63" x2="750.00" y2="444.63" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="744.00" cy="445.99" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="744.00" y="479.99" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">1.1</text>
+      <line x1="1070.00" y1="324.05" x2="1070.00" y2="314.12" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="1064.00" y1="314.12" x2="1076.00" y2="314.12" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="1070.00" cy="324.05" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="1070.00" y="358.05" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">4.6</text>
+    </g>
+    <text x="581" y="538" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">Payload size (log-spaced categories)</text>
+    <text x="24" y="310" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle" transform="rotate(-90 24 310)">Latency (ms)</text>
+    <rect x="42" y="557" width="1036" height="43" rx="12" fill="#0b1524" stroke="#334155"/>
+    <text x="560" y="575" fill="#94a3b8" font-size="11.5" text-anchor="middle">Directional snapshot · Apple M5 · v22.19.0 · darwin/arm64 · commit 414d4bf7 · 2026-08-29</text>
+    <text x="560" y="591" fill="#94a3b8" font-size="11.5" text-anchor="middle">Mean dots + p99 whiskers · 20 timed iterations per point · no pass/fail budget</text>
+  </g>
+</svg>

--- a/site/src/assets/charts/index-query-scaling.svg
+++ b/site/src/assets/charts/index-query-scaling.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="620" viewBox="0 0 1120 620" role="img" aria-labelledby="title description">
+  <title id="title">In-memory index query scaling</title>
+  <desc id="description">Line chart comparing exact-match, prefix, and compound local in-memory index query latency from 100 to 10,000 documents. Dots show means and capped whiskers show p99. This is a directional single-machine snapshot, not a performance guarantee.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#94a3b8" stroke-opacity=".035"/>
+    </pattern>
+    <style>text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }</style>
+  </defs>
+  <rect width="1120" height="620" rx="26" fill="url(#background)"/>
+  <rect width="1120" height="620" rx="26" fill="url(#grid)"/>
+  <path d="M0 26A26 26 0 0 1 26 0H1094A26 26 0 0 1 1120 26V32H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="42" y="59" fill="#f8fafc" font-size="29" font-weight="780">In-memory index query scaling</text>
+    <text x="42" y="84" fill="#94a3b8" font-size="15">Mean local query latency by indexed document count; p99 whiskers</text>
+    <line x1="92" y1="107" x2="120" y2="107" stroke="#2dd4bf" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="106" cy="107" r="5" fill="#0f172a" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="130" y="112" fill="#e2e8f0" font-size="14" font-weight="650">Exact match</text>
+    <line x1="337" y1="107" x2="365" y2="107" stroke="#818cf8" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="351" cy="107" r="5" fill="#0f172a" stroke="#818cf8" stroke-width="2"/>
+    <text x="375" y="112" fill="#e2e8f0" font-size="14" font-weight="650">Prefix query</text>
+    <line x1="582" y1="107" x2="610" y2="107" stroke="#f59e0b" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="596" cy="107" r="5" fill="#0f172a" stroke="#f59e0b" stroke-width="2"/>
+    <text x="620" y="112" fill="#e2e8f0" font-size="14" font-weight="650">Compound query</text>
+    <line x1="92" y1="485.00" x2="1070" y2="485.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="490.00" fill="#94a3b8" font-size="13" text-anchor="end">0</text>
+    <line x1="92" y1="415.00" x2="1070" y2="415.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="420.00" fill="#94a3b8" font-size="13" text-anchor="end">1</text>
+    <line x1="92" y1="345.00" x2="1070" y2="345.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="350.00" fill="#94a3b8" font-size="13" text-anchor="end">2</text>
+    <line x1="92" y1="275.00" x2="1070" y2="275.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="280.00" fill="#94a3b8" font-size="13" text-anchor="end">3</text>
+    <line x1="92" y1="205.00" x2="1070" y2="205.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="210.00" fill="#94a3b8" font-size="13" text-anchor="end">4</text>
+    <line x1="92" y1="135.00" x2="1070" y2="135.00" stroke="#334155" stroke-width="1"/>
+    <text x="78" y="140.00" fill="#94a3b8" font-size="13" text-anchor="end">5</text>
+    <line x1="92" y1="135" x2="92" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92" y1="485" x2="1070" y2="485" stroke="#64748b" stroke-width="1.5"/>
+    <line x1="92.00" y1="485" x2="92.00" y2="492" stroke="#64748b"/>
+    <text x="92.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">100</text>
+    <line x1="581.00" y1="485" x2="581.00" y2="492" stroke="#64748b"/>
+    <text x="581.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">1K</text>
+    <line x1="1070.00" y1="485" x2="1070.00" y2="492" stroke="#64748b"/>
+    <text x="1070.00" y="512" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">10K</text>
+    <g aria-label="Exact match">
+      <path d="M92.00 478.46 L581.00 467.61 L1070.00 348.08" fill="none" stroke="#2dd4bf" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="92.00" y1="478.46" x2="92.00" y2="468.60" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="86.00" y1="468.60" x2="98.00" y2="468.60" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="92.00" cy="478.46" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="92.00" y="466.46" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.09</text>
+      <line x1="581.00" y1="467.61" x2="581.00" y2="459.72" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="575.00" y1="459.72" x2="587.00" y2="459.72" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="581.00" cy="467.61" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="581.00" y="455.61" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">0.25</text>
+      <line x1="1070.00" y1="348.08" x2="1070.00" y2="225.99" stroke="#2dd4bf" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="1064.00" y1="225.99" x2="1076.00" y2="225.99" stroke="#2dd4bf" stroke-width="2"/>
+      <circle cx="1070.00" cy="348.08" r="6" fill="#0f172a" stroke="#2dd4bf" stroke-width="3"/>
+      <text x="1070.00" y="336.08" fill="#2dd4bf" font-size="11.5" font-weight="750" text-anchor="middle">2</text>
+    </g>
+    <g aria-label="Prefix query">
+      <path d="M92.00 481.37 L581.00 470.68 L1070.00 375.31" fill="none" stroke="#818cf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="92.00" y1="481.37" x2="92.00" y2="476.37" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="86.00" y1="476.37" x2="98.00" y2="476.37" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="92.00" cy="481.37" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="92.00" y="454.37" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.05</text>
+      <line x1="581.00" y1="470.68" x2="581.00" y2="463.30" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="575.00" y1="463.30" x2="587.00" y2="463.30" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="581.00" cy="470.68" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="581.00" y="443.68" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">0.2</text>
+      <line x1="1070.00" y1="375.31" x2="1070.00" y2="362.93" stroke="#818cf8" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="1064.00" y1="362.93" x2="1076.00" y2="362.93" stroke="#818cf8" stroke-width="2"/>
+      <circle cx="1070.00" cy="375.31" r="6" fill="#0f172a" stroke="#818cf8" stroke-width="3"/>
+      <text x="1070.00" y="409.31" fill="#818cf8" font-size="11.5" font-weight="750" text-anchor="middle">1.6</text>
+    </g>
+    <g aria-label="Compound query">
+      <path d="M92.00 482.04 L581.00 480.41 L1070.00 458.96" fill="none" stroke="#f59e0b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="92.00" y1="482.04" x2="92.00" y2="481.06" stroke="#f59e0b" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="86.00" y1="481.06" x2="98.00" y2="481.06" stroke="#f59e0b" stroke-width="2"/>
+      <circle cx="92.00" cy="482.04" r="6" fill="#0f172a" stroke="#f59e0b" stroke-width="3"/>
+      <text x="92.00" y="440.04" fill="#f59e0b" font-size="11.5" font-weight="750" text-anchor="middle">0.04</text>
+      <line x1="581.00" y1="480.41" x2="581.00" y2="479.81" stroke="#f59e0b" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="575.00" y1="479.81" x2="587.00" y2="479.81" stroke="#f59e0b" stroke-width="2"/>
+      <circle cx="581.00" cy="480.41" r="6" fill="#0f172a" stroke="#f59e0b" stroke-width="3"/>
+      <text x="581.00" y="438.41" fill="#f59e0b" font-size="11.5" font-weight="750" text-anchor="middle">0.07</text>
+      <line x1="1070.00" y1="458.96" x2="1070.00" y2="450.94" stroke="#f59e0b" stroke-width="2" stroke-opacity=".65"/>
+      <line x1="1064.00" y1="450.94" x2="1076.00" y2="450.94" stroke="#f59e0b" stroke-width="2"/>
+      <circle cx="1070.00" cy="458.96" r="6" fill="#0f172a" stroke="#f59e0b" stroke-width="3"/>
+      <text x="1070.00" y="416.96" fill="#f59e0b" font-size="11.5" font-weight="750" text-anchor="middle">0.37</text>
+    </g>
+    <text x="581" y="538" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle">Indexed documents (log-spaced categories)</text>
+    <text x="24" y="310" fill="#cbd5e1" font-size="14" font-weight="650" text-anchor="middle" transform="rotate(-90 24 310)">Latency (ms)</text>
+    <rect x="42" y="557" width="1036" height="43" rx="12" fill="#0b1524" stroke="#334155"/>
+    <text x="560" y="575" fill="#94a3b8" font-size="11.5" text-anchor="middle">Directional snapshot · Apple M5 · v22.19.0 · darwin/arm64 · commit 414d4bf7 · 2026-08-29</text>
+    <text x="560" y="591" fill="#94a3b8" font-size="11.5" text-anchor="middle">Mean dots + p99 whiskers · 20 timed iterations per point · no pass/fail budget</text>
+  </g>
+</svg>

--- a/site/src/content/docs/concepts/performance.md
+++ b/site/src/content/docs/concepts/performance.md
@@ -65,6 +65,18 @@ V2 memory indexes use sorted compound-key arrays with binary-search lookup; incr
 
 Peerborne includes six benchmark suites across two packages. Each suite uses a statistical runner that reports min, max, mean, median, p99, and standard deviation with warmup iterations and optional memory-delta tracking.
 
+The charts below are generated from the committed
+[`benchmark-snapshot.json`](https://github.com/Peerborne/peerborne/blob/main/site/src/data/benchmark-snapshot.json)
+snapshot. It was collected on Apple M5 hardware with 32 GB RAM, Node.js
+22.19.0, and macOS arm64. Most points use 20 timed iterations; the convergence
+suite uses four and the blind-index field series uses ten because those suites
+intentionally reduce the requested count for their more expensive cases.
+
+Treat the values as a directional, single-machine snapshot—not a performance
+guarantee or a comparison with other systems. The convergence chart is a local
+simulation, not a browser, relay, or wide-area network measurement. Dots show
+means and capped whiskers show p99. No chart establishes a pass/fail budget.
+
 ### Core benchmarks
 
 Source: [`packages/core/src/__benchmarks__/`](https://github.com/Peerborne/peerborne/tree/main/packages/core/src/__benchmarks__)
@@ -75,6 +87,12 @@ Source: [`packages/core/src/__benchmarks__/`](https://github.com/Peerborne/peerb
 | **Crypto Overhead** | [`crypto-overhead.ts`](https://github.com/Peerborne/peerborne/blob/main/packages/core/src/__benchmarks__/crypto-overhead.ts) | Key generation cost (ECDSA P-384, AES-GCM-256), key rotation at 10 KB, plaintext vs encrypted change propagation across sizes, isolated crypto operation overhead |
 | **Convergence Simulation** | [`convergence-simulation.ts`](https://github.com/Peerborne/peerborne/blob/main/packages/core/src/__benchmarks__/convergence-simulation.ts) | Simulated multi-peer convergence: 2–32 peers making concurrent edits through the full sign-encrypt-broadcast-decrypt-verify pipeline, measures time-to-convergence, message count, and bandwidth |
 
+![Line chart of mean sign-and-encrypt and decrypt-and-verify latency from 1 KB to 1 MB, with p99 whiskers.](../../../assets/charts/crdt-pipeline-latency.svg)
+
+![Line chart comparing mean plaintext and encrypted synthetic pipeline latency from 1 KB to 1 MB, with p99 whiskers.](../../../assets/charts/crypto-pipeline-overhead.svg)
+
+![Line chart of local simulated convergence latency from two to 32 peers on a logarithmic latency axis, with p99 whiskers.](../../../assets/charts/convergence-scaling.svg)
+
 ### Index benchmarks
 
 Source: [`packages/index/src/__benchmarks__/`](https://github.com/Peerborne/peerborne/tree/main/packages/index/src/__benchmarks__)
@@ -84,6 +102,12 @@ Source: [`packages/index/src/__benchmarks__/`](https://github.com/Peerborne/peer
 | **Index Query Scaling** | [`index-query-scaling.ts`](https://github.com/Peerborne/peerborne/blob/main/packages/index/src/__benchmarks__/index-query-scaling.ts) | Query latency vs index size: 100–100K documents. Exact-match, range, prefix, compound, and sorted queries against MemoryIndexStorage, plus single-document update cost and full-scan baseline |
 | **Bloom Filter Scaling** | [`bloom-filter-scaling.ts`](https://github.com/Peerborne/peerborne/blob/main/packages/index/src/__benchmarks__/bloom-filter-scaling.ts) | Insert throughput at filter sizes 1K–1M bits, positive/negative query time, false-positive rate at fill counts 100–10K, serialization/deserialization time, CRDT merge (join) time, memory footprint |
 | **Blind Index Performance** | [`blind-index-perf.ts`](https://github.com/Peerborne/peerborne/blob/main/packages/index/src/__benchmarks__/blind-index-perf.ts) | Encrypted search operations: field-key derivation (HKDF), single/compound token generation, token match/mismatch comparison, field-count scaling (1–16 fields), batch throughput (100 tokens) |
+
+![Line chart comparing mean exact-match, prefix, and compound local index query latency from 100 to 10,000 documents, with p99 whiskers.](../../../assets/charts/index-query-scaling.svg)
+
+![Line chart comparing the mean cost to insert 1,000 items and merge filters across Bloom filter sizes from 1 Kb to 1 Mb, with p99 whiskers.](../../../assets/charts/bloom-filter-scaling.svg)
+
+![Line chart of mean blind-index key derivation and tokenization latency from one to 16 fields, with p99 whiskers.](../../../assets/charts/blind-index-scaling.svg)
 
 ## Performance-aware tests
 
@@ -153,3 +177,18 @@ yarn workspace @peerborne/index benchmark --iterations 1 --max-documents 100
 ```
 
 Both suites output Markdown tables with statistical summaries. The `--iterations` flag controls the sample count (default 100); `--max-documents` bounds index-query scaling only.
+
+To replace the committed measurement snapshot and regenerate its SVG charts,
+run both suites with the recorded parameters, then collect and render:
+
+```sh
+yarn workspace @peerborne/core benchmark --iterations 20
+yarn workspace @peerborne/index benchmark --iterations 20 --max-documents 10000
+yarn workspace @peerborne/site benchmarks:snapshot --core-iterations 20 --index-iterations 20 --max-documents 10000
+yarn workspace @peerborne/site charts:generate
+yarn workspace @peerborne/site charts:test
+```
+
+Benchmark collection is intentionally separate from SVG rendering. Rerunning a
+benchmark produces new measurements; rendering the same committed JSON snapshot
+must produce byte-identical charts, which the site build checks.

--- a/site/src/data/benchmark-snapshot.json
+++ b/site/src/data/benchmark-snapshot.json
@@ -1,0 +1,495 @@
+{
+  "schemaVersion": 1,
+  "sourceCommit": "414d4bf7cc6efd761cff81e41f39573578f40dea",
+  "collectedAt": "2026-08-29T00:15:53.149Z",
+  "system": {
+    "node": "v22.19.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "cpu": "Apple M5",
+    "memoryBytes": 34359738368
+  },
+  "commands": [
+    "yarn workspace @peerborne/core benchmark --iterations 20",
+    "yarn workspace @peerborne/index benchmark --iterations 20 --max-documents 10000"
+  ],
+  "parameters": {
+    "coreIterations": 20,
+    "convergenceIterations": 4,
+    "indexIterations": 20,
+    "maxDocuments": 10000
+  },
+  "suites": [
+    {
+      "benchmark": "crdt-sync-latency",
+      "timestamp": "2026-08-29T00:15:29.158Z",
+      "system": {
+        "node": "v22.19.0",
+        "platform": "darwin",
+        "arch": "arm64"
+      },
+      "results": [
+        {
+          "name": "sign-encrypt-1kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.38974369999999825,
+            "p99": 0.4067090000000064
+          }
+        },
+        {
+          "name": "sign-encrypt-10kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.47411250000000393,
+            "p99": 1.7199999999999989
+          }
+        },
+        {
+          "name": "sign-encrypt-100kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.4674790499999972,
+            "p99": 0.4960829999999987
+          }
+        },
+        {
+          "name": "sign-encrypt-1mb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 1.135191600000013,
+            "p99": 1.1802090000000476
+          }
+        },
+        {
+          "name": "decrypt-verify-1kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.3346123999999989,
+            "p99": 0.3626250000000084
+          }
+        },
+        {
+          "name": "decrypt-verify-10kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.33596249999999656,
+            "p99": 0.35249999999999204
+          }
+        },
+        {
+          "name": "decrypt-verify-100kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.42148749999999924,
+            "p99": 0.4415830000000369
+          }
+        },
+        {
+          "name": "decrypt-verify-1mb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 1.1987229000000041,
+            "p99": 3.0831249999999955
+          }
+        }
+      ]
+    },
+    {
+      "benchmark": "crypto-overhead",
+      "timestamp": "2026-08-29T00:15:29.493Z",
+      "system": {
+        "node": "v22.19.0",
+        "platform": "darwin",
+        "arch": "arm64"
+      },
+      "results": [
+        {
+          "name": "plaintext-pipeline-1kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.002966550000004986,
+            "p99": 0.0040840000000343935
+          }
+        },
+        {
+          "name": "plaintext-pipeline-10kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.023656200000010584,
+            "p99": 0.02612500000009277
+          }
+        },
+        {
+          "name": "plaintext-pipeline-100kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.2297708,
+            "p99": 0.24712499999998272
+          }
+        },
+        {
+          "name": "plaintext-pipeline-1mb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 2.4262188999999976,
+            "p99": 2.7761669999999867
+          }
+        },
+        {
+          "name": "encrypted-pipeline-1kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.7101417000000196,
+            "p99": 0.7472080000000005
+          }
+        },
+        {
+          "name": "encrypted-pipeline-10kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.7403290999999967,
+            "p99": 0.7592910000000757
+          }
+        },
+        {
+          "name": "encrypted-pipeline-100kb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 1.1145062999999993,
+            "p99": 1.1535420000000158
+          }
+        },
+        {
+          "name": "encrypted-pipeline-1mb",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 4.598689549999994,
+            "p99": 4.882375000000025
+          }
+        }
+      ]
+    },
+    {
+      "benchmark": "convergence-simulation",
+      "timestamp": "2026-08-29T00:15:53.149Z",
+      "system": {
+        "node": "v22.19.0",
+        "platform": "darwin",
+        "arch": "arm64"
+      },
+      "results": [
+        {
+          "name": "convergence-2-peers",
+          "iterations": 4,
+          "unit": "ms",
+          "stats": {
+            "mean": 14.327301749999975,
+            "p99": 14.6875
+          }
+        },
+        {
+          "name": "convergence-4-peers",
+          "iterations": 4,
+          "unit": "ms",
+          "stats": {
+            "mean": 55.076739249999974,
+            "p99": 57.126249999999914
+          }
+        },
+        {
+          "name": "convergence-8-peers",
+          "iterations": 4,
+          "unit": "ms",
+          "stats": {
+            "mean": 219.33636474999986,
+            "p99": 224.99312499999996
+          }
+        },
+        {
+          "name": "convergence-16-peers",
+          "iterations": 4,
+          "unit": "ms",
+          "stats": {
+            "mean": 858.1773750000001,
+            "p99": 910.1468750000004
+          }
+        },
+        {
+          "name": "convergence-32-peers",
+          "iterations": 4,
+          "unit": "ms",
+          "stats": {
+            "mean": 3586.584552000001,
+            "p99": 3890.380583000002
+          }
+        }
+      ]
+    },
+    {
+      "benchmark": "index-query-scaling",
+      "timestamp": "2026-08-29T00:15:32.599Z",
+      "system": {
+        "node": "v22.19.0",
+        "platform": "darwin",
+        "arch": "arm64"
+      },
+      "results": [
+        {
+          "name": "exact-match-100",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.09343760000000145,
+            "p99": 0.23433400000000404
+          }
+        },
+        {
+          "name": "exact-match-1000",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.24841035000000175,
+            "p99": 0.3611659999999972
+          }
+        },
+        {
+          "name": "exact-match-10000",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 1.956004199999984,
+            "p99": 3.7001249999998436
+          }
+        },
+        {
+          "name": "prefix-query-100",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.05192694999999929,
+            "p99": 0.12329099999999471
+          }
+        },
+        {
+          "name": "prefix-query-1000",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.20451044999999937,
+            "p99": 0.3099579999999946
+          }
+        },
+        {
+          "name": "prefix-query-10000",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 1.567002050000042,
+            "p99": 1.7439159999998992
+          }
+        },
+        {
+          "name": "compound-query-100",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.04230610000000183,
+            "p99": 0.056250000000005684
+          }
+        },
+        {
+          "name": "compound-query-1000",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.06555635000000706,
+            "p99": 0.07408300000000168
+          }
+        },
+        {
+          "name": "compound-query-10000",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.3720249500000136,
+            "p99": 0.48658400000022084
+          }
+        }
+      ]
+    },
+    {
+      "benchmark": "bloom-filter-scaling",
+      "timestamp": "2026-08-29T00:15:32.710Z",
+      "system": {
+        "node": "v22.19.0",
+        "platform": "darwin",
+        "arch": "arm64"
+      },
+      "results": [
+        {
+          "name": "insert-1000-into-1k-bits",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.23427514999993945,
+            "p99": 0.4271670000002814
+          }
+        },
+        {
+          "name": "insert-1000-into-8k-bits",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.19219370000005256,
+            "p99": 0.21166700000003402
+          }
+        },
+        {
+          "name": "insert-1000-into-64k-bits",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.1777979500000356,
+            "p99": 0.5779579999998532
+          }
+        },
+        {
+          "name": "insert-1000-into-256k-bits",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.14262705000005554,
+            "p99": 0.15716699999984485
+          }
+        },
+        {
+          "name": "insert-1000-into-1m-bits",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.13263775000002626,
+            "p99": 0.1521669999997357
+          }
+        },
+        {
+          "name": "merge-1k-bits",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.0041979499999797555,
+            "p99": 0.005999999999858119
+          }
+        },
+        {
+          "name": "merge-8k-bits",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.026756200000022545,
+            "p99": 0.07637500000009823
+          }
+        },
+        {
+          "name": "merge-64k-bits",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.009091650000027585,
+            "p99": 0.009833000000071479
+          }
+        },
+        {
+          "name": "merge-256k-bits",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.03371455000001333,
+            "p99": 0.03600000000005821
+          }
+        },
+        {
+          "name": "merge-1m-bits",
+          "iterations": 20,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.1318706999999449,
+            "p99": 0.14170800000010786
+          }
+        }
+      ]
+    },
+    {
+      "benchmark": "blind-index-perf",
+      "timestamp": "2026-08-29T00:15:32.632Z",
+      "system": {
+        "node": "v22.19.0",
+        "platform": "darwin",
+        "arch": "arm64"
+      },
+      "results": [
+        {
+          "name": "derive-and-tokenize-1-fields",
+          "iterations": 10,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.05907919999999649,
+            "p99": 0.07562499999994543
+          }
+        },
+        {
+          "name": "derive-and-tokenize-2-fields",
+          "iterations": 10,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.11058329999996204,
+            "p99": 0.1659999999997126
+          }
+        },
+        {
+          "name": "derive-and-tokenize-4-fields",
+          "iterations": 10,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.22844159999999647,
+            "p99": 0.37150000000019645
+          }
+        },
+        {
+          "name": "derive-and-tokenize-8-fields",
+          "iterations": 10,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.34855439999996635,
+            "p99": 0.4022920000002159
+          }
+        },
+        {
+          "name": "derive-and-tokenize-16-fields",
+          "iterations": 10,
+          "unit": "ms",
+          "stats": {
+            "mean": 0.7637124999999741,
+            "p99": 1.4450000000001637
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add six accessible SVG charts generated from a pinned, machine-described benchmark snapshot
- separate benchmark collection from deterministic chart rendering
- document single-machine, simulation, iteration-count, and no-budget boundaries
- verify chart regeneration in the site build and site-tooling tests

Stacked on #404, which makes the benchmark runners executable with a pinned workspace dependency.

## Validation

- `yarn workspace @peerborne/site charts:test`
- `yarn workspace @peerborne/site build`
- `yarn build`
- `node site/scripts/check-links.mjs` (0 issues)
- XML validation for all six SVG outputs
- Chromium render inspection for all six charts
- `git diff --check`