### PR TITLE
docs: render one responsive copy per figure

### DIFF
--- a/site/scripts/rehype-docs-figures.mjs
+++ b/site/scripts/rehype-docs-figures.mjs
@@ -27,14 +27,7 @@ function svgFigure(node, figureIndex) {
   delete image.properties.title;
   const kind = source.includes('/charts/') ? 'chart' : 'diagram';
   const captionId = `docs-figure-caption-${figureIndex}`;
-  const expandedImage = {
-    ...image,
-    properties: {
-      ...image.properties,
-      alt: '',
-      loading: 'lazy',
-    },
-  };
+  const viewportId = `docs-figure-viewport-${figureIndex}`;
 
   return {
     type: 'element',
@@ -51,7 +44,13 @@ function svgFigure(node, figureIndex) {
           {
             type: 'element',
             tagName: 'div',
-            properties: { className: ['docs-figure__viewport'] },
+            properties: {
+              'aria-labelledby': captionId,
+              className: ['docs-figure__viewport'],
+              id: viewportId,
+              role: 'region',
+              tabIndex: 0,
+            },
             children: [image],
           },
           {
@@ -77,22 +76,25 @@ function svgFigure(node, figureIndex) {
             type: 'element',
             tagName: 'summary',
             properties: {
-              'aria-label': `View ${kind} at full size: ${caption.trim()}`,
+              'aria-controls': viewportId,
+              'aria-describedby': captionId,
             },
             children: [
-              { type: 'text', value: `View ${kind} at full size` },
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: { className: ['docs-figure__expand-label'] },
+                children: [
+                  { type: 'text', value: `View ${kind} at full size` },
+                ],
+              },
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: { className: ['docs-figure__fit-label'] },
+                children: [{ type: 'text', value: `Fit ${kind} to page` }],
+              },
             ],
-          },
-          {
-            type: 'element',
-            tagName: 'div',
-            properties: {
-              'aria-label': `Full-size ${kind}: ${caption.trim()}`,
-              className: ['docs-figure__full-size'],
-              role: 'region',
-              tabIndex: 0,
-            },
-            children: [expandedImage],
           },
         ],
       },

--- a/site/scripts/rehype-docs-figures.test.mjs
+++ b/site/scripts/rehype-docs-figures.test.mjs
@@ -37,7 +37,14 @@ test('wraps a captioned standalone SVG in a semantic figure', () => {
   ]);
   const semanticFigure = figure.children[0];
   assert.equal(semanticFigure.tagName, 'figure');
-  assert.equal(semanticFigure.children[0].tagName, 'div');
+  const viewport = semanticFigure.children[0];
+  assert.equal(viewport.tagName, 'div');
+  assert.equal(viewport.properties.role, 'region');
+  assert.equal(viewport.properties.tabIndex, 0);
+  assert.equal(
+    viewport.properties['aria-labelledby'],
+    semanticFigure.children.at(-1).properties.id,
+  );
   assert.equal(
     semanticFigure.children[0].children[0].properties.title,
     undefined,
@@ -54,25 +61,32 @@ test('wraps a captioned standalone SVG in a semantic figure', () => {
   const details = figure.children[1];
   assert.equal(details.tagName, 'details');
   assert.equal(
-    details.children[0].children[0].value,
+    details.children[0].children[0].children[0].value,
     'View chart at full size',
   );
   assert.equal(
-    details.children[0].properties['aria-label'],
-    'View chart at full size: Local latency snapshot.',
+    details.children[0].children[1].children[0].value,
+    'Fit chart to page',
   );
   assert.equal(
     details.properties['aria-describedby'],
     semanticFigure.children.at(-1).properties.id,
   );
-  const fullSize = details.children[1];
-  assert.equal(fullSize.properties.role, 'region');
-  assert.equal(fullSize.properties.tabIndex, 0);
   assert.equal(
-    fullSize.properties['aria-label'],
-    'Full-size chart: Local latency snapshot.',
+    details.children[0].properties['aria-controls'],
+    viewport.properties.id,
   );
-  assert.equal(fullSize.children[0].properties.alt, '');
+  assert.equal(
+    details.children[0].properties['aria-describedby'],
+    semanticFigure.children.at(-1).properties.id,
+  );
+  assert.equal(
+    figure.children
+      .flatMap((child) => child.children ?? [])
+      .flatMap((child) => child.children ?? [])
+      .filter((child) => child.tagName === 'img').length,
+    1,
+  );
 });
 
 test('leaves non-SVG and non-standalone images unchanged', () => {

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -68,6 +68,11 @@ pre.astro-code {
   margin: 0;
 }
 
+.docs-figure__viewport:focus-visible {
+  outline: 2px solid var(--sl-color-accent-high);
+  outline-offset: 2px;
+}
+
 .docs-figure__caption {
   margin-block-start: 0.65rem;
   padding-inline: 0.15rem;
@@ -89,39 +94,55 @@ pre.astro-code {
   font-weight: 600;
 }
 
-.docs-figure__details[open] > summary {
-  margin-block-end: 0.65rem;
+.docs-figure__details > summary:focus-visible {
+  outline: 2px solid var(--sl-color-accent-high);
+  outline-offset: 2px;
 }
 
-.docs-figure__full-size {
-  max-width: 100%;
+.docs-figure__fit-label {
+  display: none;
+}
+
+.docs-figure__details[open] .docs-figure__expand-label {
+  display: none;
+}
+
+.docs-figure__details[open] .docs-figure__fit-label {
+  display: inline;
+}
+
+.docs-figure:has(> .docs-figure__details[open]) .docs-figure__viewport {
   max-height: min(80vh, 50rem);
   overflow: auto;
   overscroll-behavior: contain;
-  border: 1px solid var(--sl-color-gray-5);
-  border-radius: 0.65rem;
-  background: #0f172a;
   scrollbar-width: thin;
 }
 
-.docs-figure__full-size > img {
-  display: block;
+.docs-figure:has(> .docs-figure__details[open])
+  .docs-figure__viewport
+  > img {
   width: auto;
   min-width: max-content;
   max-width: none;
-  height: auto;
-  margin: 0;
-}
-
-.docs-figure__full-size:focus-visible {
-  outline: 2px solid var(--sl-color-accent-high);
-  outline-offset: 2px;
 }
 
 @media print {
   .docs-figure__viewport {
     border-color: #94a3b8;
     box-shadow: none;
+  }
+
+  .docs-figure:has(> .docs-figure__details[open]) .docs-figure__viewport {
+    max-height: none;
+    overflow: hidden;
+  }
+
+  .docs-figure:has(> .docs-figure__details[open])
+    .docs-figure__viewport
+    > img {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
   }
 
   .docs-figure__details {


### PR DESCRIPTION
## Summary

- render each documentation SVG once instead of cloning it into a second disclosure panel
- let the disclosure toggle the same image between fit-to-page and scrollable intrinsic size
- preserve fitted figures in print output, including when a disclosure was left open
- retain captions, unique control IDs, and chart-versus-diagram labels

## Validation

- yarn workspace @peerborne/site figures:test
- yarn workspace @peerborne/site build
- node site/scripts/check-links.mjs site/dist .
- desktop, mobile, expanded, and print-media browser checks