### PR TITLE
docs: generate remaining documentation diagrams

### DIFF
--- a/docs/indexing-design.md
+++ b/docs/indexing-design.md
@@ -64,24 +64,10 @@ search.
 
 ## Local architecture
 
-```
-authorized decrypted CRDT snapshot
-              |
-              v
-      IndexManager validation
-       |                  |
-       v                  v
- named compound keys   stored indexed fields
-       |                  |
-       +------ planner ----+
-                 |
-                 v
-       candidate range/union
-                 |
-          full predicate recheck
-                 |
-     deterministic sort/cursor/project
-```
+![Local index pipeline from an authorized decrypted snapshot through validation, planning, predicate recheck, and deterministic results](../site/src/assets/diagrams/local-index-pipeline.svg "A local index is a rebuildable projection of authorized, decrypted document state.")
+
+_A local index is a rebuildable projection of authorized, decrypted document
+state. Every candidate still passes the complete predicate locally._
 
 An `IndexDefinition` binds a name, collection path prefix, schema generation,
 field types, invalid-value policy, local storage policy, and ordered physical
@@ -174,23 +160,11 @@ The suite is informational: no CI regression budgets exist yet.
 
 ## Distributed architecture
 
-```
-signed collection manifest (schema hash + generation + search-key epoch)
-                                |
-             +------------------+------------------+
-             |                                     |
-     signed expiring Bloom snapshot         signed direct request
-       (blind routing tokens only)       (blind tokens or explicit AST)
-             |                                     |
-             +--------- candidate peer/path claims-+
-                                |
-                    normal secure document load
-                 ACL + signature + decrypt + history
-                                |
-                       complete local recheck
-                                |
-                  deterministic bounded page merge
-```
+![Distributed index protocol primitives from a signed manifest through discovery or direct requests, secure document loading, and local verification](../site/src/assets/diagrams/distributed-index-flow.svg "Distributed indexing supplies bounded candidate claims, not an authoritative global result set.")
+
+_These protocol and orchestration primitives supply bounded candidate claims;
+they are not an implemented end-to-end distributed search service or an
+authoritative global result set._
 
 ### Collection control plane
 

--- a/guides/coordination-servers.md
+++ b/guides/coordination-servers.md
@@ -20,7 +20,7 @@ Peerborne uses [libp2p](https://libp2p.io/) for networking. The following server
 
 ### 1.1 Bootstrap / Signaling Node
 
-| | |
+| Field | Details |
 |---|---|
 | **Purpose** | Initial peer discovery. When a Peerborne client starts, it dials the bootstrap node to join the network and discover other peers. |
 | **When needed** | Always. At least one bootstrap node must be reachable for a new peer to join the swarm. |
@@ -39,7 +39,7 @@ In Peerborne, the bootstrap node and relay node are combined into a single proce
 
 ### 1.2 Circuit Relay Node
 
-| | |
+| Field | Details |
 |---|---|
 | **Purpose** | NAT traversal for browsers that cannot establish direct WebRTC connections. The relay forwards data between two peers that cannot reach each other directly. |
 | **When needed** | Whenever browser peers are behind restrictive NATs (symmetric NAT, corporate firewalls). This is the common case on the open internet. |
@@ -50,16 +50,17 @@ In Peerborne, the bootstrap node and relay node are combined into a single proce
 In Peerborne's architecture, the relay server runs `circuitRelayServer()` which implements libp2p Circuit Relay V2. Browser clients configure `circuitRelayTransport()` to connect through the relay.
 
 **Data flow through relay:**
-```text
-Browser A ──WebSocket──> Relay Server ──WebSocket──> Browser B
-                  (Circuit Relay V2)
-```
+
+![Browser A and Browser B exchange encrypted libp2p traffic through a Circuit Relay v2 server when a direct path is unavailable](../site/src/assets/diagrams/relay-data-flow.svg "The relay forwards opaque libp2p traffic; it does not decrypt document payloads.")
+
+_The relay forwards opaque libp2p traffic; it does not decrypt document
+payloads._
 
 After the relayed connection is established, libp2p may upgrade to a direct WebRTC connection if both peers' NATs allow it (ICE hole-punching). If direct connection succeeds, the relay is no longer in the data path.
 
 ### 1.3 STUN Server
 
-| | |
+| Field | Details |
 |---|---|
 | **Purpose** | WebRTC ICE candidate gathering. STUN (Session Traversal Utilities for NAT) allows browsers to discover their public IP address and port mapping, which is needed to establish direct WebRTC connections. |
 | **When needed** | Whenever WebRTC is used (browser-to-browser). |
@@ -71,7 +72,7 @@ Peerborne's browser clients use `@libp2p/webrtc` which relies on the browser's b
 
 ### 1.4 TURN Server
 
-| | |
+| Field | Details |
 |---|---|
 | **Purpose** | Relays media/data when STUN-based hole-punching fails (symmetric NAT on both sides). TURN (Traversal Using Relays around NAT) is a fallback relay at the WebRTC layer. |
 | **When needed** | When peers are behind symmetric NATs where STUN cannot establish a direct path. |
@@ -84,7 +85,7 @@ If you need TURN, consider [coturn](https://github.com/coturn/coturn) (open sour
 
 ### 1.5 Pinning Service
 
-| | |
+| Field | Details |
 |---|---|
 | **Purpose** | Persistent storage for IPFS/Helia content. When all peers go offline, pinned content remains available. Without pinning, document data exists only while at least one peer with that data is online. |
 | **When needed** | When data persistence is required beyond peer availability. |
@@ -97,7 +98,7 @@ Self-hosted pinning therefore requires application-specific publication, persist
 
 ### 1.6 DHT Bootstrap Node
 
-| | |
+| Field | Details |
 |---|---|
 | **Purpose** | Kademlia DHT for large-scale peer discovery. The DHT enables peers to find each other without relying solely on pubsub-based discovery. |
 | **When needed** | At scale (hundreds+ of peers) where pubsub discovery alone is insufficient. |
@@ -127,29 +128,10 @@ At minimum, you need **one relay/bootstrap server** and access to **public STUN 
 
 ### 2.2 Architecture
 
-```text
-                    ┌─────────────────────┐
-                    │   Your Server       │
-                    │                     │
-                    │  ┌───────────────┐  │
-                    │  │ Relay Server  │  │
-                    │  │ (Bootstrap +  │  │
-                    │  │  Circuit Relay│  │
-                    │  │  + GossipSub) │  │
-                    │  └──────┬────────┘  │
-                    │         │           │
-                    │    Port 9001 (WS)   │
-                    │    Port 9002 (TCP)  │
-                    └─────────┼───────────┘
-                              │
-              ┌───────────────┼───────────────┐
-              │               │               │
-         ┌────┴────┐    ┌────┴────┐    ┌────┴────┐
-         │Browser A│    │Browser B│    │Browser C│
-         └─────────┘    └─────────┘    └─────────┘
+![A single host runs the combined bootstrap and Circuit Relay server for several browser peers, with STUN assisting direct WebRTC paths](../site/src/assets/diagrams/single-relay-topology.svg "A minimal deployment has one failure domain and no capacity guarantee.")
 
-         (All browsers use public STUN for WebRTC)
-```
+_A minimal deployment combines bootstrap, GossipSub, and Circuit Relay v2 on
+one host. It has one failure domain and no tested capacity guarantee._
 
 ### 2.3 Quick Start with Docker
 
@@ -290,58 +272,40 @@ The relay-info.json output path is determined automatically: `/shared/relay-info
 
 ### 3.1 Architecture
 
-For production with 100+ peers, deploy multiple relay nodes. Note that each
-relay has its own libp2p peer ID, so a single load-balanced hostname that
+For deployments that need multiple failure domains, deploy multiple relay
+nodes. Each relay has its own libp2p peer ID, so a single load-balanced hostname that
 routes clients to arbitrary backends will break dialing of
 `/.../p2p/<peerId>` addresses. The supported pattern is one public DNS name
 per relay (clients are configured with all of them); see
 [`docs/deployment.md`](../docs/deployment.md) for details.
 
-```text
-                          ┌──────────────┐
-                          │   DNS / LB   │
-                          │ relay.app.com│
-                          └──────┬───────┘
-                                 │
-                 ┌───────────────┼───────────────┐
-                 │               │               │
-          ┌──────┴──────┐ ┌─────┴──────┐ ┌──────┴──────┐
-          │  Relay #1   │ │  Relay #2  │ │  Relay #3   │
-          │ (Region A)  │ │ (Region B) │ │ (Region C)  │
-          │ Port 9001   │ │ Port 9001  │ │ Port 9001   │
-          │ Port 9002   │ │ Port 9002  │ │ Port 9002   │
-          └──────┬──────┘ └─────┬──────┘ └──────┬──────┘
-                 │              │               │
-                 └──────────────┼───────────────┘
-                                │ (TCP mesh between relays)
-                                │
-              ┌─────────────────┼─────────────────┐
-              │                 │                 │
-         ┌────┴────┐      ┌────┴────┐      ┌────┴────┐
-         │Browser  │      │Browser  │      │Pinning  │
-         │ Peers   │      │ Peers   │      │ Node    │
-         └─────────┘      └─────────┘      └─────────┘
-```
+![Browser clients connect to independently named regional relay processes; Peerborne does not provide built-in relay meshing or failover](../site/src/assets/diagrams/multi-relay-topology.svg "Each relay keeps its own DNS name and peer ID, but the repository does not ship a relay mesh or failover layer.")
 
-### 3.2 Recommended Topology by Scale
+_Each relay keeps its own DNS name and peer ID. The repository does not ship
+relay-to-relay startup dialing, a supported relay mesh, or client failover._
 
-#### Small (10-50 peers)
+### 3.2 Illustrative Topology Patterns
+
+These are availability patterns, not tested capacity tiers. Measure connection,
+reservation, bandwidth, and topic load for your own deployment.
+
+#### Single failure domain
 - 1 relay/bootstrap server
 - Public STUN servers
-- Optional: 1 pinning node
+- Application-specific durability integration if offline availability is needed
 
-#### Medium (50-500 peers)
+#### Multiple regions
 - 2-3 relay/bootstrap servers in different regions
-- Each relay connects to the others via TCP (port 9002)
-- Multiple bootstrap addresses in client config
-- 1 pinning node
+- Custom relay-to-relay dialing only after the application supplies and validates it
+- Independently named bootstrap addresses in application config
+- Application-specific durability integration
 - Consider adding a TURN server (coturn)
 
-#### Large (500-1000+ peers)
+#### Higher availability
 - 3-5 relay/bootstrap servers, geographically distributed
-- Relay nodes form a full mesh via TCP
-- DNS-based load balancing or anycast
-- Multiple pinning nodes
+- One DNS name and stable peer ID per relay
+- Application-specific routing and failover; Peerborne does not provide them
+- Multiple application-managed durability nodes, if implemented
 - Dedicated DHT bootstrap nodes (set `clientMode: false`)
 - TURN server cluster
 - Monitoring and alerting
@@ -360,11 +324,17 @@ const config = defaultNodeConfig({
 });
 ```
 
-The client will attempt to connect to all bootstrap nodes. Once connected to any one, pubsub peer discovery will find the rest of the network.
+The client attempts the configured bootstrap addresses independently. A
+connection to one relay exposes only the peers visible through that relay's
+discovery mesh; it does not discover other isolated relay processes or provide
+automatic cross-relay failover.
 
-### 3.4 Relay Node Inter-Connection
+### 3.4 Custom Relay Inter-Connection (Not Shipped)
 
-Relay nodes should connect to each other so GossipSub messages propagate across the entire network. Configure each relay to bootstrap from the others:
+The checked-in relay does not configure startup dialing between relay
+processes. Cross-relay GossipSub propagation would require custom code and
+deployment validation. The following is an unshipped, unverified source-edit
+sketch rather than a supported configuration recipe:
 
 ```typescript
 // In relay-server/src/index.ts, add bootstrap for peer relays
@@ -388,11 +358,12 @@ peerDiscovery: [
 - A **TLS-terminating reverse proxy** (nginx, Caddy, Traefik) in front of a single relay is fine and required for `wss://` in production (see Section 2.6). The proxy terminates TLS and forwards WebSocket frames transparently via `Upgrade` headers — this is technically Layer 7 but preserves the connection end-to-end.
 - Do **not** use a **connection-splitting proxy** that terminates one WebSocket and opens a new upstream WebSocket, as this breaks libp2p's connection state and multiplexed streams.
 - For **multiple relay nodes**, give clients all relay addresses (one
-  multiaddr per relay, each with its own peer ID) and let libp2p handle
-  connection management. A single shared hostname that load-balances across
-  backends with different peer IDs is **not** supported. Source-IP hashing
-  does not pin a peer ID. Use one hostname/SNI route per durable relay identity;
-  DNS round-robin on a single hostname has the same problem.
+  multiaddr per relay, each with its own peer ID). Libp2p may dial those
+  configured addresses, but Peerborne does not provide or verify an application
+  failover policy. A single shared hostname that load-balances across backends
+  with different peer IDs is **not** supported. Source-IP hashing does not pin a
+  peer ID. Use one hostname/SNI route per durable relay identity; DNS
+  round-robin on a single hostname has the same problem.
 
 ### 3.6 Monitoring and Health Checks
 

--- a/guides/history-compaction-design.md
+++ b/guides/history-compaction-design.md
@@ -25,15 +25,17 @@ The core issue: **initial sync time grows linearly** with edit count, making lon
 
 ### 2.1 Overview
 
-Introduce a new node type in the Merkle-DAG: **snapshot nodes**. A snapshot node contains the full serialized CRDT state at a given point in history, acting as a checkpoint. Peers can load from the latest snapshot instead of replaying the entire change history.
+Introduce a **snapshot record** containing the full serialized CRDT state at a
+point in history. It is signed when document signing is enabled. The snapshot
+is stored separately from the retained sync tree and records its boundary
+change CID. Pruning keeps a configurable recent tail, which can include changes
+at and before that boundary, while later changes remain in the same sync tree.
 
-```text
-Before compaction:
-  [change-1] <- [change-2] <- ... <- [change-N] (root)
+![Before compaction the sync tree retains the full change history; afterward a separate snapshot records its boundary while the sync tree keeps a configurable recent tail and later changes](../site/src/assets/diagrams/history-compaction.svg "Compaction stores the snapshot separately while the retained sync tree may overlap the snapshotted history.")
 
-After compaction:
-  [snapshot-at-500] <- [change-501] <- ... <- [change-N] (root)
-```
+_Compaction stores the snapshot separately from the retained sync tree. The
+snapshot is not an inline parent change, although its boundary CID can also be
+present as a retained change node._
 
 ### 2.2 Snapshot Creation
 
@@ -41,7 +43,7 @@ A snapshot is created by an authorized **writer** when the number of un-compacte
 
 1. Serialize the current CRDT document state via `CRDTProvider.getSnapshot(doc)` (already defined as optional on the interface)
 2. Record the CID of the most recent change node included in the snapshot
-3. Sign the snapshot with the writer's private key (see Section 2.6 for payload format)
+3. Sign the snapshot with the writer's private key when document signing is enabled (see Section 2.6 for payload format)
 4. Store the snapshot in-memory (`_latestSnapshot`) — it is included only in load/snapshot-load responses, **not** in incremental pubsub sync messages, to avoid bandwidth bloat
 5. Optionally prune old change nodes from the in-memory sync tree via `_pruneChanges(keepCount)` (see Section 2.4)
 
@@ -58,7 +60,7 @@ export interface CRDTSnapshotNode<ChangesType, PublicKey> {
   /** Number of change nodes compacted into this snapshot */
   compactedCount: number;
 
-  /** Signature of the snapshot creator (see Section 2.6 for binary payload format) */
+  /** Snapshot creator signature, or empty bytes when signing is disabled */
   signature: Uint8Array;
 
   /** Public key of the snapshot creator (optional; may be absent on the wire) */
@@ -96,7 +98,7 @@ The key insight: **CRDTs are designed to converge from any state**. A Yjs `encod
 The document load protocol (`/collabswarm/doc-load/1.0.0`) is updated to:
 
 1. Check if a snapshot exists
-2. If yes, send the snapshot node + only post-snapshot changes
+2. If yes, send the snapshot node plus the current retained changes tree; the receiver skips history at or before the snapshot boundary
 3. If no, send the full change history (backward compatible)
 
 A new protocol `/collabswarm/snapshot-load/1.0.0` is added for peers that explicitly request a snapshot (e.g., when they detect they are too far behind).
@@ -117,12 +119,14 @@ export type CRDTSyncMessage<ChangesType, PublicKey = unknown> = {
 
 When a peer receives a sync message with a `snapshot` field:
 1. Load the snapshot state via `CRDTProvider.applySnapshot(doc, snapshot.state)` when available, or `CRDTProvider.remoteChange(doc, snapshot.state)` as fallback
-2. Then apply any post-snapshot changes from the `changes` tree (the snapshot boundary CID is added to `_hashes` so `_mergeSyncTree` skips pre-snapshot nodes)
-3. Update the hash set to include the snapshot CID and all post-snapshot CIDs
+2. Then apply later changes from the retained `changes` tree (the snapshot boundary CID is added to `_hashes` so `_mergeSyncTree` skips the retained tail at and before the boundary)
+3. Update the hash set with the snapshot boundary and every applied later change CID
 
 ### 2.6 Snapshot Verification
 
-A snapshot must be verified before applying:
+A snapshot must be verified before applying when document signing is enabled.
+With signing disabled, its signature is empty and this application-level writer
+authentication gate is bypassed:
 
 1. **Writer authorization**: The snapshot signature is verified by trying all public keys in the document's writer ACL (the embedded `publicKey` field is not relied upon because some key types like `CryptoKey` do not survive JSON serialization). Before verification, an ACL pre-pass (`_applyACLFromTree`) populates writer keys from the change tree so that fresh `open()` calls can verify snapshots.
 2. **Signature verification**: The signature must be valid for the binary signing payload described below

--- a/notes/auth.md
+++ b/notes/auth.md
@@ -1,102 +1,62 @@
-# Flow
+# Document Change Security Flows
 
-## Decrypt Change Message
+The current change path creates two related artifacts. The serialized CRDT
+change is encrypted with the document key and stored by CID without its own
+application signature. A separate sync envelope carries history references,
+is signed when ordinary document signing is enabled, and is then encrypted for
+transport. Receivers decrypt the envelope and, when signing is enabled, verify
+the writer before applying validated history.
 
-```plantuml
-@startuml
-title Decrypt Change Message 
-start
-:open stream to peer
- (document);
-:change source recv'd
- (document);
-:decrypt
- (auth prov);
-if (can decrypt?) then(yes)
-  if (for any key in
-      ACL_write,
-      can verify?) then (yes)
-    :deserialize
-      (document);
-    :apply remote change
-      (CRDT provider);
-    stop
-  else (no)
-    :warning;
-  stop
-  endif
-else(no)
-  :warning;
-stop
-endif
-@enduml
-```
-[[plantuml](
-  http://www.plantuml.com/plantuml/uml/NP6nJiGm44HxVyLqv2I-u2Wub2kXGVJ8SZONYsHjhJSvcQ_7IHo1SBFIpFFCMhuajQBpD1hrEXAkv2H7HJjOlX7UA2LRfjamSmwH64c5x0GDY4HYq7J1pHEndfxCsUqNKvZ54OJSyj3zGxgzewXsrW5Hmb9atwDnbb7TvnDq86uofPC1LhSF0iiPNvJXsM0xB-thvrsyqcCLreo5nFUvHk3804frAfOT_JTL_CzcEs9Z73E4fg24_JK7shvVFxPrVKTI-QGX6e36H6Wur9wx5VPyMv43uCxtPiKgzSjinEvVoYYVyGC0
-  )]
+![A local change becomes a separately encrypted stored payload and a conditionally signed, encrypted sync envelope that a receiver decrypts and verifies](../site/src/assets/diagrams/sync-envelope-lifecycle.svg "Stored payloads and sync envelopes have separate integrity and authorization checks.")
 
+_Stored payloads and sync envelopes have separate integrity and authorization
+checks._
 
-## Change Document
+The full change pipeline also shows CID creation, inline and deferred history,
+and the receiver's ordered checks:
 
-```plantuml
-@startuml
-title Change Document 
-start
+![A Peerborne change creates separate CID-addressed storage and encrypted GossipSub wire artifacts](../site/src/assets/diagrams/change-pipeline.svg "One local change creates distinct storage and wire artifacts.")
 
-if (write access?) then (yes)
-:create change object;
-:serialize change object;
-:sign change object 
-(auth prov);
-:encrypt
-(document key);
-else(no)
-endif
-stop
-@enduml
-```
+_One local change creates distinct storage and wire artifacts. See the
+[security concept](../site/src/content/docs/concepts/security.md) for the
+current guarantees and limitations._
 
-[[plantuml](
-http://www.plantuml.com/plantuml/uml/RSz1hi8m30JGlK_XPNA5_iMl11S9wRGrf4aLkw1oUY8g5aWixMTBCxrQgBOjYKmiWKzpo1FuNEAs81lJsubaPFUeOk0G8rJ_FTkCp6w7UkfYHMWMZ-zokIBQ7tMAAY79yuV8bB-NJ6wjSWy6lc7txGOvrdqrSiCdpG582fUB9-H1HY9IAolrRMezNW00
-  )]
+## References
 
+- [Web Cryptography API: symmetric encryption](https://jameshfisher.com/2017/11/02/web-cryptography-api-symmetric-encryption/)
+- [TypeScript generics](https://www.typescriptlang.org/docs/handbook/2/generics.html)
+- [JavaScript typed arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays)
 
-References:
-  https://jameshfisher.com/2017/11/02/web-cryptography-api-symmetric-encryption/
-  https://www.tutorialsteacher.com/typescript/typescript-generic-class
-  https://www.typescriptlang.org/docs/handbook/2/generics.html
-  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays 
+# SubtleCrypto Algorithms
 
-
-#Subtle Crypo Algos
-
-# Key type
+## Key Type
 
 https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey
 
-## encrypt
+## Encrypt
 
 https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt
 
-### Algos for symmetric
+### Symmetric Algorithms
 
-  All symmetric algos require shared data used to encrypt and decrypt. All use underlying cipher AES (Advanced Encryption Standard):
-  * CTR
-  * CBC
-  * GCM
+All symmetric algorithms require shared key material used to encrypt and
+decrypt. The supported AES modes are:
+
+- CTR
+- CBC
+- GCM
 
 > GCM does provide built-in authentication, and for this reason it's often recommended over the other two ... GCM is an "authenticated" mode, which means that it includes checks that the ciphertext has not been modified by an attacker
 
-AesGcmParams
-  * name: "AES-GCM"
-  * iv: BufferSource
-    * unique for every encryption operation carried out with a given key
-    * 96 bits long ... from a random number generator
-    * does not have to be secret, just unique: so it is OK, for example, to transmit it in the clear alongside the encrypted message
-  * tagLength is optional and defaults to 128; bits of the authentication tag 
+`AesGcmParams`:
 
-## sign
+- `name`: `AES-GCM`
+- `iv`: a 96-bit `BufferSource` that must be unique for every encryption
+  operation with the same key; it does not need to be secret
+- `tagLength`: optional authentication-tag length; defaults to 128 bits
 
-### Algos for public-key
+## Sign
+
+### Public-Key Algorithms
 
 Three of these algorithms (RSASSA-PKCS1-v1_5, RSA-PSS, and ECDSA) are public-key

--- a/packages/core/src/beekem/tree-math.ts
+++ b/packages/core/src/beekem/tree-math.ts
@@ -3,17 +3,9 @@
  *
  * Based on the MLS RFC 9420 tree math (Appendix C).
  *
- * Node indexing (example with 8 leaves):
- *
- * ```
- *         7
- *        / \
- *       3   11
- *      / \ / \
- *     1  5 9  13
- *    /\ /\ /\ /\
- *   0 2 4 6 8 10 12 14
- * ```
+ * For an eight-leaf tree, breadth layout uses root 7; its children 3 and 11;
+ * the next internal level 1, 5, 9, and 13; and leaves 0, 2, 4, 6, 8, 10, 12,
+ * and 14.
  *
  * - Leaves are at even indices (0, 2, 4, ...)
  * - Internal nodes are at odd indices (1, 3, 5, ...)

--- a/site/scripts/generate-doc-diagrams.mjs
+++ b/site/scripts/generate-doc-diagrams.mjs
@@ -541,6 +541,520 @@ function storedPayload() {
   });
 }
 
+function localIndexPipeline() {
+  const body = `
+    ${pill(886, 51, 264, 'LOCAL PROJECTION ONLY', {
+      fill: '#0f2b2e',
+      stroke: '#2dd4bf',
+      text: '#99f6e4',
+    })}
+
+    ${card(180, 137, 840, 72, { fill: '#123038', stroke: '#14b8a6', strokeWidth: 2 })}
+    ${text(600, 168, 'Authorized, decrypted CRDT snapshot', 'card-title', { anchor: 'middle' })}
+    ${text(600, 193, 'Source state already available to the local application', 'body', { anchor: 'middle' })}
+    ${arrow('M600 209V239', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+
+    ${card(180, 247, 840, 94, { fill: '#18213c', stroke: '#818cf8', strokeWidth: 2 })}
+    ${text(600, 280, 'IndexManager validation and normalization', 'card-title', { anchor: 'middle' })}
+    ${text(600, 308, 'Schema generation · field types · invalid-value policy · storage policy', 'body', { anchor: 'middle' })}
+    ${text(600, 330, 'Malformed values fail or skip according to the index definition; values stay out of diagnostics.', 'body', { anchor: 'middle' })}
+
+    ${arrow('M600 341V374H280V392')}
+    ${arrow('M600 341V374H920V392')}
+    ${card(80, 400, 400, 112, { fill: '#151f35', stroke: '#6366f1', strokeWidth: 2 })}
+    ${text(280, 436, 'Named compound physical keys', 'card-title', { anchor: 'middle' })}
+    ${lines(280, 464, ['Leading equality fields, then one range or prefix', 'Required fields only for physical keys'], {
+      anchor: 'middle',
+      lineHeight: 23,
+    })}
+    ${card(720, 400, 400, 112, { fill: '#151f35', stroke: '#6366f1', strokeWidth: 2 })}
+    ${text(920, 436, 'Stored indexed fields', 'card-title', { anchor: 'middle' })}
+    ${lines(920, 464, ['Local projection for predicate rechecks and output', 'Memory by default; cleartext persistence is explicit'], {
+      anchor: 'middle',
+      lineHeight: 23,
+    })}
+
+    ${arrow('M280 512V550H455V568')}
+    ${arrow('M920 512V550H745V568')}
+    ${card(220, 576, 760, 86, { fill: '#111f34', stroke: '#475569', strokeWidth: 2 })}
+    ${text(600, 610, 'Query planner', 'card-title', { anchor: 'middle' })}
+    ${text(600, 638, 'Select a physical key or require an explicit full scan; record residual predicates.', 'body', { anchor: 'middle' })}
+    ${arrow('M600 662V694')}
+
+    ${card(220, 702, 760, 72, { fill: '#123038', stroke: '#14b8a6', strokeWidth: 2 })}
+    ${text(600, 733, 'Candidate range, union, or approved full scan', 'card-title', { anchor: 'middle' })}
+    ${text(600, 758, 'Physical lookup narrows work; it never decides the final result by itself.', 'body', { anchor: 'middle' })}
+    ${arrow('M600 774V806', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+
+    ${card(80, 814, 1040, 84, { fill: '#0f2b2e', stroke: '#2dd4bf', strokeWidth: 2 })}
+    ${text(600, 847, 'Full predicate recheck', 'card-title', { anchor: 'middle' })}
+    ${text(600, 875, 'Then deterministic sort, cursor validation, count, and projection for the bounded local result.', 'body', { anchor: 'middle' })}`;
+
+  return diagramFrame({
+    id: 'local-index-pipeline',
+    height: 930,
+    title: 'Local indexing pipeline',
+    subtitle: 'Indexes are rebuildable materialized projections of authorized, decrypted local document state.',
+    description:
+      'A local authorized and decrypted CRDT snapshot enters IndexManager validation and normalization. The manager derives named compound physical keys and stored indexed fields. The query planner chooses a physical key or an explicitly approved full scan, reads a candidate range or union, rechecks the complete predicate, and then performs deterministic sorting, cursor handling, counting, and projection. Physical lookup narrows local work but does not independently decide results. Memory storage is the default and cleartext local persistence requires an explicit choice.',
+    body,
+  });
+}
+
+function distributedIndexFlow() {
+  const body = `
+    ${pill(796, 51, 354, 'PROTOCOL + ORCHESTRATION PRIMITIVES', {
+      fill: '#3b2b13',
+      stroke: '#f59e0b',
+      text: '#fde68a',
+    })}
+
+    ${card(150, 137, 900, 92, { fill: '#18213c', stroke: '#818cf8', strokeWidth: 2 })}
+    ${text(600, 172, 'Signed collection manifest', 'card-title', { anchor: 'middle' })}
+    ${text(600, 199, 'Schema hash · generation · search-key epoch · discovery mode · TTL · response budget', 'body', { anchor: 'middle' })}
+    ${text(600, 221, 'Manager signature and monotonic sequence are validated.', 'body', { anchor: 'middle' })}
+
+    ${arrow('M600 229V262H300V280')}
+    ${arrow('M600 229V262H900V280')}
+    ${card(70, 288, 460, 138, { fill: '#123038', stroke: '#14b8a6', strokeWidth: 2 })}
+    ${text(300, 325, 'Signed, expiring Bloom snapshot', 'card-title', { anchor: 'middle' })}
+    ${lines(300, 354, ['Blind equality-routing tokens only', 'A positive match nominates a peer; it proves nothing', 'about a document or the completeness of the result set.'], {
+      anchor: 'middle',
+      lineHeight: 24,
+    })}
+    ${card(670, 288, 460, 138, { fill: '#151f35', stroke: '#6366f1', strokeWidth: 2 })}
+    ${text(900, 325, 'Signed, bounded direct request', 'card-title', { anchor: 'middle' })}
+    ${lines(900, 354, ['Blind tokens or an explicitly disclosed query AST', 'Responses remain size-, time-, and count-bounded', 'and can omit, fabricate, or reorder candidates.'], {
+      anchor: 'middle',
+      lineHeight: 24,
+    })}
+
+    ${arrow('M300 426V461H455V479', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+    ${arrow('M900 426V461H745V479')}
+    ${card(190, 487, 820, 86, { fill: '#2d2518', stroke: '#f59e0b', strokeWidth: 2 })}
+    ${text(600, 520, 'Untrusted candidate peer / document-path claims', 'card-title', { anchor: 'middle' })}
+    ${text(600, 548, 'Signatures attribute the claimant; they do not make a claim true or complete.', 'body', { anchor: 'middle' })}
+    ${arrow('M600 573V605')}
+
+    ${card(190, 613, 820, 92, { fill: '#111f34', stroke: '#475569', strokeWidth: 2 })}
+    ${text(600, 647, 'Normal secure document load', 'card-title', { anchor: 'middle' })}
+    ${text(600, 675, 'Apply configured quorum/CID gates, authorization, signatures, decryption, and history validation.', 'body', { anchor: 'middle' })}
+    ${text(600, 697, 'A collection search key never grants document read access.', 'body', { anchor: 'middle' })}
+    ${arrow('M600 705V737')}
+
+    ${card(190, 745, 820, 74, { fill: '#123038', stroke: '#14b8a6', strokeWidth: 2 })}
+    ${text(600, 777, 'Complete predicate recheck on authorized local state', 'card-title', { anchor: 'middle' })}
+    ${text(600, 802, 'Only this local evaluation can admit the loaded document to the result page.', 'body', { anchor: 'middle' })}
+    ${arrow('M600 819V851', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+
+    ${card(190, 859, 820, 70, { fill: '#151f35', stroke: '#6366f1', strokeWidth: 2 })}
+    ${text(600, 890, 'Deterministic bounded page merge', 'card-title', { anchor: 'middle' })}
+    ${text(600, 915, 'No global completeness or exact-count guarantee in an open Byzantine network.', 'body', { anchor: 'middle' })}
+
+    ${card(50, 957, 1100, 66, { fill: '#301f2c', stroke: '#f472b6', strokeWidth: 2 })}
+    ${text(600, 984, 'EVIDENCE BOUNDARY', 'eyebrow', { anchor: 'middle', fill: '#f9a8d4' })}
+    ${text(600, 1008, 'These are composable protocol and manager primitives—not a shipped turnkey end-to-end distributed search workflow.', 'body-strong', { anchor: 'middle' })}`;
+
+  return diagramFrame({
+    id: 'distributed-index-flow',
+    height: 1055,
+    title: 'Distributed indexing trust flow',
+    subtitle: 'Remote discovery nominates untrusted candidates; normal document security and a full local recheck remain authoritative.',
+    description:
+      'A signed collection manifest controls schema generation, search-key epoch, discovery mode, expiration, and response budgets. Peers can use signed expiring Bloom snapshots with blind routing tokens or signed bounded direct requests. Both paths yield untrusted peer and document-path claims. A requester must load each candidate through normal authorization, signature, decryption, history, and configured quorum or CID gates, then recheck the complete predicate locally before a deterministic bounded merge. Distributed completeness and exact global counts are not guaranteed. The diagram describes composable protocol and orchestration primitives, not a shipped turnkey end-to-end distributed search workflow.',
+    body,
+  });
+}
+
+function relayDataFlow() {
+  const body = `
+    ${pill(892, 51, 258, 'ENCRYPTED APP TRAFFIC', {
+      fill: '#0f2b2e',
+      stroke: '#2dd4bf',
+      text: '#99f6e4',
+    })}
+
+    ${card(50, 250, 260, 142, { fill: '#18213c', stroke: '#818cf8', strokeWidth: 2 })}
+    ${text(180, 292, 'Browser A', 'card-title', { anchor: 'middle' })}
+    ${text(180, 322, 'libp2p client', 'body-strong', { anchor: 'middle' })}
+    ${text(180, 349, 'behind NAT / firewall', 'body', { anchor: 'middle' })}
+    ${pill(93, 366, 174, 'DOCUMENT PEER', {
+      fill: '#172554',
+      stroke: '#6366f1',
+      text: '#c7d2fe',
+    })}
+
+    <g filter="url(#shadow)">
+      ${card(430, 216, 340, 210, { fill: '#123038', stroke: '#14b8a6', strokeWidth: 2.5, radius: 24 })}
+    </g>
+    ${text(600, 260, 'Relay server', 'card-title', { anchor: 'middle', fill: '#99f6e4' })}
+    ${lines(600, 294, ['Bootstrap + identify', 'Circuit Relay v2 forwarding', 'GossipSub peer discovery'], {
+      anchor: 'middle',
+      className: 'body-strong',
+      lineHeight: 27,
+    })}
+    ${pill(494, 377, 212, 'NO DOCUMENT KEY', {
+      fill: '#0f3b3b',
+      stroke: '#2dd4bf',
+      text: '#99f6e4',
+    })}
+
+    ${card(890, 250, 260, 142, { fill: '#18213c', stroke: '#818cf8', strokeWidth: 2 })}
+    ${text(1020, 292, 'Browser B', 'card-title', { anchor: 'middle' })}
+    ${text(1020, 322, 'libp2p client', 'body-strong', { anchor: 'middle' })}
+    ${text(1020, 349, 'behind NAT / firewall', 'body', { anchor: 'middle' })}
+    ${pill(933, 366, 174, 'DOCUMENT PEER', {
+      fill: '#172554',
+      stroke: '#6366f1',
+      text: '#c7d2fe',
+    })}
+
+    <path d="M310 321H422" fill="none" stroke="#2dd4bf" stroke-width="4" marker-start="url(#arrowTeal)" marker-end="url(#arrowTeal)"/>
+    <path d="M778 321H890" fill="none" stroke="#2dd4bf" stroke-width="4" marker-start="url(#arrowTeal)" marker-end="url(#arrowTeal)"/>
+    ${text(366, 302, 'WebSocket', 'body-strong', { anchor: 'middle', fill: '#99f6e4' })}
+    ${text(834, 302, 'WebSocket', 'body-strong', { anchor: 'middle', fill: '#99f6e4' })}
+    ${text(600, 463, 'Circuit Relay v2 carries the live libp2p connection when a direct path is unavailable.', 'body', { anchor: 'middle' })}
+
+    <path d="M180 240C350 116 850 116 1020 240" fill="none" stroke="#a78bfa" stroke-width="3" stroke-dasharray="10 8" marker-end="url(#arrowIndigo)"/>
+    ${pill(419, 137, 362, 'OPTIONAL DIRECT WEBRTC UPGRADE', {
+      fill: '#302441',
+      stroke: '#a78bfa',
+      text: '#ddd6fe',
+    })}
+
+    ${card(50, 510, 1100, 92, { fill: '#111d2e', stroke: '#475569', strokeWidth: 2 })}
+    ${text(76, 544, 'PATH SEMANTICS', 'eyebrow', { fill: '#93c5fd' })}
+    ${text(245, 544, 'The relay forwards encrypted Peerborne traffic and does not need document plaintext or signing private keys.', 'body-strong')}
+    ${text(76, 576, 'If ICE establishes a direct WebRTC connection, libp2p can remove the relay from the data path; that upgrade is not guaranteed.', 'body')}`;
+
+  return diagramFrame({
+    id: 'relay-data-flow',
+    height: 635,
+    title: 'Browser data flow through Circuit Relay',
+    subtitle: 'A reachable relay provides a cross-NAT path; a direct WebRTC upgrade may replace it when network conditions allow.',
+    description:
+      'Browser A and Browser B connect to a relay server over WebSocket. Circuit Relay version 2 forwards their encrypted Peerborne traffic when a direct path is unavailable. The relay also provides bootstrap identify and GossipSub peer discovery, but it does not need document keys, document plaintext, or signing private keys. A dashed optional path shows that libp2p may upgrade to direct WebRTC after ICE succeeds; this upgrade is not guaranteed.',
+    body,
+  });
+}
+
+function singleRelayTopology() {
+  const body = `
+    ${pill(881, 51, 269, 'DEVELOPMENT / LIMITED TRIAL', {
+      fill: '#3b2b13',
+      stroke: '#f59e0b',
+      text: '#fde68a',
+    })}
+
+    ${card(50, 145, 245, 106, { fill: '#151f35', stroke: '#6366f1', strokeWidth: 2 })}
+    ${text(172.5, 181, 'DNS + TLS', 'card-title', { anchor: 'middle' })}
+    ${text(172.5, 210, 'relay.example.com', 'body-strong', { anchor: 'middle' })}
+    ${text(172.5, 234, 'HTTPS origin requires WSS', 'body', { anchor: 'middle' })}
+    ${arrow('M295 198H402')}
+
+    <g filter="url(#shadow)">
+      ${card(410, 132, 380, 248, { fill: '#123038', stroke: '#14b8a6', strokeWidth: 2.5, radius: 24 })}
+    </g>
+    ${text(600, 172, 'One relay / bootstrap process', 'card-title', { anchor: 'middle', fill: '#99f6e4' })}
+    ${lines(600, 207, ['Bootstrap + identify', 'Circuit Relay v2', 'GossipSub peer discovery'], {
+      anchor: 'middle',
+      className: 'body-strong',
+      lineHeight: 28,
+    })}
+    ${card(453, 300, 294, 52, { fill: '#0f2b2e', stroke: '#2dd4bf' })}
+    ${text(600, 322, '9001 WebSocket · 9002 TCP', 'body-strong', { anchor: 'middle' })}
+    ${text(600, 342, 'often 443/WSS through a reverse proxy', 'body', { anchor: 'middle' })}
+
+    ${card(905, 145, 245, 106, { fill: '#302441', stroke: '#a78bfa', strokeWidth: 2 })}
+    ${text(1027.5, 181, 'Public STUN', 'card-title', { anchor: 'middle' })}
+    ${text(1027.5, 210, 'ICE candidate gathering', 'body-strong', { anchor: 'middle' })}
+    ${text(1027.5, 234, 'for optional direct WebRTC', 'body', { anchor: 'middle' })}
+
+    ${card(80, 510, 260, 112, { fill: '#18213c', stroke: '#818cf8', strokeWidth: 2 })}
+    ${text(210, 552, 'Browser A', 'card-title', { anchor: 'middle' })}
+    ${text(210, 583, 'configured relay multiaddr', 'body', { anchor: 'middle' })}
+    ${pill(125, 590, 170, 'WSS CLIENT', {
+      fill: '#172554',
+      stroke: '#6366f1',
+      text: '#c7d2fe',
+    })}
+    ${card(470, 510, 260, 112, { fill: '#18213c', stroke: '#818cf8', strokeWidth: 2 })}
+    ${text(600, 552, 'Browser B', 'card-title', { anchor: 'middle' })}
+    ${text(600, 583, 'configured relay multiaddr', 'body', { anchor: 'middle' })}
+    ${pill(515, 590, 170, 'WSS CLIENT', {
+      fill: '#172554',
+      stroke: '#6366f1',
+      text: '#c7d2fe',
+    })}
+    ${card(860, 510, 260, 112, { fill: '#18213c', stroke: '#818cf8', strokeWidth: 2 })}
+    ${text(990, 552, 'Browser C', 'card-title', { anchor: 'middle' })}
+    ${text(990, 583, 'configured relay multiaddr', 'body', { anchor: 'middle' })}
+    ${pill(905, 590, 170, 'WSS CLIENT', {
+      fill: '#172554',
+      stroke: '#6366f1',
+      text: '#c7d2fe',
+    })}
+
+    ${arrow('M520 380V432H210V502', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+    ${arrow('M600 380V502', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+    ${arrow('M680 380V432H990V502', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+    <path d="M1027 251V446H990V502" fill="none" stroke="#a78bfa" stroke-width="2.5" stroke-dasharray="9 7" marker-end="url(#arrowIndigo)"/>
+    <path d="M990 446H600V502" fill="none" stroke="#a78bfa" stroke-width="2.5" stroke-dasharray="9 7" marker-end="url(#arrowIndigo)"/>
+    <path d="M600 446H210V502" fill="none" stroke="#a78bfa" stroke-width="2.5" stroke-dasharray="9 7" marker-end="url(#arrowIndigo)"/>
+
+    ${card(50, 672, 1100, 112, { fill: '#301f2c', stroke: '#f472b6', strokeWidth: 2 })}
+    ${text(76, 707, 'SINGLE POINT OF COORDINATION', 'eyebrow', { fill: '#f9a8d4' })}
+    ${text(76, 739, 'If this process or host is unreachable, new peers lose the configured bootstrap and relay path.', 'body-strong')}
+    ${text(76, 766, 'This topology has no high-availability or concurrent-peer guarantee and does not provide durable document storage.', 'body')}`;
+
+  return diagramFrame({
+    id: 'single-relay-topology',
+    height: 820,
+    title: 'Minimal single-relay topology',
+    subtitle: 'One reachable process combines bootstrap discovery, Circuit Relay v2, and GossipSub peer discovery.',
+    description:
+      'A DNS name and TLS endpoint lead to one relay and bootstrap process. It exposes WebSocket service, commonly behind a port 443 WSS reverse proxy, and a TCP listener for node-to-node connections. Three browsers use a configured relay multiaddress; dashed connections to public STUN represent optional WebRTC ICE candidate gathering. The relay is a single point of coordination, has no high-availability or concurrent-peer guarantee, and does not provide durable document storage.',
+    body,
+  });
+}
+
+function multiRelayTopology() {
+  const relay = (x, label, hostname, region) => `${card(x, 170, 300, 174, {
+    fill: '#123038',
+    stroke: '#14b8a6',
+    strokeWidth: 2,
+  })}
+    ${text(x + 150, 208, label, 'card-title', { anchor: 'middle' })}
+    ${text(x + 150, 238, hostname, 'body-strong', { anchor: 'middle' })}
+    ${text(x + 150, 266, region, 'body', { anchor: 'middle' })}
+    ${text(x + 150, 294, 'WSS for browsers · TCP for relay peers', 'body', { anchor: 'middle' })}
+    ${pill(x + 57, 307, 186, 'OWN DNS + TLS', {
+      fill: '#0f3b3b',
+      stroke: '#2dd4bf',
+      text: '#99f6e4',
+    })}`;
+  const client = (x, label, choice) => `${card(x, 400, 300, 112, {
+    fill: '#18213c',
+    stroke: '#818cf8',
+    strokeWidth: 2,
+  })}
+    ${text(x + 150, 440, label, 'card-title', { anchor: 'middle' })}
+    ${text(x + 150, 470, choice, 'body', { anchor: 'middle' })}
+    ${text(x + 150, 494, 'from application configuration', 'body', { anchor: 'middle' })}`;
+
+  const body = `
+    ${pill(844, 51, 306, 'NO BUILT-IN MESH OR FAILOVER', {
+      fill: '#3b2b13',
+      stroke: '#f59e0b',
+      text: '#fde68a',
+    })}
+    ${text(50, 142, 'INDEPENDENT RELAY ENDPOINTS', 'eyebrow', { fill: '#5eead4' })}
+    ${relay(50, 'Relay US', 'relay-us.example.com', 'US region')}
+    ${relay(450, 'Relay EU', 'relay-eu.example.com', 'EU region')}
+    ${relay(850, 'Relay AP', 'relay-ap.example.com', 'Asia-Pacific region')}
+
+    ${card(50, 548, 1100, 102, { fill: '#2d2518', stroke: '#f59e0b', strokeWidth: 2 })}
+    ${text(76, 582, 'INDEPENDENT PROCESSES', 'eyebrow', { fill: '#fde68a' })}
+    ${text(76, 614, 'Peerborne does not ship relay-to-relay startup dialing, a supported TCP mesh, shared discovery, or client failover.', 'body-strong')}
+    ${text(76, 639, 'Any routing or peering across these processes is custom deployment code that must be implemented and verified.', 'body')}
+
+    ${client(50, 'Browser A', 'chooses Relay US')}
+    ${client(450, 'Browser B', 'chooses Relay EU')}
+    ${client(850, 'Browser C', 'chooses Relay AP')}
+
+    ${arrow('M200 392V352', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+    ${arrow('M600 392V352', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+    ${arrow('M1000 392V352', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+
+    ${card(50, 730, 1100, 132, { fill: '#301f2c', stroke: '#f472b6', strokeWidth: 2 })}
+    ${text(76, 767, 'WHAT MULTIPLE RELAYS DO NOT AUTOMATE', 'eyebrow', { fill: '#f9a8d4' })}
+    ${text(76, 799, 'Clients do not discover a global relay pool or fail over automatically; applications supply explicit relay multiaddresses.', 'body-strong')}
+    ${text(76, 826, 'Each relay forwards traffic only for its own established connections. Relays do not provide durable document storage.', 'body')}
+    ${text(76, 850, 'Durability requires separate, application-specific publication, persistence, and recovery integration.', 'body')}
+
+    ${card(50, 890, 1100, 66, { fill: '#111d2e', stroke: '#475569', strokeWidth: 2 })}
+    ${text(600, 917, 'DEPLOYMENT BOUNDARY', 'eyebrow', { anchor: 'middle', fill: '#93c5fd' })}
+    ${text(600, 941, 'Multiple processes become a high-availability design only after custom routing, connection policy, and failover are implemented and tested.', 'body', { anchor: 'middle' })}`;
+
+  return diagramFrame({
+    id: 'multi-relay-topology',
+    height: 990,
+    title: 'Multi-relay deployment boundary',
+    subtitle: 'Each relay has its own DNS and TLS endpoint; Peerborne does not provide a mesh or automatic failover between them.',
+    description:
+      'Three independent relay processes use separate DNS names: relay-us, relay-eu, and relay-ap. Each provides WSS for configured browser clients and a TCP listener, but Peerborne does not ship relay-to-relay startup dialing, a supported mesh, shared relay discovery, or automatic client failover. Browser A is configured for the US relay, Browser B for the EU relay, and Browser C for the AP relay. Each process forwards traffic only for its own established connections and does not provide durable document storage. High availability, routing, peering, and durability require application-specific integration and verification.',
+    body,
+  });
+}
+
+function historyCompaction() {
+  const changeNode = (x, y, label, options = {}) => `${card(x, y, options.width ?? 158, 66, {
+    fill: options.root ? '#123038' : '#18213c',
+    stroke: options.root ? '#14b8a6' : '#6366f1',
+    strokeWidth: options.root ? 2.5 : 2,
+  })}
+    ${text(x + (options.width ?? 158) / 2, y + 40, label, 'body-strong', { anchor: 'middle' })}`;
+  const body = `
+    ${pill(865, 51, 285, 'SNAPSHOT STORED SEPARATELY', {
+      fill: '#0f2b2e',
+      stroke: '#2dd4bf',
+      text: '#99f6e4',
+    })}
+
+    ${text(50, 146, 'BEFORE COMPACTION', 'eyebrow', { fill: '#a5b4fc' })}
+    ${card(50, 167, 1100, 145, { fill: '#111f34', stroke: '#475569', strokeWidth: 2 })}
+    ${changeNode(82, 208, 'change 1')}
+    ${changeNode(282, 208, 'change 2')}
+    ${text(490, 249, '…', 'card-title', { anchor: 'middle' })}
+    ${changeNode(552, 208, '…')}
+    ${changeNode(752, 208, 'change 499')}
+    ${changeNode(952, 208, 'change 500', { root: true, width: 166 })}
+    ${arrow('M282 241H248')}
+    ${arrow('M552 241H518')}
+    ${arrow('M752 241H718')}
+    ${arrow('M952 241H918')}
+    ${text(1035, 294, 'current root', 'body', { anchor: 'middle', fill: '#99f6e4' })}
+
+    ${text(50, 363, 'AFTER COMPACTION', 'eyebrow', { fill: '#5eead4' })}
+    ${card(50, 386, 475, 242, { fill: '#123038', stroke: '#14b8a6', strokeWidth: 2.5 })}
+    ${text(287.5, 426, 'Latest snapshot record', 'card-title', { anchor: 'middle' })}
+    ${lines(82, 464, ['Serialized full CRDT state', 'lastChangeNodeCID = change 500', 'compactedCount + timestamp', 'writer signature when signing is enabled'], {
+      className: 'body-strong',
+      lineHeight: 27,
+    })}
+    ${pill(82, 576, 411, 'LOAD / SNAPSHOT-LOAD RESPONSES', {
+      fill: '#0f3b3b',
+      stroke: '#2dd4bf',
+      text: '#99f6e4',
+    })}
+
+    ${card(575, 386, 575, 242, { fill: '#151f35', stroke: '#6366f1', strokeWidth: 2.5 })}
+    ${text(862.5, 426, 'Retained sync tree after prune', 'card-title', { anchor: 'middle' })}
+    ${changeNode(600, 476, 'kept tail', { width: 105 })}
+    ${changeNode(733, 476, '…', { width: 55 })}
+    ${changeNode(816, 476, 'change 499', { width: 110 })}
+    ${changeNode(954, 476, '500 · boundary/root', { root: true, width: 170 })}
+    ${arrow('M733 509H713')}
+    ${arrow('M816 509H796')}
+    ${arrow('M954 509H934')}
+    ${lines(862.5, 559, ['The recent tail includes the boundary and earlier nodes.', 'Later changes append as new roots; ACL leaves may also remain.'], {
+      anchor: 'middle',
+      lineHeight: 22,
+    })}
+    ${pill(676, 598, 373, 'CURRENT IN-MEMORY TREE AFTER PRUNE', {
+      fill: '#172554',
+      stroke: '#6366f1',
+      text: '#c7d2fe',
+    })}
+
+    ${card(50, 662, 1100, 110, { fill: '#301f2c', stroke: '#f472b6', strokeWidth: 2 })}
+    ${text(76, 696, 'BOUNDARY, NOT AN INLINE CHANGE LINK', 'eyebrow', { fill: '#f9a8d4' })}
+    ${text(76, 728, 'The snapshot carries change 500’s CID as metadata; the snapshot itself is not linked into the sync tree as a change node.', 'body-strong')}
+    ${text(76, 751, 'Pruning the in-memory tree does not delete old Helia blocks unless optional post-prune garbage collection is enabled.', 'body')}`;
+
+  return diagramFrame({
+    id: 'history-compaction',
+    height: 806,
+    title: 'History compaction and snapshot boundary',
+    subtitle: 'A snapshot record is separate from a retained sync tree that can overlap the snapshotted history.',
+    description:
+      'Before compaction at change 500, a sync tree retains changes from change 1 through its current root at change 500. After compaction, a separate latest snapshot record contains serialized CRDT state, the boundary CID for change 500, a compacted count, timestamp, and a writer signature when signing is enabled. The retained in-memory sync tree keeps the boundary and a configurable recent tail of earlier nodes; later changes append to that retained tree and become new roots, and preserved ACL leaves can also remain. The snapshot itself is not an inline parent link. Snapshots are included in load or snapshot-load responses rather than ordinary incremental pubsub, and pruning the in-memory tree does not delete old Helia blocks unless optional garbage collection is enabled.',
+    body,
+  });
+}
+
+function syncEnvelopeLifecycle() {
+  const body = `
+    ${pill(930, 51, 220, 'TWO ARTIFACTS', {
+      fill: '#0f2b2e',
+      stroke: '#2dd4bf',
+      text: '#99f6e4',
+    })}
+
+    ${text(50, 145, '1 · LOCAL STORED PAYLOAD', 'eyebrow', { fill: '#a5b4fc' })}
+    ${card(50, 168, 230, 96, { fill: '#18213c', stroke: '#818cf8', strokeWidth: 2 })}
+    ${text(165, 205, 'CRDT delta', 'card-title', { anchor: 'middle' })}
+    ${text(165, 234, 'from CRDTProvider', 'body', { anchor: 'middle' })}
+    ${card(340, 168, 250, 96, { fill: '#151f35', stroke: '#6366f1', strokeWidth: 2 })}
+    ${text(465, 202, 'Serialize + encrypt', 'card-title', { anchor: 'middle' })}
+    ${text(465, 230, 'with the document key', 'body', { anchor: 'middle' })}
+    ${card(650, 148, 280, 136, { fill: '#123038', stroke: '#14b8a6', strokeWidth: 2.5 })}
+    ${text(790, 186, 'Stored Helia payload', 'card-title', { anchor: 'middle' })}
+    ${lines(790, 216, ['Encrypted serialized change', 'Unsigned at rest', 'No per-block ACL decision'], {
+      anchor: 'middle',
+      className: 'body-strong',
+      lineHeight: 24,
+    })}
+    ${card(990, 168, 160, 96, { fill: '#0f2b2e', stroke: '#2dd4bf', strokeWidth: 2.5 })}
+    ${text(1070, 205, 'CID', 'card-title', { anchor: 'middle', fill: '#99f6e4' })}
+    ${text(1070, 234, 'content address', 'body', { anchor: 'middle' })}
+    ${arrow('M280 216H332')}
+    ${arrow('M590 216H642')}
+    ${arrow('M930 216H982', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+
+    ${text(50, 345, '2 · SEPARATE SYNC ENVELOPE', 'eyebrow', { fill: '#5eead4' })}
+    ${card(50, 368, 250, 112, { fill: '#18213c', stroke: '#818cf8', strokeWidth: 2 })}
+    ${text(175, 405, 'CRDTSyncMessage', 'card-title', { anchor: 'middle' })}
+    ${lines(175, 434, ['Names the CID', 'May also carry inline history'], { anchor: 'middle', lineHeight: 24 })}
+    ${card(350, 368, 250, 112, { fill: '#302441', stroke: '#a78bfa', strokeWidth: 2 })}
+    ${text(475, 405, 'Sign when enabled', 'card-title', { anchor: 'middle' })}
+    ${lines(475, 434, ['P-384 signature covers', 'the wire message'], { anchor: 'middle', lineHeight: 24 })}
+    ${card(650, 368, 250, 112, { fill: '#123038', stroke: '#14b8a6', strokeWidth: 2 })}
+    ${text(775, 405, 'Serialize + encrypt', 'card-title', { anchor: 'middle' })}
+    ${lines(775, 434, ['Document-key encryption', 'protects the full envelope'], { anchor: 'middle', lineHeight: 24 })}
+    ${card(950, 368, 200, 112, { fill: '#0f2b2e', stroke: '#2dd4bf', strokeWidth: 2 })}
+    ${text(1050, 405, 'Publish', 'card-title', { anchor: 'middle', fill: '#99f6e4' })}
+    ${lines(1050, 434, ['Encrypted envelope', 'on GossipSub'], { anchor: 'middle', lineHeight: 24 })}
+    ${arrow('M300 424H342')}
+    ${arrow('M600 424H642')}
+    ${arrow('M900 424H942', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+
+    ${text(50, 543, '3 · RECEIVER PROCESSING', 'eyebrow', { fill: '#fbbf24' })}
+    ${card(50, 566, 235, 118, { fill: '#0f2b2e', stroke: '#2dd4bf', strokeWidth: 2 })}
+    ${text(167.5, 605, 'Encrypted envelope', 'card-title', { anchor: 'middle' })}
+    ${text(167.5, 636, 'received from GossipSub', 'body', { anchor: 'middle' })}
+    ${card(325, 566, 235, 118, { fill: '#151f35', stroke: '#6366f1', strokeWidth: 2 })}
+    ${text(442.5, 604, 'Decrypt + deserialize', 'card-title', { anchor: 'middle' })}
+    ${lines(442.5, 635, ['Open the document-key frame', 'and recover the message'], { anchor: 'middle', lineHeight: 24 })}
+    ${card(600, 566, 235, 118, { fill: '#302441', stroke: '#a78bfa', strokeWidth: 2 })}
+    ${text(717.5, 604, 'Verify when required', 'card-title', { anchor: 'middle' })}
+    ${lines(717.5, 635, ['Check a current writer', 'when signing is enabled'], { anchor: 'middle', lineHeight: 24 })}
+    ${card(875, 566, 275, 118, { fill: '#18213c', stroke: '#818cf8', strokeWidth: 2 })}
+    ${text(1012.5, 604, 'Apply inline / fetch CID', 'card-title', { anchor: 'middle' })}
+    ${lines(1012.5, 635, ['Inline changes can apply now;', 'missing payloads use Helia'], { anchor: 'middle', lineHeight: 24 })}
+    ${arrow('M285 625H317', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+    ${arrow('M560 625H592')}
+    ${arrow('M835 625H867')}
+
+    ${arrow('M1012 684V736H265V758')}
+    ${card(100, 766, 330, 112, { fill: '#111f34', stroke: '#475569', strokeWidth: 2 })}
+    ${text(265, 804, 'Validate requested CID', 'card-title', { anchor: 'middle' })}
+    ${lines(265, 835, ['Helia checks fetched bytes', 'against the content address'], { anchor: 'middle', lineHeight: 24 })}
+    ${card(485, 766, 330, 112, { fill: '#123038', stroke: '#14b8a6', strokeWidth: 2 })}
+    ${text(650, 804, 'Decrypt + deserialize block', 'card-title', { anchor: 'middle' })}
+    ${lines(650, 835, ['Use the document key;', 'no separate block signature exists'], { anchor: 'middle', lineHeight: 24 })}
+    ${card(870, 766, 280, 112, { fill: '#0f2b2e', stroke: '#2dd4bf', strokeWidth: 2 })}
+    ${text(1010, 804, 'Apply CRDT change', 'card-title', { anchor: 'middle', fill: '#99f6e4' })}
+    ${lines(1010, 835, ['Merge the validated,', 'decrypted provider delta'], { anchor: 'middle', lineHeight: 24 })}
+    ${arrow('M430 822H477')}
+    ${arrow('M815 822H862', { stroke: '#2dd4bf', marker: 'arrowTeal' })}
+
+    ${card(50, 908, 1100, 102, { fill: '#301f2c', stroke: '#f472b6', strokeWidth: 2 })}
+    ${text(76, 940, 'SIGNING BOUNDARY', 'eyebrow', { fill: '#f9a8d4' })}
+    ${text(76, 968, 'The stored CID-addressed block remains unsigned; the wire-message signature is separate and conditional.', 'body-strong')}
+    ${text(76, 994, 'Disabling ordinary signing leaves encryption in place but removes this writer-authentication gate for ordinary sync.', 'body')}`;
+
+  return diagramFrame({
+    id: 'sync-envelope-lifecycle',
+    height: 1042,
+    title: 'Stored payload and sync-envelope lifecycle',
+    subtitle: 'A local change creates an unsigned encrypted stored block and a separate conditionally signed encrypted wire envelope.',
+    description:
+      'A CRDT delta is serialized and encrypted with the document key, stored in Helia without a block signature or per-block ACL decision, and content-addressed by a CID. A separate CRDT sync message names that CID and may carry inline history. When ordinary signing is enabled, Peerborne signs the wire message with P-384, then serializes and encrypts the full envelope before publishing it on GossipSub. A receiver decrypts and deserializes the envelope, verifies a current writer when required, applies inline changes or fetches missing CIDs, validates fetched bytes against the requested CID, decrypts and deserializes the unsigned stored block, and applies the CRDT delta.',
+    body,
+  });
+}
+
 export function diagramDefinitions() {
   return [
     ['package-dependencies.svg', packageDependencies],
@@ -549,6 +1063,13 @@ export function diagramDefinitions() {
     ['document-change-lifecycle.svg', changeLifecycle],
     ['shadow-sync-graph.svg', shadowSyncGraph],
     ['stored-change-payload.svg', storedPayload],
+    ['local-index-pipeline.svg', localIndexPipeline],
+    ['distributed-index-flow.svg', distributedIndexFlow],
+    ['relay-data-flow.svg', relayDataFlow],
+    ['single-relay-topology.svg', singleRelayTopology],
+    ['multi-relay-topology.svg', multiRelayTopology],
+    ['history-compaction.svg', historyCompaction],
+    ['sync-envelope-lifecycle.svg', syncEnvelopeLifecycle],
   ];
 }
 

--- a/site/scripts/generate-doc-diagrams.test.mjs
+++ b/site/scripts/generate-doc-diagrams.test.mjs
@@ -3,15 +3,33 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { generateDiagrams } from './generate-doc-diagrams.mjs';
+import {
+  diagramDefinitions,
+  generateDiagrams,
+} from './generate-doc-diagrams.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 
-test('all six documentation diagrams are deterministic and current', () => {
+test('all documentation diagrams are deterministic and current', () => {
   const first = generateDiagrams();
   const second = generateDiagrams();
 
-  assert.equal(first.size, 6);
+  assert.equal(first.size, diagramDefinitions().length);
+  assert.deepEqual([...first.keys()], [
+    'package-dependencies.svg',
+    'networking-stack.svg',
+    'encryption-identity.svg',
+    'document-change-lifecycle.svg',
+    'shadow-sync-graph.svg',
+    'stored-change-payload.svg',
+    'local-index-pipeline.svg',
+    'distributed-index-flow.svg',
+    'relay-data-flow.svg',
+    'single-relay-topology.svg',
+    'multi-relay-topology.svg',
+    'history-compaction.svg',
+    'sync-envelope-lifecycle.svg',
+  ]);
   assert.deepEqual(first, second);
   for (const [filename, svg] of first) {
     const output = readFileSync(

--- a/site/src/assets/diagrams/distributed-index-flow.svg
+++ b/site/src/assets/diagrams/distributed-index-flow.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1055" viewBox="0 0 1200 1055" role="img" aria-labelledby="distributed-index-flow-title distributed-index-flow-description">
+  <title id="distributed-index-flow-title">Distributed indexing trust flow</title>
+  <desc id="distributed-index-flow-description">A signed collection manifest controls schema generation, search-key epoch, discovery mode, expiration, and response budgets. Peers can use signed expiring Bloom snapshots with blind routing tokens or signed bounded direct requests. Both paths yield untrusted peer and document-path claims. A requester must load each candidate through normal authorization, signature, decryption, history, and configured quorum or CID gates, then recheck the complete predicate locally before a deterministic bounded merge. Distributed completeness and exact global counts are not guaranteed. The diagram describes composable protocol and orchestration primitives, not a shipped turnkey end-to-end distributed search workflow.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="0.55" stop-color="#111827"/>
+      <stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#c7d2fe" stroke-opacity="0.035"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#020617" flood-opacity="0.38"/>
+    </filter>
+    <marker id="arrowIndigo" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#818cf8"/>
+    </marker>
+    <marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#2dd4bf"/>
+    </marker>
+    <style>
+      text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .title { fill: #f8fafc; font-size: 30px; font-weight: 760; }
+      .subtitle { fill: #94a3b8; font-size: 17px; }
+      .eyebrow { font-size: 15px; font-weight: 760; letter-spacing: 1.25px; }
+      .section { fill: #e2e8f0; font-size: 16px; font-weight: 740; letter-spacing: .5px; }
+      .card-title { fill: #f8fafc; font-size: 19px; font-weight: 740; }
+      .body { fill: #cbd5e1; font-size: 15px; }
+      .body-strong { fill: #e2e8f0; font-size: 15px; font-weight: 700; }
+      .badge { font-size: 15px; font-weight: 760; letter-spacing: .35px; }
+      .node { fill: #f8fafc; font-size: 18px; font-weight: 760; }
+      .node-detail { fill: #cbd5e1; font-size: 15px; }
+      .number { fill: #0f172a; font-size: 15px; font-weight: 800; text-anchor: middle; dominant-baseline: middle; }
+    </style>
+  </defs>
+  <rect width="1200" height="1055" rx="28" fill="url(#background)"/>
+  <rect width="1200" height="1055" rx="28" fill="url(#grid)"/>
+  <path d="M0 28A28 28 0 0 1 28 0H1172A28 28 0 0 1 1200 28V34H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="50" y="69" class="title">Distributed indexing trust flow</text>
+    <text x="50" y="99" class="subtitle">Remote discovery nominates untrusted candidates; normal document security and a full local recheck remain authoritative.</text>
+
+    <rect x="796" y="51" width="354" height="34" rx="17" fill="#3b2b13" stroke="#f59e0b" stroke-width="1.5"/>
+    <text x="973" y="74" class="badge" text-anchor="middle" fill="#fde68a">PROTOCOL + ORCHESTRATION PRIMITIVES</text>
+
+    <rect x="150" y="137" width="900" height="92" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="600" y="172" class="card-title" text-anchor="middle">Signed collection manifest</text>
+    <text x="600" y="199" class="body" text-anchor="middle">Schema hash · generation · search-key epoch · discovery mode · TTL · response budget</text>
+    <text x="600" y="221" class="body" text-anchor="middle">Manager signature and monotonic sequence are validated.</text>
+
+    <path d="M600 229V262H300V280" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M600 229V262H900V280" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <rect x="70" y="288" width="460" height="138" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2"/>
+    <text x="300" y="325" class="card-title" text-anchor="middle">Signed, expiring Bloom snapshot</text>
+    <text x="300" y="354" class="body" text-anchor="middle">Blind equality-routing tokens only</text>
+<text x="300" y="378" class="body" text-anchor="middle">A positive match nominates a peer; it proves nothing</text>
+<text x="300" y="402" class="body" text-anchor="middle">about a document or the completeness of the result set.</text>
+    <rect x="670" y="288" width="460" height="138" rx="18" fill="#151f35" stroke="#6366f1" stroke-width="2"/>
+    <text x="900" y="325" class="card-title" text-anchor="middle">Signed, bounded direct request</text>
+    <text x="900" y="354" class="body" text-anchor="middle">Blind tokens or an explicitly disclosed query AST</text>
+<text x="900" y="378" class="body" text-anchor="middle">Responses remain size-, time-, and count-bounded</text>
+<text x="900" y="402" class="body" text-anchor="middle">and can omit, fabricate, or reorder candidates.</text>
+
+    <path d="M300 426V461H455V479" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+    <path d="M900 426V461H745V479" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <rect x="190" y="487" width="820" height="86" rx="18" fill="#2d2518" stroke="#f59e0b" stroke-width="2"/>
+    <text x="600" y="520" class="card-title" text-anchor="middle">Untrusted candidate peer / document-path claims</text>
+    <text x="600" y="548" class="body" text-anchor="middle">Signatures attribute the claimant; they do not make a claim true or complete.</text>
+    <path d="M600 573V605" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+
+    <rect x="190" y="613" width="820" height="92" rx="18" fill="#111f34" stroke="#475569" stroke-width="2"/>
+    <text x="600" y="647" class="card-title" text-anchor="middle">Normal secure document load</text>
+    <text x="600" y="675" class="body" text-anchor="middle">Apply configured quorum/CID gates, authorization, signatures, decryption, and history validation.</text>
+    <text x="600" y="697" class="body" text-anchor="middle">A collection search key never grants document read access.</text>
+    <path d="M600 705V737" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+
+    <rect x="190" y="745" width="820" height="74" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2"/>
+    <text x="600" y="777" class="card-title" text-anchor="middle">Complete predicate recheck on authorized local state</text>
+    <text x="600" y="802" class="body" text-anchor="middle">Only this local evaluation can admit the loaded document to the result page.</text>
+    <path d="M600 819V851" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+
+    <rect x="190" y="859" width="820" height="70" rx="18" fill="#151f35" stroke="#6366f1" stroke-width="2"/>
+    <text x="600" y="890" class="card-title" text-anchor="middle">Deterministic bounded page merge</text>
+    <text x="600" y="915" class="body" text-anchor="middle">No global completeness or exact-count guarantee in an open Byzantine network.</text>
+
+    <rect x="50" y="957" width="1100" height="66" rx="18" fill="#301f2c" stroke="#f472b6" stroke-width="2"/>
+    <text x="600" y="984" class="eyebrow" text-anchor="middle" fill="#f9a8d4">EVIDENCE BOUNDARY</text>
+    <text x="600" y="1008" class="body-strong" text-anchor="middle">These are composable protocol and manager primitives—not a shipped turnkey end-to-end distributed search workflow.</text>
+  </g>
+</svg>

--- a/site/src/assets/diagrams/history-compaction.svg
+++ b/site/src/assets/diagrams/history-compaction.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="806" viewBox="0 0 1200 806" role="img" aria-labelledby="history-compaction-title history-compaction-description">
+  <title id="history-compaction-title">History compaction and snapshot boundary</title>
+  <desc id="history-compaction-description">Before compaction at change 500, a sync tree retains changes from change 1 through its current root at change 500. After compaction, a separate latest snapshot record contains serialized CRDT state, the boundary CID for change 500, a compacted count, timestamp, and a writer signature when signing is enabled. The retained in-memory sync tree keeps the boundary and a configurable recent tail of earlier nodes; later changes append to that retained tree and become new roots, and preserved ACL leaves can also remain. The snapshot itself is not an inline parent link. Snapshots are included in load or snapshot-load responses rather than ordinary incremental pubsub, and pruning the in-memory tree does not delete old Helia blocks unless optional garbage collection is enabled.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="0.55" stop-color="#111827"/>
+      <stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#c7d2fe" stroke-opacity="0.035"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#020617" flood-opacity="0.38"/>
+    </filter>
+    <marker id="arrowIndigo" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#818cf8"/>
+    </marker>
+    <marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#2dd4bf"/>
+    </marker>
+    <style>
+      text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .title { fill: #f8fafc; font-size: 30px; font-weight: 760; }
+      .subtitle { fill: #94a3b8; font-size: 17px; }
+      .eyebrow { font-size: 15px; font-weight: 760; letter-spacing: 1.25px; }
+      .section { fill: #e2e8f0; font-size: 16px; font-weight: 740; letter-spacing: .5px; }
+      .card-title { fill: #f8fafc; font-size: 19px; font-weight: 740; }
+      .body { fill: #cbd5e1; font-size: 15px; }
+      .body-strong { fill: #e2e8f0; font-size: 15px; font-weight: 700; }
+      .badge { font-size: 15px; font-weight: 760; letter-spacing: .35px; }
+      .node { fill: #f8fafc; font-size: 18px; font-weight: 760; }
+      .node-detail { fill: #cbd5e1; font-size: 15px; }
+      .number { fill: #0f172a; font-size: 15px; font-weight: 800; text-anchor: middle; dominant-baseline: middle; }
+    </style>
+  </defs>
+  <rect width="1200" height="806" rx="28" fill="url(#background)"/>
+  <rect width="1200" height="806" rx="28" fill="url(#grid)"/>
+  <path d="M0 28A28 28 0 0 1 28 0H1172A28 28 0 0 1 1200 28V34H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="50" y="69" class="title">History compaction and snapshot boundary</text>
+    <text x="50" y="99" class="subtitle">A snapshot record is separate from a retained sync tree that can overlap the snapshotted history.</text>
+
+    <rect x="865" y="51" width="285" height="34" rx="17" fill="#0f2b2e" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="1007.5" y="74" class="badge" text-anchor="middle" fill="#99f6e4">SNAPSHOT STORED SEPARATELY</text>
+
+    <text x="50" y="146" class="eyebrow" fill="#a5b4fc">BEFORE COMPACTION</text>
+    <rect x="50" y="167" width="1100" height="145" rx="18" fill="#111f34" stroke="#475569" stroke-width="2"/>
+    <rect x="82" y="208" width="158" height="66" rx="18" fill="#18213c" stroke="#6366f1" stroke-width="2"/>
+    <text x="161" y="248" class="body-strong" text-anchor="middle">change 1</text>
+    <rect x="282" y="208" width="158" height="66" rx="18" fill="#18213c" stroke="#6366f1" stroke-width="2"/>
+    <text x="361" y="248" class="body-strong" text-anchor="middle">change 2</text>
+    <text x="490" y="249" class="card-title" text-anchor="middle">…</text>
+    <rect x="552" y="208" width="158" height="66" rx="18" fill="#18213c" stroke="#6366f1" stroke-width="2"/>
+    <text x="631" y="248" class="body-strong" text-anchor="middle">…</text>
+    <rect x="752" y="208" width="158" height="66" rx="18" fill="#18213c" stroke="#6366f1" stroke-width="2"/>
+    <text x="831" y="248" class="body-strong" text-anchor="middle">change 499</text>
+    <rect x="952" y="208" width="166" height="66" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2.5"/>
+    <text x="1035" y="248" class="body-strong" text-anchor="middle">change 500</text>
+    <path d="M282 241H248" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M552 241H518" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M752 241H718" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M952 241H918" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <text x="1035" y="294" class="body" text-anchor="middle" fill="#99f6e4">current root</text>
+
+    <text x="50" y="363" class="eyebrow" fill="#5eead4">AFTER COMPACTION</text>
+    <rect x="50" y="386" width="475" height="242" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2.5"/>
+    <text x="287.5" y="426" class="card-title" text-anchor="middle">Latest snapshot record</text>
+    <text x="82" y="464" class="body-strong">Serialized full CRDT state</text>
+<text x="82" y="491" class="body-strong">lastChangeNodeCID = change 500</text>
+<text x="82" y="518" class="body-strong">compactedCount + timestamp</text>
+<text x="82" y="545" class="body-strong">writer signature when signing is enabled</text>
+    <rect x="82" y="576" width="411" height="34" rx="17" fill="#0f3b3b" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="287.5" y="599" class="badge" text-anchor="middle" fill="#99f6e4">LOAD / SNAPSHOT-LOAD RESPONSES</text>
+
+    <rect x="575" y="386" width="575" height="242" rx="18" fill="#151f35" stroke="#6366f1" stroke-width="2.5"/>
+    <text x="862.5" y="426" class="card-title" text-anchor="middle">Retained sync tree after prune</text>
+    <rect x="600" y="476" width="105" height="66" rx="18" fill="#18213c" stroke="#6366f1" stroke-width="2"/>
+    <text x="652.5" y="516" class="body-strong" text-anchor="middle">kept tail</text>
+    <rect x="733" y="476" width="55" height="66" rx="18" fill="#18213c" stroke="#6366f1" stroke-width="2"/>
+    <text x="760.5" y="516" class="body-strong" text-anchor="middle">…</text>
+    <rect x="816" y="476" width="110" height="66" rx="18" fill="#18213c" stroke="#6366f1" stroke-width="2"/>
+    <text x="871" y="516" class="body-strong" text-anchor="middle">change 499</text>
+    <rect x="954" y="476" width="170" height="66" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2.5"/>
+    <text x="1039" y="516" class="body-strong" text-anchor="middle">500 · boundary/root</text>
+    <path d="M733 509H713" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M816 509H796" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M954 509H934" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <text x="862.5" y="559" class="body" text-anchor="middle">The recent tail includes the boundary and earlier nodes.</text>
+<text x="862.5" y="581" class="body" text-anchor="middle">Later changes append as new roots; ACL leaves may also remain.</text>
+    <rect x="676" y="598" width="373" height="34" rx="17" fill="#172554" stroke="#6366f1" stroke-width="1.5"/>
+    <text x="862.5" y="621" class="badge" text-anchor="middle" fill="#c7d2fe">CURRENT IN-MEMORY TREE AFTER PRUNE</text>
+
+    <rect x="50" y="662" width="1100" height="110" rx="18" fill="#301f2c" stroke="#f472b6" stroke-width="2"/>
+    <text x="76" y="696" class="eyebrow" fill="#f9a8d4">BOUNDARY, NOT AN INLINE CHANGE LINK</text>
+    <text x="76" y="728" class="body-strong">The snapshot carries change 500’s CID as metadata; the snapshot itself is not linked into the sync tree as a change node.</text>
+    <text x="76" y="751" class="body">Pruning the in-memory tree does not delete old Helia blocks unless optional post-prune garbage collection is enabled.</text>
+  </g>
+</svg>

--- a/site/src/assets/diagrams/local-index-pipeline.svg
+++ b/site/src/assets/diagrams/local-index-pipeline.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="930" viewBox="0 0 1200 930" role="img" aria-labelledby="local-index-pipeline-title local-index-pipeline-description">
+  <title id="local-index-pipeline-title">Local indexing pipeline</title>
+  <desc id="local-index-pipeline-description">A local authorized and decrypted CRDT snapshot enters IndexManager validation and normalization. The manager derives named compound physical keys and stored indexed fields. The query planner chooses a physical key or an explicitly approved full scan, reads a candidate range or union, rechecks the complete predicate, and then performs deterministic sorting, cursor handling, counting, and projection. Physical lookup narrows local work but does not independently decide results. Memory storage is the default and cleartext local persistence requires an explicit choice.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="0.55" stop-color="#111827"/>
+      <stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#c7d2fe" stroke-opacity="0.035"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#020617" flood-opacity="0.38"/>
+    </filter>
+    <marker id="arrowIndigo" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#818cf8"/>
+    </marker>
+    <marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#2dd4bf"/>
+    </marker>
+    <style>
+      text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .title { fill: #f8fafc; font-size: 30px; font-weight: 760; }
+      .subtitle { fill: #94a3b8; font-size: 17px; }
+      .eyebrow { font-size: 15px; font-weight: 760; letter-spacing: 1.25px; }
+      .section { fill: #e2e8f0; font-size: 16px; font-weight: 740; letter-spacing: .5px; }
+      .card-title { fill: #f8fafc; font-size: 19px; font-weight: 740; }
+      .body { fill: #cbd5e1; font-size: 15px; }
+      .body-strong { fill: #e2e8f0; font-size: 15px; font-weight: 700; }
+      .badge { font-size: 15px; font-weight: 760; letter-spacing: .35px; }
+      .node { fill: #f8fafc; font-size: 18px; font-weight: 760; }
+      .node-detail { fill: #cbd5e1; font-size: 15px; }
+      .number { fill: #0f172a; font-size: 15px; font-weight: 800; text-anchor: middle; dominant-baseline: middle; }
+    </style>
+  </defs>
+  <rect width="1200" height="930" rx="28" fill="url(#background)"/>
+  <rect width="1200" height="930" rx="28" fill="url(#grid)"/>
+  <path d="M0 28A28 28 0 0 1 28 0H1172A28 28 0 0 1 1200 28V34H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="50" y="69" class="title">Local indexing pipeline</text>
+    <text x="50" y="99" class="subtitle">Indexes are rebuildable materialized projections of authorized, decrypted local document state.</text>
+
+    <rect x="886" y="51" width="264" height="34" rx="17" fill="#0f2b2e" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="1018" y="74" class="badge" text-anchor="middle" fill="#99f6e4">LOCAL PROJECTION ONLY</text>
+
+    <rect x="180" y="137" width="840" height="72" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2"/>
+    <text x="600" y="168" class="card-title" text-anchor="middle">Authorized, decrypted CRDT snapshot</text>
+    <text x="600" y="193" class="body" text-anchor="middle">Source state already available to the local application</text>
+    <path d="M600 209V239" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+
+    <rect x="180" y="247" width="840" height="94" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="600" y="280" class="card-title" text-anchor="middle">IndexManager validation and normalization</text>
+    <text x="600" y="308" class="body" text-anchor="middle">Schema generation · field types · invalid-value policy · storage policy</text>
+    <text x="600" y="330" class="body" text-anchor="middle">Malformed values fail or skip according to the index definition; values stay out of diagnostics.</text>
+
+    <path d="M600 341V374H280V392" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M600 341V374H920V392" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <rect x="80" y="400" width="400" height="112" rx="18" fill="#151f35" stroke="#6366f1" stroke-width="2"/>
+    <text x="280" y="436" class="card-title" text-anchor="middle">Named compound physical keys</text>
+    <text x="280" y="464" class="body" text-anchor="middle">Leading equality fields, then one range or prefix</text>
+<text x="280" y="487" class="body" text-anchor="middle">Required fields only for physical keys</text>
+    <rect x="720" y="400" width="400" height="112" rx="18" fill="#151f35" stroke="#6366f1" stroke-width="2"/>
+    <text x="920" y="436" class="card-title" text-anchor="middle">Stored indexed fields</text>
+    <text x="920" y="464" class="body" text-anchor="middle">Local projection for predicate rechecks and output</text>
+<text x="920" y="487" class="body" text-anchor="middle">Memory by default; cleartext persistence is explicit</text>
+
+    <path d="M280 512V550H455V568" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M920 512V550H745V568" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <rect x="220" y="576" width="760" height="86" rx="18" fill="#111f34" stroke="#475569" stroke-width="2"/>
+    <text x="600" y="610" class="card-title" text-anchor="middle">Query planner</text>
+    <text x="600" y="638" class="body" text-anchor="middle">Select a physical key or require an explicit full scan; record residual predicates.</text>
+    <path d="M600 662V694" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+
+    <rect x="220" y="702" width="760" height="72" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2"/>
+    <text x="600" y="733" class="card-title" text-anchor="middle">Candidate range, union, or approved full scan</text>
+    <text x="600" y="758" class="body" text-anchor="middle">Physical lookup narrows work; it never decides the final result by itself.</text>
+    <path d="M600 774V806" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+
+    <rect x="80" y="814" width="1040" height="84" rx="18" fill="#0f2b2e" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="600" y="847" class="card-title" text-anchor="middle">Full predicate recheck</text>
+    <text x="600" y="875" class="body" text-anchor="middle">Then deterministic sort, cursor validation, count, and projection for the bounded local result.</text>
+  </g>
+</svg>

--- a/site/src/assets/diagrams/multi-relay-topology.svg
+++ b/site/src/assets/diagrams/multi-relay-topology.svg
@@ -1,0 +1,101 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="990" viewBox="0 0 1200 990" role="img" aria-labelledby="multi-relay-topology-title multi-relay-topology-description">
+  <title id="multi-relay-topology-title">Multi-relay deployment boundary</title>
+  <desc id="multi-relay-topology-description">Three independent relay processes use separate DNS names: relay-us, relay-eu, and relay-ap. Each provides WSS for configured browser clients and a TCP listener, but Peerborne does not ship relay-to-relay startup dialing, a supported mesh, shared relay discovery, or automatic client failover. Browser A is configured for the US relay, Browser B for the EU relay, and Browser C for the AP relay. Each process forwards traffic only for its own established connections and does not provide durable document storage. High availability, routing, peering, and durability require application-specific integration and verification.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="0.55" stop-color="#111827"/>
+      <stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#c7d2fe" stroke-opacity="0.035"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#020617" flood-opacity="0.38"/>
+    </filter>
+    <marker id="arrowIndigo" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#818cf8"/>
+    </marker>
+    <marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#2dd4bf"/>
+    </marker>
+    <style>
+      text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .title { fill: #f8fafc; font-size: 30px; font-weight: 760; }
+      .subtitle { fill: #94a3b8; font-size: 17px; }
+      .eyebrow { font-size: 15px; font-weight: 760; letter-spacing: 1.25px; }
+      .section { fill: #e2e8f0; font-size: 16px; font-weight: 740; letter-spacing: .5px; }
+      .card-title { fill: #f8fafc; font-size: 19px; font-weight: 740; }
+      .body { fill: #cbd5e1; font-size: 15px; }
+      .body-strong { fill: #e2e8f0; font-size: 15px; font-weight: 700; }
+      .badge { font-size: 15px; font-weight: 760; letter-spacing: .35px; }
+      .node { fill: #f8fafc; font-size: 18px; font-weight: 760; }
+      .node-detail { fill: #cbd5e1; font-size: 15px; }
+      .number { fill: #0f172a; font-size: 15px; font-weight: 800; text-anchor: middle; dominant-baseline: middle; }
+    </style>
+  </defs>
+  <rect width="1200" height="990" rx="28" fill="url(#background)"/>
+  <rect width="1200" height="990" rx="28" fill="url(#grid)"/>
+  <path d="M0 28A28 28 0 0 1 28 0H1172A28 28 0 0 1 1200 28V34H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="50" y="69" class="title">Multi-relay deployment boundary</text>
+    <text x="50" y="99" class="subtitle">Each relay has its own DNS and TLS endpoint; Peerborne does not provide a mesh or automatic failover between them.</text>
+
+    <rect x="844" y="51" width="306" height="34" rx="17" fill="#3b2b13" stroke="#f59e0b" stroke-width="1.5"/>
+    <text x="997" y="74" class="badge" text-anchor="middle" fill="#fde68a">NO BUILT-IN MESH OR FAILOVER</text>
+    <text x="50" y="142" class="eyebrow" fill="#5eead4">INDEPENDENT RELAY ENDPOINTS</text>
+    <rect x="50" y="170" width="300" height="174" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2"/>
+    <text x="200" y="208" class="card-title" text-anchor="middle">Relay US</text>
+    <text x="200" y="238" class="body-strong" text-anchor="middle">relay-us.example.com</text>
+    <text x="200" y="266" class="body" text-anchor="middle">US region</text>
+    <text x="200" y="294" class="body" text-anchor="middle">WSS for browsers · TCP for relay peers</text>
+    <rect x="107" y="307" width="186" height="34" rx="17" fill="#0f3b3b" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="200" y="330" class="badge" text-anchor="middle" fill="#99f6e4">OWN DNS + TLS</text>
+    <rect x="450" y="170" width="300" height="174" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2"/>
+    <text x="600" y="208" class="card-title" text-anchor="middle">Relay EU</text>
+    <text x="600" y="238" class="body-strong" text-anchor="middle">relay-eu.example.com</text>
+    <text x="600" y="266" class="body" text-anchor="middle">EU region</text>
+    <text x="600" y="294" class="body" text-anchor="middle">WSS for browsers · TCP for relay peers</text>
+    <rect x="507" y="307" width="186" height="34" rx="17" fill="#0f3b3b" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="600" y="330" class="badge" text-anchor="middle" fill="#99f6e4">OWN DNS + TLS</text>
+    <rect x="850" y="170" width="300" height="174" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2"/>
+    <text x="1000" y="208" class="card-title" text-anchor="middle">Relay AP</text>
+    <text x="1000" y="238" class="body-strong" text-anchor="middle">relay-ap.example.com</text>
+    <text x="1000" y="266" class="body" text-anchor="middle">Asia-Pacific region</text>
+    <text x="1000" y="294" class="body" text-anchor="middle">WSS for browsers · TCP for relay peers</text>
+    <rect x="907" y="307" width="186" height="34" rx="17" fill="#0f3b3b" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="1000" y="330" class="badge" text-anchor="middle" fill="#99f6e4">OWN DNS + TLS</text>
+
+    <rect x="50" y="548" width="1100" height="102" rx="18" fill="#2d2518" stroke="#f59e0b" stroke-width="2"/>
+    <text x="76" y="582" class="eyebrow" fill="#fde68a">INDEPENDENT PROCESSES</text>
+    <text x="76" y="614" class="body-strong">Peerborne does not ship relay-to-relay startup dialing, a supported TCP mesh, shared discovery, or client failover.</text>
+    <text x="76" y="639" class="body">Any routing or peering across these processes is custom deployment code that must be implemented and verified.</text>
+
+    <rect x="50" y="400" width="300" height="112" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="200" y="440" class="card-title" text-anchor="middle">Browser A</text>
+    <text x="200" y="470" class="body" text-anchor="middle">chooses Relay US</text>
+    <text x="200" y="494" class="body" text-anchor="middle">from application configuration</text>
+    <rect x="450" y="400" width="300" height="112" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="600" y="440" class="card-title" text-anchor="middle">Browser B</text>
+    <text x="600" y="470" class="body" text-anchor="middle">chooses Relay EU</text>
+    <text x="600" y="494" class="body" text-anchor="middle">from application configuration</text>
+    <rect x="850" y="400" width="300" height="112" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="1000" y="440" class="card-title" text-anchor="middle">Browser C</text>
+    <text x="1000" y="470" class="body" text-anchor="middle">chooses Relay AP</text>
+    <text x="1000" y="494" class="body" text-anchor="middle">from application configuration</text>
+
+    <path d="M200 392V352" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+    <path d="M600 392V352" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+    <path d="M1000 392V352" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+
+    <rect x="50" y="730" width="1100" height="132" rx="18" fill="#301f2c" stroke="#f472b6" stroke-width="2"/>
+    <text x="76" y="767" class="eyebrow" fill="#f9a8d4">WHAT MULTIPLE RELAYS DO NOT AUTOMATE</text>
+    <text x="76" y="799" class="body-strong">Clients do not discover a global relay pool or fail over automatically; applications supply explicit relay multiaddresses.</text>
+    <text x="76" y="826" class="body">Each relay forwards traffic only for its own established connections. Relays do not provide durable document storage.</text>
+    <text x="76" y="850" class="body">Durability requires separate, application-specific publication, persistence, and recovery integration.</text>
+
+    <rect x="50" y="890" width="1100" height="66" rx="18" fill="#111d2e" stroke="#475569" stroke-width="2"/>
+    <text x="600" y="917" class="eyebrow" text-anchor="middle" fill="#93c5fd">DEPLOYMENT BOUNDARY</text>
+    <text x="600" y="941" class="body" text-anchor="middle">Multiple processes become a high-availability design only after custom routing, connection policy, and failover are implemented and tested.</text>
+  </g>
+</svg>

--- a/site/src/assets/diagrams/relay-data-flow.svg
+++ b/site/src/assets/diagrams/relay-data-flow.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="635" viewBox="0 0 1200 635" role="img" aria-labelledby="relay-data-flow-title relay-data-flow-description">
+  <title id="relay-data-flow-title">Browser data flow through Circuit Relay</title>
+  <desc id="relay-data-flow-description">Browser A and Browser B connect to a relay server over WebSocket. Circuit Relay version 2 forwards their encrypted Peerborne traffic when a direct path is unavailable. The relay also provides bootstrap identify and GossipSub peer discovery, but it does not need document keys, document plaintext, or signing private keys. A dashed optional path shows that libp2p may upgrade to direct WebRTC after ICE succeeds; this upgrade is not guaranteed.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="0.55" stop-color="#111827"/>
+      <stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#c7d2fe" stroke-opacity="0.035"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#020617" flood-opacity="0.38"/>
+    </filter>
+    <marker id="arrowIndigo" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#818cf8"/>
+    </marker>
+    <marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#2dd4bf"/>
+    </marker>
+    <style>
+      text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .title { fill: #f8fafc; font-size: 30px; font-weight: 760; }
+      .subtitle { fill: #94a3b8; font-size: 17px; }
+      .eyebrow { font-size: 15px; font-weight: 760; letter-spacing: 1.25px; }
+      .section { fill: #e2e8f0; font-size: 16px; font-weight: 740; letter-spacing: .5px; }
+      .card-title { fill: #f8fafc; font-size: 19px; font-weight: 740; }
+      .body { fill: #cbd5e1; font-size: 15px; }
+      .body-strong { fill: #e2e8f0; font-size: 15px; font-weight: 700; }
+      .badge { font-size: 15px; font-weight: 760; letter-spacing: .35px; }
+      .node { fill: #f8fafc; font-size: 18px; font-weight: 760; }
+      .node-detail { fill: #cbd5e1; font-size: 15px; }
+      .number { fill: #0f172a; font-size: 15px; font-weight: 800; text-anchor: middle; dominant-baseline: middle; }
+    </style>
+  </defs>
+  <rect width="1200" height="635" rx="28" fill="url(#background)"/>
+  <rect width="1200" height="635" rx="28" fill="url(#grid)"/>
+  <path d="M0 28A28 28 0 0 1 28 0H1172A28 28 0 0 1 1200 28V34H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="50" y="69" class="title">Browser data flow through Circuit Relay</text>
+    <text x="50" y="99" class="subtitle">A reachable relay provides a cross-NAT path; a direct WebRTC upgrade may replace it when network conditions allow.</text>
+
+    <rect x="892" y="51" width="258" height="34" rx="17" fill="#0f2b2e" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="1021" y="74" class="badge" text-anchor="middle" fill="#99f6e4">ENCRYPTED APP TRAFFIC</text>
+
+    <rect x="50" y="250" width="260" height="142" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="180" y="292" class="card-title" text-anchor="middle">Browser A</text>
+    <text x="180" y="322" class="body-strong" text-anchor="middle">libp2p client</text>
+    <text x="180" y="349" class="body" text-anchor="middle">behind NAT / firewall</text>
+    <rect x="93" y="366" width="174" height="34" rx="17" fill="#172554" stroke="#6366f1" stroke-width="1.5"/>
+    <text x="180" y="389" class="badge" text-anchor="middle" fill="#c7d2fe">DOCUMENT PEER</text>
+
+    <g filter="url(#shadow)">
+      <rect x="430" y="216" width="340" height="210" rx="24" fill="#123038" stroke="#14b8a6" stroke-width="2.5"/>
+    </g>
+    <text x="600" y="260" class="card-title" text-anchor="middle" fill="#99f6e4">Relay server</text>
+    <text x="600" y="294" class="body-strong" text-anchor="middle">Bootstrap + identify</text>
+<text x="600" y="321" class="body-strong" text-anchor="middle">Circuit Relay v2 forwarding</text>
+<text x="600" y="348" class="body-strong" text-anchor="middle">GossipSub peer discovery</text>
+    <rect x="494" y="377" width="212" height="34" rx="17" fill="#0f3b3b" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="600" y="400" class="badge" text-anchor="middle" fill="#99f6e4">NO DOCUMENT KEY</text>
+
+    <rect x="890" y="250" width="260" height="142" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="1020" y="292" class="card-title" text-anchor="middle">Browser B</text>
+    <text x="1020" y="322" class="body-strong" text-anchor="middle">libp2p client</text>
+    <text x="1020" y="349" class="body" text-anchor="middle">behind NAT / firewall</text>
+    <rect x="933" y="366" width="174" height="34" rx="17" fill="#172554" stroke="#6366f1" stroke-width="1.5"/>
+    <text x="1020" y="389" class="badge" text-anchor="middle" fill="#c7d2fe">DOCUMENT PEER</text>
+
+    <path d="M310 321H422" fill="none" stroke="#2dd4bf" stroke-width="4" marker-start="url(#arrowTeal)" marker-end="url(#arrowTeal)"/>
+    <path d="M778 321H890" fill="none" stroke="#2dd4bf" stroke-width="4" marker-start="url(#arrowTeal)" marker-end="url(#arrowTeal)"/>
+    <text x="366" y="302" class="body-strong" text-anchor="middle" fill="#99f6e4">WebSocket</text>
+    <text x="834" y="302" class="body-strong" text-anchor="middle" fill="#99f6e4">WebSocket</text>
+    <text x="600" y="463" class="body" text-anchor="middle">Circuit Relay v2 carries the live libp2p connection when a direct path is unavailable.</text>
+
+    <path d="M180 240C350 116 850 116 1020 240" fill="none" stroke="#a78bfa" stroke-width="3" stroke-dasharray="10 8" marker-end="url(#arrowIndigo)"/>
+    <rect x="419" y="137" width="362" height="34" rx="17" fill="#302441" stroke="#a78bfa" stroke-width="1.5"/>
+    <text x="600" y="160" class="badge" text-anchor="middle" fill="#ddd6fe">OPTIONAL DIRECT WEBRTC UPGRADE</text>
+
+    <rect x="50" y="510" width="1100" height="92" rx="18" fill="#111d2e" stroke="#475569" stroke-width="2"/>
+    <text x="76" y="544" class="eyebrow" fill="#93c5fd">PATH SEMANTICS</text>
+    <text x="245" y="544" class="body-strong">The relay forwards encrypted Peerborne traffic and does not need document plaintext or signing private keys.</text>
+    <text x="76" y="576" class="body">If ICE establishes a direct WebRTC connection, libp2p can remove the relay from the data path; that upgrade is not guaranteed.</text>
+  </g>
+</svg>

--- a/site/src/assets/diagrams/single-relay-topology.svg
+++ b/site/src/assets/diagrams/single-relay-topology.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="820" viewBox="0 0 1200 820" role="img" aria-labelledby="single-relay-topology-title single-relay-topology-description">
+  <title id="single-relay-topology-title">Minimal single-relay topology</title>
+  <desc id="single-relay-topology-description">A DNS name and TLS endpoint lead to one relay and bootstrap process. It exposes WebSocket service, commonly behind a port 443 WSS reverse proxy, and a TCP listener for node-to-node connections. Three browsers use a configured relay multiaddress; dashed connections to public STUN represent optional WebRTC ICE candidate gathering. The relay is a single point of coordination, has no high-availability or concurrent-peer guarantee, and does not provide durable document storage.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="0.55" stop-color="#111827"/>
+      <stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#c7d2fe" stroke-opacity="0.035"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#020617" flood-opacity="0.38"/>
+    </filter>
+    <marker id="arrowIndigo" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#818cf8"/>
+    </marker>
+    <marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#2dd4bf"/>
+    </marker>
+    <style>
+      text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .title { fill: #f8fafc; font-size: 30px; font-weight: 760; }
+      .subtitle { fill: #94a3b8; font-size: 17px; }
+      .eyebrow { font-size: 15px; font-weight: 760; letter-spacing: 1.25px; }
+      .section { fill: #e2e8f0; font-size: 16px; font-weight: 740; letter-spacing: .5px; }
+      .card-title { fill: #f8fafc; font-size: 19px; font-weight: 740; }
+      .body { fill: #cbd5e1; font-size: 15px; }
+      .body-strong { fill: #e2e8f0; font-size: 15px; font-weight: 700; }
+      .badge { font-size: 15px; font-weight: 760; letter-spacing: .35px; }
+      .node { fill: #f8fafc; font-size: 18px; font-weight: 760; }
+      .node-detail { fill: #cbd5e1; font-size: 15px; }
+      .number { fill: #0f172a; font-size: 15px; font-weight: 800; text-anchor: middle; dominant-baseline: middle; }
+    </style>
+  </defs>
+  <rect width="1200" height="820" rx="28" fill="url(#background)"/>
+  <rect width="1200" height="820" rx="28" fill="url(#grid)"/>
+  <path d="M0 28A28 28 0 0 1 28 0H1172A28 28 0 0 1 1200 28V34H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="50" y="69" class="title">Minimal single-relay topology</text>
+    <text x="50" y="99" class="subtitle">One reachable process combines bootstrap discovery, Circuit Relay v2, and GossipSub peer discovery.</text>
+
+    <rect x="881" y="51" width="269" height="34" rx="17" fill="#3b2b13" stroke="#f59e0b" stroke-width="1.5"/>
+    <text x="1015.5" y="74" class="badge" text-anchor="middle" fill="#fde68a">DEVELOPMENT / LIMITED TRIAL</text>
+
+    <rect x="50" y="145" width="245" height="106" rx="18" fill="#151f35" stroke="#6366f1" stroke-width="2"/>
+    <text x="172.5" y="181" class="card-title" text-anchor="middle">DNS + TLS</text>
+    <text x="172.5" y="210" class="body-strong" text-anchor="middle">relay.example.com</text>
+    <text x="172.5" y="234" class="body" text-anchor="middle">HTTPS origin requires WSS</text>
+    <path d="M295 198H402" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+
+    <g filter="url(#shadow)">
+      <rect x="410" y="132" width="380" height="248" rx="24" fill="#123038" stroke="#14b8a6" stroke-width="2.5"/>
+    </g>
+    <text x="600" y="172" class="card-title" text-anchor="middle" fill="#99f6e4">One relay / bootstrap process</text>
+    <text x="600" y="207" class="body-strong" text-anchor="middle">Bootstrap + identify</text>
+<text x="600" y="235" class="body-strong" text-anchor="middle">Circuit Relay v2</text>
+<text x="600" y="263" class="body-strong" text-anchor="middle">GossipSub peer discovery</text>
+    <rect x="453" y="300" width="294" height="52" rx="18" fill="#0f2b2e" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="600" y="322" class="body-strong" text-anchor="middle">9001 WebSocket · 9002 TCP</text>
+    <text x="600" y="342" class="body" text-anchor="middle">often 443/WSS through a reverse proxy</text>
+
+    <rect x="905" y="145" width="245" height="106" rx="18" fill="#302441" stroke="#a78bfa" stroke-width="2"/>
+    <text x="1027.5" y="181" class="card-title" text-anchor="middle">Public STUN</text>
+    <text x="1027.5" y="210" class="body-strong" text-anchor="middle">ICE candidate gathering</text>
+    <text x="1027.5" y="234" class="body" text-anchor="middle">for optional direct WebRTC</text>
+
+    <rect x="80" y="510" width="260" height="112" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="210" y="552" class="card-title" text-anchor="middle">Browser A</text>
+    <text x="210" y="583" class="body" text-anchor="middle">configured relay multiaddr</text>
+    <rect x="125" y="590" width="170" height="34" rx="17" fill="#172554" stroke="#6366f1" stroke-width="1.5"/>
+    <text x="210" y="613" class="badge" text-anchor="middle" fill="#c7d2fe">WSS CLIENT</text>
+    <rect x="470" y="510" width="260" height="112" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="600" y="552" class="card-title" text-anchor="middle">Browser B</text>
+    <text x="600" y="583" class="body" text-anchor="middle">configured relay multiaddr</text>
+    <rect x="515" y="590" width="170" height="34" rx="17" fill="#172554" stroke="#6366f1" stroke-width="1.5"/>
+    <text x="600" y="613" class="badge" text-anchor="middle" fill="#c7d2fe">WSS CLIENT</text>
+    <rect x="860" y="510" width="260" height="112" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="990" y="552" class="card-title" text-anchor="middle">Browser C</text>
+    <text x="990" y="583" class="body" text-anchor="middle">configured relay multiaddr</text>
+    <rect x="905" y="590" width="170" height="34" rx="17" fill="#172554" stroke="#6366f1" stroke-width="1.5"/>
+    <text x="990" y="613" class="badge" text-anchor="middle" fill="#c7d2fe">WSS CLIENT</text>
+
+    <path d="M520 380V432H210V502" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+    <path d="M600 380V502" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+    <path d="M680 380V432H990V502" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+    <path d="M1027 251V446H990V502" fill="none" stroke="#a78bfa" stroke-width="2.5" stroke-dasharray="9 7" marker-end="url(#arrowIndigo)"/>
+    <path d="M990 446H600V502" fill="none" stroke="#a78bfa" stroke-width="2.5" stroke-dasharray="9 7" marker-end="url(#arrowIndigo)"/>
+    <path d="M600 446H210V502" fill="none" stroke="#a78bfa" stroke-width="2.5" stroke-dasharray="9 7" marker-end="url(#arrowIndigo)"/>
+
+    <rect x="50" y="672" width="1100" height="112" rx="18" fill="#301f2c" stroke="#f472b6" stroke-width="2"/>
+    <text x="76" y="707" class="eyebrow" fill="#f9a8d4">SINGLE POINT OF COORDINATION</text>
+    <text x="76" y="739" class="body-strong">If this process or host is unreachable, new peers lose the configured bootstrap and relay path.</text>
+    <text x="76" y="766" class="body">This topology has no high-availability or concurrent-peer guarantee and does not provide durable document storage.</text>
+  </g>
+</svg>

--- a/site/src/assets/diagrams/sync-envelope-lifecycle.svg
+++ b/site/src/assets/diagrams/sync-envelope-lifecycle.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1042" viewBox="0 0 1200 1042" role="img" aria-labelledby="sync-envelope-lifecycle-title sync-envelope-lifecycle-description">
+  <title id="sync-envelope-lifecycle-title">Stored payload and sync-envelope lifecycle</title>
+  <desc id="sync-envelope-lifecycle-description">A CRDT delta is serialized and encrypted with the document key, stored in Helia without a block signature or per-block ACL decision, and content-addressed by a CID. A separate CRDT sync message names that CID and may carry inline history. When ordinary signing is enabled, Peerborne signs the wire message with P-384, then serializes and encrypts the full envelope before publishing it on GossipSub. A receiver decrypts and deserializes the envelope, verifies a current writer when required, applies inline changes or fetches missing CIDs, validates fetched bytes against the requested CID, decrypts and deserializes the unsigned stored block, and applies the CRDT delta.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1220"/>
+      <stop offset="0.55" stop-color="#111827"/>
+      <stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#c7d2fe" stroke-opacity="0.035"/>
+    </pattern>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#020617" flood-opacity="0.38"/>
+    </filter>
+    <marker id="arrowIndigo" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#818cf8"/>
+    </marker>
+    <marker id="arrowTeal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#2dd4bf"/>
+    </marker>
+    <style>
+      text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .title { fill: #f8fafc; font-size: 30px; font-weight: 760; }
+      .subtitle { fill: #94a3b8; font-size: 17px; }
+      .eyebrow { font-size: 15px; font-weight: 760; letter-spacing: 1.25px; }
+      .section { fill: #e2e8f0; font-size: 16px; font-weight: 740; letter-spacing: .5px; }
+      .card-title { fill: #f8fafc; font-size: 19px; font-weight: 740; }
+      .body { fill: #cbd5e1; font-size: 15px; }
+      .body-strong { fill: #e2e8f0; font-size: 15px; font-weight: 700; }
+      .badge { font-size: 15px; font-weight: 760; letter-spacing: .35px; }
+      .node { fill: #f8fafc; font-size: 18px; font-weight: 760; }
+      .node-detail { fill: #cbd5e1; font-size: 15px; }
+      .number { fill: #0f172a; font-size: 15px; font-weight: 800; text-anchor: middle; dominant-baseline: middle; }
+    </style>
+  </defs>
+  <rect width="1200" height="1042" rx="28" fill="url(#background)"/>
+  <rect width="1200" height="1042" rx="28" fill="url(#grid)"/>
+  <path d="M0 28A28 28 0 0 1 28 0H1172A28 28 0 0 1 1200 28V34H0Z" fill="#2dd4bf"/>
+  <g>
+    <text x="50" y="69" class="title">Stored payload and sync-envelope lifecycle</text>
+    <text x="50" y="99" class="subtitle">A local change creates an unsigned encrypted stored block and a separate conditionally signed encrypted wire envelope.</text>
+
+    <rect x="930" y="51" width="220" height="34" rx="17" fill="#0f2b2e" stroke="#2dd4bf" stroke-width="1.5"/>
+    <text x="1040" y="74" class="badge" text-anchor="middle" fill="#99f6e4">TWO ARTIFACTS</text>
+
+    <text x="50" y="145" class="eyebrow" fill="#a5b4fc">1 · LOCAL STORED PAYLOAD</text>
+    <rect x="50" y="168" width="230" height="96" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="165" y="205" class="card-title" text-anchor="middle">CRDT delta</text>
+    <text x="165" y="234" class="body" text-anchor="middle">from CRDTProvider</text>
+    <rect x="340" y="168" width="250" height="96" rx="18" fill="#151f35" stroke="#6366f1" stroke-width="2"/>
+    <text x="465" y="202" class="card-title" text-anchor="middle">Serialize + encrypt</text>
+    <text x="465" y="230" class="body" text-anchor="middle">with the document key</text>
+    <rect x="650" y="148" width="280" height="136" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2.5"/>
+    <text x="790" y="186" class="card-title" text-anchor="middle">Stored Helia payload</text>
+    <text x="790" y="216" class="body-strong" text-anchor="middle">Encrypted serialized change</text>
+<text x="790" y="240" class="body-strong" text-anchor="middle">Unsigned at rest</text>
+<text x="790" y="264" class="body-strong" text-anchor="middle">No per-block ACL decision</text>
+    <rect x="990" y="168" width="160" height="96" rx="18" fill="#0f2b2e" stroke="#2dd4bf" stroke-width="2.5"/>
+    <text x="1070" y="205" class="card-title" text-anchor="middle" fill="#99f6e4">CID</text>
+    <text x="1070" y="234" class="body" text-anchor="middle">content address</text>
+    <path d="M280 216H332" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M590 216H642" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M930 216H982" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+
+    <text x="50" y="345" class="eyebrow" fill="#5eead4">2 · SEPARATE SYNC ENVELOPE</text>
+    <rect x="50" y="368" width="250" height="112" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="175" y="405" class="card-title" text-anchor="middle">CRDTSyncMessage</text>
+    <text x="175" y="434" class="body" text-anchor="middle">Names the CID</text>
+<text x="175" y="458" class="body" text-anchor="middle">May also carry inline history</text>
+    <rect x="350" y="368" width="250" height="112" rx="18" fill="#302441" stroke="#a78bfa" stroke-width="2"/>
+    <text x="475" y="405" class="card-title" text-anchor="middle">Sign when enabled</text>
+    <text x="475" y="434" class="body" text-anchor="middle">P-384 signature covers</text>
+<text x="475" y="458" class="body" text-anchor="middle">the wire message</text>
+    <rect x="650" y="368" width="250" height="112" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2"/>
+    <text x="775" y="405" class="card-title" text-anchor="middle">Serialize + encrypt</text>
+    <text x="775" y="434" class="body" text-anchor="middle">Document-key encryption</text>
+<text x="775" y="458" class="body" text-anchor="middle">protects the full envelope</text>
+    <rect x="950" y="368" width="200" height="112" rx="18" fill="#0f2b2e" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="1050" y="405" class="card-title" text-anchor="middle" fill="#99f6e4">Publish</text>
+    <text x="1050" y="434" class="body" text-anchor="middle">Encrypted envelope</text>
+<text x="1050" y="458" class="body" text-anchor="middle">on GossipSub</text>
+    <path d="M300 424H342" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M600 424H642" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M900 424H942" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+
+    <text x="50" y="543" class="eyebrow" fill="#fbbf24">3 · RECEIVER PROCESSING</text>
+    <rect x="50" y="566" width="235" height="118" rx="18" fill="#0f2b2e" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="167.5" y="605" class="card-title" text-anchor="middle">Encrypted envelope</text>
+    <text x="167.5" y="636" class="body" text-anchor="middle">received from GossipSub</text>
+    <rect x="325" y="566" width="235" height="118" rx="18" fill="#151f35" stroke="#6366f1" stroke-width="2"/>
+    <text x="442.5" y="604" class="card-title" text-anchor="middle">Decrypt + deserialize</text>
+    <text x="442.5" y="635" class="body" text-anchor="middle">Open the document-key frame</text>
+<text x="442.5" y="659" class="body" text-anchor="middle">and recover the message</text>
+    <rect x="600" y="566" width="235" height="118" rx="18" fill="#302441" stroke="#a78bfa" stroke-width="2"/>
+    <text x="717.5" y="604" class="card-title" text-anchor="middle">Verify when required</text>
+    <text x="717.5" y="635" class="body" text-anchor="middle">Check a current writer</text>
+<text x="717.5" y="659" class="body" text-anchor="middle">when signing is enabled</text>
+    <rect x="875" y="566" width="275" height="118" rx="18" fill="#18213c" stroke="#818cf8" stroke-width="2"/>
+    <text x="1012.5" y="604" class="card-title" text-anchor="middle">Apply inline / fetch CID</text>
+    <text x="1012.5" y="635" class="body" text-anchor="middle">Inline changes can apply now;</text>
+<text x="1012.5" y="659" class="body" text-anchor="middle">missing payloads use Helia</text>
+    <path d="M285 625H317" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+    <path d="M560 625H592" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M835 625H867" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+
+    <path d="M1012 684V736H265V758" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <rect x="100" y="766" width="330" height="112" rx="18" fill="#111f34" stroke="#475569" stroke-width="2"/>
+    <text x="265" y="804" class="card-title" text-anchor="middle">Validate requested CID</text>
+    <text x="265" y="835" class="body" text-anchor="middle">Helia checks fetched bytes</text>
+<text x="265" y="859" class="body" text-anchor="middle">against the content address</text>
+    <rect x="485" y="766" width="330" height="112" rx="18" fill="#123038" stroke="#14b8a6" stroke-width="2"/>
+    <text x="650" y="804" class="card-title" text-anchor="middle">Decrypt + deserialize block</text>
+    <text x="650" y="835" class="body" text-anchor="middle">Use the document key;</text>
+<text x="650" y="859" class="body" text-anchor="middle">no separate block signature exists</text>
+    <rect x="870" y="766" width="280" height="112" rx="18" fill="#0f2b2e" stroke="#2dd4bf" stroke-width="2"/>
+    <text x="1010" y="804" class="card-title" text-anchor="middle" fill="#99f6e4">Apply CRDT change</text>
+    <text x="1010" y="835" class="body" text-anchor="middle">Merge the validated,</text>
+<text x="1010" y="859" class="body" text-anchor="middle">decrypted provider delta</text>
+    <path d="M430 822H477" fill="none" stroke="#818cf8" stroke-width="3" marker-end="url(#arrowIndigo)"/>
+    <path d="M815 822H862" fill="none" stroke="#2dd4bf" stroke-width="3" marker-end="url(#arrowTeal)"/>
+
+    <rect x="50" y="908" width="1100" height="102" rx="18" fill="#301f2c" stroke="#f472b6" stroke-width="2"/>
+    <text x="76" y="940" class="eyebrow" fill="#f9a8d4">SIGNING BOUNDARY</text>
+    <text x="76" y="968" class="body-strong">The stored CID-addressed block remains unsigned; the wire-message signature is separate and conditional.</text>
+    <text x="76" y="994" class="body">Disabling ordinary signing leaves encryption in place but removes this writer-authentication gate for ordinary sync.</text>
+  </g>
+</svg>

--- a/site/src/content/docs/concepts/security.md
+++ b/site/src/content/docs/concepts/security.md
@@ -138,10 +138,7 @@ The initial invitation API therefore requires an explicit
 changing membership. Invitation recipients may receive retained operations for
 values that were later changed or deleted.
 
-```text
-stored payload = encrypt(document key, serialized CRDT change) → CID
-sync/response  = encrypt(document key, serialize(CRDTSyncMessage + optional signature))
-```
+![A local change becomes a separately encrypted stored payload and a conditionally signed, encrypted sync envelope that a receiver decrypts and verifies](../../../assets/diagrams/sync-envelope-lifecycle.svg "Storage blocks and wire envelopes are distinct encrypted artifacts with different integrity checks.")
 
 ### Ordinary document signing configuration
 


### PR DESCRIPTION
## Summary

- replace remaining ASCII and PlantUML figures with seven generated SVG diagrams
- extend deterministic diagram coverage from six to thirteen assets
- correct compaction, multi-relay, security, and distributed-index evidence boundaries
- repair blank coordination-guide table headers and remove malformed PlantUML links

## Validation

- yarn build
- yarn test
- yarn test:relay
- yarn workspace @peerborne/site build
- yarn workspace @peerborne/site diagrams:test
- yarn workspace @peerborne/site charts:test
- node site/scripts/check-links.mjs site/dist .
- xmllint and browser-rendered visual checks